### PR TITLE
Add query_string tag from Django 5.1

### DIFF
--- a/home/templatetags/future.py
+++ b/home/templatetags/future.py
@@ -1,0 +1,38 @@
+from django import template
+from django.utils.itercompat import is_iterable
+
+register = template.Library()
+
+
+# Backport from unreleased Django
+# This can be removed after Django 5.1 is released
+@register.simple_tag(takes_context=True)
+def query_string(context, query_dict=None, **kwargs):
+    """
+    Add, remove, and change parameters of a ``QueryDict`` and return the result
+    as a query string. If the ``query_dict`` argument is not provided, default
+    to ``request.GET``.
+    For example::
+        {% query_string foo=3 %}
+    To remove a key::
+        {% query_string foo=None %}
+    To use with pagination::
+        {% query_string page=page_obj.next_page_number %}
+    A custom ``QueryDict`` can also be used::
+        {% query_string my_query_dict foo=3 %}
+    """
+    if query_dict is None:
+        query_dict = context.request.GET
+    query_dict = query_dict.copy()
+    for key, value in kwargs.items():
+        if value is None:
+            if key in query_dict:
+                del query_dict[key]
+        elif is_iterable(value) and not isinstance(value, str):
+            query_dict.setlist(key, value)
+        else:
+            query_dict[key] = value
+    if not query_dict:
+        return ""
+    query_string = query_dict.urlencode()
+    return f"?{query_string}"

--- a/templates/partial/pagination.html
+++ b/templates/partial/pagination.html
@@ -1,7 +1,8 @@
+{% load future %}
 <nav class="govuk-pagination" role="navigation" aria-label="Pagination">
     {% if page_obj.has_previous %}
     <div class="govuk-pagination__prev">
-      <a class="govuk-link govuk-pagination__link" href="{% url 'home:pagination' page=page_obj.previous_page_number %}" rel="prev">
+      <a class="govuk-link govuk-pagination__link" href="{% url 'home:pagination' page=page_obj.previous_page_number %}{% query_string clear_label=None clear_filter=None value=None %}" rel="prev">
         <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
           <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
         </svg>
@@ -15,7 +16,7 @@
             {% else %}
                 <li class="govuk-pagination__item">
             {% endif %}
-                <a class="govuk-link govuk-pagination__link" href="{% url 'home:pagination' page=p %}" aria-label="Page {{ p }}">
+                <a class="govuk-link govuk-pagination__link" href="{% url 'home:pagination' page=p %}{% query_string clear_label=None clear_filter=None value=None %}" aria-label="Page {{ p }}">
                     {{ p }}
                 </a>
                 </li>
@@ -26,7 +27,7 @@
     {% endfor %}
     {% if page_obj.has_next %}
     <div class="govuk-pagination__next">
-      <a class="govuk-link govuk-pagination__link" href="{% url 'home:pagination' page=page_obj.next_page_number %}" rel="next"> <span class="govuk-pagination__link-title">Next<span class="govuk-visually-hidden"> page</span></span> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+      <a class="govuk-link govuk-pagination__link" href="{% url 'home:pagination' page=page_obj.next_page_number %}{% query_string clear_label=None clear_filter=None value=None %}" rel="next"> <span class="govuk-pagination__link-title">Next<span class="govuk-visually-hidden"> page</span></span> <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
           <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
         </svg></a>
     </div>


### PR DESCRIPTION
This tag will be released in the next version of Django:

https://github.com/django/django/commit/e67d3580edbee1a4b58d40875293714ac3fc6937#diff-30b3434053ec4af0e27c503a53ec0e3aa8fb74ea75b458ac62507c66f2f78dd4R1172

However, it's really useful for us right now since it allows you to generate pagination links that preserve existing query parameters.

This means the search query and filters won't be lost when navigating between pages.

Any time we generate a link that goes back to the search page, we can use this to preserve the query string.