### PR TITLE
Find-moj-data-45/search-highlighting

### DIFF
--- a/home/service/search.py
+++ b/home/service/search.py
@@ -93,12 +93,6 @@ class SearchService(GenericService):
         else:
             pattern = f'({re.escape(query)})'
             for result in highlighted_results.page_results:
-                metadata = result.metadata
-                if metadata.get("search_summary"):
-                    metadata["search_summary"] = re.sub(
-                        pattern, r'**\1**', metadata["search_summary"], flags=re.IGNORECASE,
-                    )
-
                 result.description = re.sub(
                     pattern, r'**\1**', result.description, flags=re.IGNORECASE,
                 )

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -107,6 +107,8 @@ class SearchService(GenericService):
 
     def _get_match_reason_display_names(self):
         return {
+            "id": "ID",
+            "urn": "URN",
             "domains": "Domain",
             "name": "Name",
             "description": "Description",

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -107,8 +107,6 @@ class SearchService(GenericService):
 
     def _get_match_reason_display_names(self):
         return {
-            "urn": "URN",
-            "id": "ID",
             "domain": "Domain",
             "name": "Name",
             "description": "Description",

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -42,8 +42,13 @@ class SearchService(GenericService):
             sort=sort_option,
             count=items_per_page,
         )
+        highlighted_results = (
+            self._highlight_results(results, query)
+            if query != ""
+            else results
+        )
 
-        return results
+        return highlighted_results
 
     def _get_paginator(self, items_per_page: int) -> Paginator:
         pages_list = list(range(self.results.total_results))
@@ -79,3 +84,20 @@ class SearchService(GenericService):
         }
 
         return context
+
+    def _highlight_results(self, results, string_to_highlight):
+        "Take a SearchResponse and add bold markdown where a string appears"
+        for result in results.page_results:
+            metadata = getattr(result, "metadata")
+            highlighted_search_summary = metadata.get("search_summary", "").replace(
+                string_to_highlight, f"**{string_to_highlight}**"
+            )
+            setattr(result, "metadata", metadata)
+
+            name = getattr(result, "description")
+            highlighted_description = name.replace(
+                string_to_highlight, f"**{string_to_highlight}**"
+            )
+            setattr(result, "description", highlighted_description)
+
+        return results

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -56,7 +56,6 @@ class SearchService(GenericService):
         return Paginator(pages_list, items_per_page)
 
     def _get_context(self) -> dict[str, Any]:
-
         if self.form["query"].value():
             page_title = f'Search for "{self.form["query"].value()}" - Data catalogue'
         else:
@@ -81,6 +80,7 @@ class SearchService(GenericService):
             "paginator": self.paginator,
             "total_results": self.results.total_results,
             "label_clear_href": label_clear_href,
+            "readable_match_reasons": self._get_match_reason_display_names(),
         }
 
         return context
@@ -101,3 +101,14 @@ class SearchService(GenericService):
             setattr(result, "description", highlighted_description)
 
         return results
+
+    def _get_match_reason_display_names(self):
+        return {
+            "urn": "URN",
+            "id": "ID",
+            "domain": "Domain",
+            "name": "Name",
+            "description": "Description",
+            "fieldPaths": "Column name",
+            "fieldDescriptions": "Column description",
+        }

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -68,7 +68,7 @@ class SearchService(GenericService):
 
         context = {
             "form": self.form,
-            "results": self.results.page_results,
+            "results": self.highlighted_results.page_results,
             "page_title": page_title,
             "page_obj": self.paginator.get_page(self.page),
             "page_range": self.paginator.get_elided_page_range(

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -68,7 +68,8 @@ class SearchService(GenericService):
 
         context = {
             "form": self.form,
-            "results": self.highlighted_results.page_results,
+            "results": self.results.page_results,
+            "highlighted_results": self.highlighted_results.page_results,
             "page_title": page_title,
             "page_obj": self.paginator.get_page(self.page),
             "page_range": self.paginator.get_elided_page_range(

--- a/home/templatetags/lookup.py
+++ b/home/templatetags/lookup.py
@@ -2,8 +2,4 @@ from home.templatetags.markdown import register
 
 @register.filter
 def lookup(list, lookup_dict):
-    return [
-        lookup_dict.get(item)
-        for item in list
-        if lookup_dict.get(item)
-    ]
+    return sorted([lookup_dict.get(item)for item in list])

--- a/home/templatetags/lookup.py
+++ b/home/templatetags/lookup.py
@@ -1,0 +1,5 @@
+from home.templatetags.markdown import register
+
+@register.filter
+def lookup(list, lookup_dict):
+    return [lookup_dict[item] for item in list]

--- a/home/templatetags/lookup.py
+++ b/home/templatetags/lookup.py
@@ -2,4 +2,8 @@ from home.templatetags.markdown import register
 
 @register.filter
 def lookup(list, lookup_dict):
-    return [lookup_dict[item] for item in list]
+    return [
+        lookup_dict.get(item)
+        for item in list
+        if lookup_dict.get(item)
+    ]

--- a/templates/details.html
+++ b/templates/details.html
@@ -8,7 +8,7 @@
 
   <a onclick="history.back()" class="govuk-back-link">Back</a>
       <main class="govuk-main-wrapper">
-        <div class="govuk-grid-row"> 
+        <div class="govuk-grid-row">
           <span class="govuk-caption-m">{{result_type}}</span>
           <h2 class="govuk-heading-l">{{result.name}}</h2>
           <div class="govuk-grid-column-two-thirds">
@@ -28,16 +28,16 @@
                 {{result.metadata.owner_email}}
                 </dd>
               </div>
-      
-      
+
+
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Domain name</dt>
                 <dd class="govuk-summary-list__value">
-                {{result.metadata.domain.properties.name}}
+                {{result.metadata.domain.properties.name|markdown}}
                 </dd>
               </div>
-      
-             
+
+
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Last updated date</dt>
                 <dd class="govuk-summary-list__value">
@@ -46,24 +46,24 @@
                   {% endif %}
                 </dd>
               </div>
-      
+
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Refresh period</dt>
                 <dd class="govuk-summary-list__value">
-                
+
                 </dd>
               </div>
-      
+
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Retention period</dt>
                 <dd class="govuk-summary-list__value">
-               
+
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">DPIA Status </dt>
                 <dd class="govuk-summary-list__value">
-               
+
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
@@ -109,7 +109,7 @@
               </tbody>
             </table>
           </div>
-          
+
           <div class="govuk-grid-column-one-third">
               <div class="govuk-body">
                 <p class="govuk-heading-s">IAO or Data Owner</p>
@@ -126,7 +126,7 @@
               <div class="govuk-body">
                 <p class="govuk-heading-s">Access requirement</p>
                 <span class="govuk-body">
-                  Processing the data might require 
+                  Processing the data might require
                   permission from IAO or Data owner
                 </span>
               </div>

--- a/templates/details.html
+++ b/templates/details.html
@@ -33,7 +33,7 @@
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Domain name</dt>
                 <dd class="govuk-summary-list__value">
-                {{result.metadata.domain.properties.name|markdown}}
+                {{result.metadata.domain.properties.name}}
                 </dd>
               </div>
 

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -21,7 +21,7 @@
       <div class="govuk-body-m">{{result.metadata.search_summary|markdown}}</div>
       {% endif %}
 
-      
+
       <dl class="govuk-summary-list">
 
         <div class="govuk-summary-list__row">
@@ -48,6 +48,12 @@
           <dt class="govuk-summary-list__key">Tags</dt>
           <dd class="govuk-summary-list__value">
           {{ result.tags |join:", " }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Matched fields</dt>
+          <dd class="govuk-summary-list__value">
+          {{ result.matches |join:", " }}
           </dd>
         </div>
     </div>

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -53,7 +53,7 @@
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Matched fields</dt>
           <dd class="govuk-summary-list__value">
-          {{ result.matches |join:", " }}
+            {{ result.matches|lookup:readable_match_reasons|join:", " }}
           </dd>
         </div>
     </div>

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -1,7 +1,7 @@
 {% load markdown %}
 {% load humanize %}
 <div id="search-results">
-{% for result in results %}
+{% for result in highlighted_results %}
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -18,7 +18,13 @@
           {% endif %}
       </h3>
       {% if result.description %}
-      <div class="govuk-body-m">{{result.metadata.search_summary|markdown}}</div>
+      <div class="govuk-body-m">
+        {% if result.description|length > 200 %}
+          {{ result.description|slice:":200"|add:"..."|markdown }}
+        {% else %}
+          {{ result.description|markdown }}
+        {% endif %}
+      </div>
       {% endif %}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,8 @@ def generate_page(page_size=20):
                 result_type=choice(
                     (ResultType.DATA_PRODUCT, ResultType.TABLE)),
                 name=fake.name(),
-                description=fake.paragraphs(),
+                description=fake.paragraph(),
+                metadata={"search_summary":"a"},
             )
         )
     return results
@@ -105,10 +106,12 @@ def valid_form():
 
 
 @pytest.fixture
-def search_context(valid_form):
-    search_service = SearchService(form=valid_form, page="1")
-    context = search_service._get_context()
-    return context
+def search_service(valid_form):
+    return SearchService(form=valid_form, page="1")
+
+@pytest.fixture
+def search_context(search_service):
+    return search_service.context
 
 
 @pytest.fixture

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,5 +1,6 @@
 from types import GeneratorType
 from data_platform_catalogue.search_types import ResultType
+from home.service.search import SearchService
 
 
 class TestSearchService:
@@ -23,6 +24,43 @@ class TestSearchService:
         assert search_context["label_clear_href"] == {
             "HMCTS": "?query=test&sort=ascending&clear_filter=False&clear_label=False"
         }
+
+    def test_highlight_results_no_query(self, search_service):
+        search_service.form.cleaned_data = {"query": ""}
+        search_service._highlight_results()
+        assert (
+            normal.description == highlighted.description
+            & normal.metadata == highlighted.metadata
+            for normal, highlighted in zip(
+                search_service.results.page_results,
+                search_service.highlighted_results.page_results,
+            )
+        )
+
+    def test_highlight_results_with_query(self, search_service):
+        search_service.form.cleaned_data = {"query": "a"}
+        search_service._highlight_results()
+
+        assert (
+            "**a**" in highlighted.description
+            & "**" not in normal.description
+            for normal, highlighted
+            in zip(
+                search_service.results.page_results,
+                search_service.highlighted_results.page_results,
+            )
+            if "a" in normal.description
+        )
+        assert (
+            "**a**" in highlighted.metadata["search_summary"]
+            & "**" not in normal.metadata["search_summary"]
+            for normal, highlighted
+            in zip(
+                search_service.results.page_results,
+                search_service.highlighted_results.page_results,
+            )
+            if "a" in normal.metadata["search_summary"]
+        )
 
 
 class TestDetailsService:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -58,16 +58,6 @@ class TestSearchService:
             )
             if "a" or "A" in normal.description
         )
-        assert (
-            "**a**" or "**A**" in highlighted.metadata["search_summary"]
-            for normal, highlighted
-            in zip(
-                service.results.page_results,
-                service.highlighted_results.page_results,
-            )
-            if "a" or "A" in normal.metadata["search_summary"]
-        )
-
 
 class TestDetailsService:
     def test_get_context(self, detail_context, mock_catalogue):


### PR DESCRIPTION
* Add a matched fields entry to search results with readable names
* Apply bold highlighting for search terms on the description and search summary fields
* The search summary field isn't actually searched by datahub, it's more of a patch until we figure out how we want to handle long descriptions
* Should URN/ID even be included in matched fields? Users will not care about it's URN or ID most likely.