### PR TITLE
Integrate subdomain filter

### DIFF
--- a/home/forms/domain_model.py
+++ b/home/forms/domain_model.py
@@ -100,4 +100,4 @@ class DomainModel:
                     return domain
 
     def get_label(self, urn):
-        return self.labels.get(value, urn)
+        return self.labels.get(urn, urn)

--- a/home/forms/domain_model.py
+++ b/home/forms/domain_model.py
@@ -1,0 +1,103 @@
+from typing import NamedTuple
+
+
+class Domain(NamedTuple):
+    value: str
+    label: str
+
+
+class DomainModel:
+    """
+    Store information about domains and subdomains
+    """
+
+    def __init__(self):
+        self.labels = {}
+
+        self.top_level_domains = [
+            Domain("urn:li:domain:HMCTS", "HMCTS"),
+            Domain("urn:li:domain:HMPPS", "HMPPS"),
+            Domain("urn:li:domain:HQ", "HQ"),
+            Domain("urn:li:domain:LAA", "LAA"),
+            Domain("urn:li:domain:OPG", "OPG"),
+        ]
+
+        for value, label in self.top_level_domains:
+            self.labels[value] = label
+
+        self.subdomains = {
+            "urn:li:domain:HMPPS": [
+                Domain("urn:li:domain:2feb789b-44d3-4412-b998-1f26819fabf9", "Prisons"),
+                Domain(
+                    "urn:li:domain:abe153c1-416b-4abb-be7f-6accf2abb10a", "Probation"
+                ),
+            ],
+            "urn:li:domain:HMCTS": [
+                Domain(
+                    "urn:li:domain:4d77af6d-9eca-4c44-b189-5f1addffae55", "Civil courts"
+                ),
+                Domain(
+                    "urn:li:domain:31754f66-33df-4a73-b039-532518bc765e", "Crown courts"
+                ),
+                Domain(
+                    "urn:li:domain:81adfe94-1284-46a2-9179-945ad2a76c14",
+                    "Family courts",
+                ),
+                Domain(
+                    "urn:li:domain:b261176c-d8eb-4111-8454-c0a1fa95005f",
+                    "Magistrates courts",
+                ),
+            ],
+            "urn:li:domain:OPG": [
+                Domain(
+                    "urn:li:domain:bc091f6c-7674-4c82-a315-f5489398f099",
+                    "Lasting power of attourney",
+                ),
+                Domain(
+                    "urn:li:domain:efb9ade3-3c5d-4c5c-b451-df9f2d8136f5",
+                    "Supervision orders",
+                ),
+            ],
+            "urn:li:domain:HQ": [
+                Domain("urn:li:domain:9fb7ff13-6c7e-47ef-bef1-b13b23fd8c7a", "Estates"),
+                Domain("urn:li:domain:e4476e66-37a1-40fd-83b9-c908f805d8f4", "Finance"),
+                Domain("urn:li:domain:0985731b-8e1c-4b4a-bfc0-38e58d8ba8a1", "People"),
+                Domain(
+                    "urn:li:domain:a320c915-0b43-4277-9769-66615aab4adc", "Performance"
+                ),
+            ],
+            "urn:li:domain:LAA": [
+                Domain(
+                    "urn:li:domain:24344488-d770-437a-ba6f-e6129203b927",
+                    "Civil legal advice",
+                ),
+                Domain("urn:li:domain:Legal%20Aid", "Legal aid"),
+                Domain(
+                    "urn:li:domain:5c423c06-d328-431f-8634-7a7e86928819",
+                    "Public defender",
+                ),
+            ],
+        }
+
+        for domain, subdomains in self.subdomains.items():
+            domain_label = self.labels[domain]
+            for value, label in subdomains:
+                self.labels[value] = f"{domain_label} - {label}"
+
+    def all_subdomains(self) -> list[Domain]:  # -> list[Any]
+        """
+        A flat list of all subdomains
+        """
+        subdomains = []
+        for domain_choices in self.subdomains.values():
+            subdomains.extend(domain_choices)
+        return subdomains
+
+    def get_parent_value(self, subdomain_value) -> str | None:
+        for domain, subdomains in self.subdomains.items():
+            for s in subdomains:
+                if subdomain_value == s[0]:
+                    return domain
+
+    def get_label(self, value):
+        return self.labels.get(value, value)

--- a/home/forms/domain_model.py
+++ b/home/forms/domain_model.py
@@ -22,8 +22,8 @@ class DomainModel:
             Domain("urn:li:domain:OPG", "OPG"),
         ]
 
-        for value, label in self.top_level_domains:
-            self.labels[value] = label
+        for urn, label in self.top_level_domains:
+            self.labels[urn] = label
 
         self.subdomains = {
             "urn:li:domain:HMPPS": [

--- a/home/forms/domain_model.py
+++ b/home/forms/domain_model.py
@@ -2,7 +2,7 @@ from typing import NamedTuple
 
 
 class Domain(NamedTuple):
-    value: str
+    urn: str
     label: str
 
 

--- a/home/forms/domain_model.py
+++ b/home/forms/domain_model.py
@@ -81,8 +81,8 @@ class DomainModel:
 
         for domain, subdomains in self.subdomains.items():
             domain_label = self.labels[domain]
-            for value, label in subdomains:
-                self.labels[value] = f"{domain_label} - {label}"
+            for urn, subdoman_label in subdomains:
+                self.labels[urn] = f"{domain_label} - {subdoman_label}"
 
     def all_subdomains(self) -> list[Domain]:  # -> list[Any]
         """

--- a/home/forms/domain_model.py
+++ b/home/forms/domain_model.py
@@ -99,5 +99,5 @@ class DomainModel:
                 if child_subdomain_urn == subdomain.urn:
                     return domain
 
-    def get_label(self, value):
-        return self.labels.get(value, value)
+    def get_label(self, urn):
+        return self.labels.get(value, urn)

--- a/home/forms/domain_model.py
+++ b/home/forms/domain_model.py
@@ -93,10 +93,10 @@ class DomainModel:
             subdomains.extend(domain_choices)
         return subdomains
 
-    def get_parent_value(self, subdomain_value) -> str | None:
+    def get_parent_urn(self, child_subdomain_urn) -> str | None:
         for domain, subdomains in self.subdomains.items():
-            for s in subdomains:
-                if subdomain_value == s[0]:
+            for subdomain in subdomains:
+                if child_subdomain_urn == subdomain.urn:
                     return domain
 
     def get_label(self, value):

--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -48,14 +48,14 @@ class SelectWithOptionAttribute(forms.Select):
         self.domain_model = DomainModel()
 
     def create_option(
-        self, name, value, label, selected, index, subindex=None, attrs=None
+        self, name, urn, label, selected, index, subindex=None, attrs=None
     ):
         option = super().create_option(
-            name, value, label, selected, index, subindex, attrs
+            name, urn, label, selected, index, subindex, attrs
         )
 
-        if value:
-            option["attrs"]["data-parent"] = self.domain_model.get_parent_urn(value)
+        if urn:
+            option["attrs"]["data-parent"] = self.domain_model.get_parent_urn(urn)
 
         return option
 

--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -3,20 +3,20 @@ from urllib.parse import urlencode
 
 from django import forms
 
-from .domain_model import DomainModel
+from .domain_model import Domain, DomainModel
 
 
-def get_domain_choices() -> list[tuple[str, str]]:
+def get_domain_choices() -> list[Domain]:
     """Make API call to obtain domain choices"""
-    choices: list[tuple[str, str]] = [
-        ("", "All domains"),
+    choices = [
+        Domain("", "All domains"),
     ]
     choices.extend(DomainModel().top_level_domains)
     return choices
 
 
-def get_subdomain_choices():
-    choices: list[tuple[str, str]] = [("", "All subdomains")]
+def get_subdomain_choices() -> list[Domain]:
+    choices = [Domain("", "All subdomains")]
     choices.extend(DomainModel().all_subdomains())
     return choices
 

--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -55,7 +55,7 @@ class SelectWithOptionAttribute(forms.Select):
         )
 
         if value:
-            option["attrs"]["data-parent"] = self.domain_model.get_parent_value(value)
+            option["attrs"]["data-parent"] = self.domain_model.get_parent_urn(value)
 
         return option
 

--- a/static/assets/js/enhanced-search.js
+++ b/static/assets/js/enhanced-search.js
@@ -8,11 +8,11 @@
  * has to hit "Apply filters" first.
  */
 
-const ALL_DOMAINS_VALUE = "*";
+const ALL_DOMAINS_VALUE = "";
 
 export const initDomainFilter = () => {
-  const subdomainSelect = document.querySelector("#subdomains-filter");
-  const topLevelDomainSelect = document.querySelector("#domains-filter");
+  const subdomainSelect = document.querySelector("#id_subdomain");
+  const topLevelDomainSelect = document.querySelector("#id_domain");
   const subdomainGroup = document.querySelector(".js-required");
 
   if (subdomainSelect === null || topLevelDomainSelect === null) {
@@ -29,7 +29,13 @@ class DomainFilter {
     this.topLevelDomainSelect = topLevelDomainSelect;
     this.subdomainSelect = subdomainSelect;
     this.options = this.#extractSubdomainOptions();
-    this.#onClearTopLevelDomain();
+
+    if (this.isWildcardTopLevelDomain()) {
+      this.#onClearTopLevelDomain();
+    } else {
+      const selectedDomain = this.topLevelDomainSelect.value;
+      this.#onSelectTopLevelDomain(selectedDomain, false);
+    }
 
     topLevelDomainSelect.addEventListener("change", () =>
       this.#onChangeDomain()
@@ -63,19 +69,19 @@ class DomainFilter {
   }
 
   #onChangeDomain() {
-    const selectedDomain = this.topLevelDomainSelect.value;
     if (this.isWildcardTopLevelDomain()) {
       this.#onClearTopLevelDomain();
     } else {
-      this.#onSelectTopLevelDomain(selectedDomain);
+      const selectedDomain = this.topLevelDomainSelect.value;
+      this.#onSelectTopLevelDomain(selectedDomain, true);
     }
 
     this.#notify();
   }
 
-  #onSelectTopLevelDomain(selectedDomain) {
+  #onSelectTopLevelDomain(selectedDomain, reset) {
     this.subdomainSelect.disabled = false;
-    this.#setSubdomainOptions(this.options[selectedDomain]);
+    this.#setSubdomainOptions(this.options[selectedDomain], reset);
   }
 
   #onClearTopLevelDomain() {
@@ -91,14 +97,16 @@ class DomainFilter {
     return this.topLevelDomainSelect.value === ALL_DOMAINS_VALUE;
   }
 
-  #setSubdomainOptions(newOptionElements) {
+  #setSubdomainOptions(newOptionElements, reset) {
     const existingOptionElements =
       this.subdomainSelect.querySelectorAll("option");
 
     existingOptionElements.forEach((option) => {
       if (option.value != ALL_DOMAINS_VALUE) {
         option.parentNode.removeChild(option);
-        option.selected = false;
+        if (reset) {
+          option.selected = false;
+        }
       }
     });
 

--- a/templates/partial/filter.html
+++ b/templates/partial/filter.html
@@ -18,7 +18,14 @@
             <div class="govuk-form-group">
               <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Domain</legend>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="{{form.domain.id_for_label}}">Top-level domain</label>
                   {{form.domain}}
+                  </div>
+                  <div class="govuk-form-group js-required">
+                    <label class="govuk-label" for="{{form.subdomain.id_for_label}}">Subdomain</label>
+                    {{form.subdomain}}
+                  </div>
               </fieldset>
             </div>
             <div class="govuk-form-group">

--- a/tests/javascript/test_enhanced_search.js
+++ b/tests/javascript/test_enhanced_search.js
@@ -1,26 +1,26 @@
 import { initDomainFilter } from "enhanced-search";
 import { expect, test } from "@jest/globals";
 
-const widget_html = `
+const unselectedWidgetHtml = `
     <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Domain</legend>
         <div class="govuk-form-group">
-            <label class="govuk-label" for="domains-filter">
+            <label class="govuk-label" for="id_domain">
                 Top-level
             </label>
-            <select class="govuk-select" id="domains-filter" name="domains">
-                <option value="*">All domains</option>
+            <select class="govuk-select" id="id_domain" name="domains">
+                <option value="">All domains</option>
                 <option value="a">Domain A</option>
                 <option value="b">Domain B</option>
                 <option value="c">Domain C</option>
             </select>
         </div>
         <div class="govuk-form-group js-required">
-            <label class="govuk-label" for="subdomains-filter">
+            <label class="govuk-label" for="id_subdomain">
                 Subdomain
             </label>
-            <select class="govuk-select" id="subdomains-filter" name="subdomains" disabled>
-                <option value="*">All subdomains</option>
+            <select class="govuk-select" id="id_subdomain" name="subdomains" disabled>
+                <option value="">All subdomains</option>
                 <option value="a1" data-parent="a">Subdomain of A 1</option>
                 <option value="a2" data-parent="a">Subdomain of A 2</option>
                 <option value="b1" data-parent="b">Subdomain of B 1</option>
@@ -30,14 +30,43 @@ const widget_html = `
     </fieldset>
 `;
 
+const selectedWidgetHtml = `
+<fieldset class="govuk-fieldset">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Domain</legend>
+<div class="govuk-form-group">
+    <label class="govuk-label" for="id_domain">
+        Top-level
+    </label>
+    <select class="govuk-select" id="id_domain" name="domains">
+        <option value="">All domains</option>
+        <option value="a" selected>Domain A</option>
+        <option value="b">Domain B</option>
+        <option value="c">Domain C</option>
+    </select>
+</div>
+<div class="govuk-form-group js-required">
+    <label class="govuk-label" for="id_subdomain">
+        Subdomain
+    </label>
+    <select class="govuk-select" id="id_subdomain" name="subdomains" disabled>
+        <option value="">All subdomains</option>
+        <option value="a1" data-parent="a">Subdomain of A 1</option>
+        <option value="a2" selected data-parent="a">Subdomain of A 2</option>
+        <option value="b1" data-parent="b">Subdomain of B 1</option>
+        <option value="b2" data-parent="b">Subdomain of B 2</option>
+    </select>
+</div>
+</fieldset>
+`;
+
 let subdomainFilter;
 let domainFilter;
 const eventSpy = jest.fn();
 
-describe("initialisation", () => {
+describe("initialisation without selected options", () => {
   beforeEach(() => {
-    document.body.innerHTML = widget_html;
-    subdomainFilter = document.querySelector("#subdomains-filter");
+    document.body.innerHTML = unselectedWidgetHtml;
+    subdomainFilter = document.querySelector("#id_subdomain");
     initDomainFilter();
   });
 
@@ -50,12 +79,32 @@ describe("initialisation", () => {
   });
 });
 
+describe("initialisation with selected options", () => {
+  beforeEach(() => {
+    document.body.innerHTML = selectedWidgetHtml;
+    subdomainFilter = document.querySelector("#id_subdomain");
+    initDomainFilter();
+  });
+
+  test("subdomain select is enabled", () => {
+    expect(subdomainFilter).toBeEnabled();
+  });
+
+  test("only the selected domain's options are available", () => {
+    const options = subdomainFilter.querySelectorAll("option");
+
+    const values = Array.from(options).map((el) => el.value);
+
+    expect(values).toEqual(["", "a1", "a2"]);
+  });
+});
+
 describe("after selecting a domain with no subdomains", () => {
   beforeEach(() => {
-    document.body.innerHTML = widget_html;
+    document.body.innerHTML = unselectedWidgetHtml;
 
-    subdomainFilter = document.querySelector("#subdomains-filter");
-    domainFilter = document.querySelector("#domains-filter");
+    subdomainFilter = document.querySelector("#id_subdomain");
+    domainFilter = document.querySelector("#id_domain");
 
     initDomainFilter();
 
@@ -71,7 +120,7 @@ describe("after selecting a domain with no subdomains", () => {
   });
 
   test("selects all subdomains", () => {
-    expect(subdomainFilter.value).toEqual("*");
+    expect(subdomainFilter.value).toEqual("");
   });
 
   test("only the all subdomains option is available", () => {
@@ -79,7 +128,7 @@ describe("after selecting a domain with no subdomains", () => {
 
     const values = Array.from(options).map((el) => el.value);
 
-    expect(values).toEqual(["*"]);
+    expect(values).toEqual([""]);
   });
 
   test("fires an event with the selected domain/subdomain pair", () => {
@@ -93,10 +142,10 @@ describe("after selecting a domain with no subdomains", () => {
 
 describe("after selecting a domain", () => {
   beforeEach(() => {
-    document.body.innerHTML = widget_html;
+    document.body.innerHTML = unselectedWidgetHtml;
 
-    subdomainFilter = document.querySelector("#subdomains-filter");
-    domainFilter = document.querySelector("#domains-filter");
+    subdomainFilter = document.querySelector("#id_subdomain");
+    domainFilter = document.querySelector("#id_domain");
 
     initDomainFilter();
 
@@ -116,7 +165,7 @@ describe("after selecting a domain", () => {
 
     const values = Array.from(options).map((el) => el.value);
 
-    expect(values).toEqual(["*", "a1", "a2"]);
+    expect(values).toEqual(["", "a1", "a2"]);
   });
 
   test("fires an event with the selected domain and null subdomain", () => {
@@ -153,11 +202,11 @@ describe("after selecting a domain", () => {
 
         const values = Array.from(options).map((el) => el.value);
 
-        expect(values).toEqual(["*", "b1", "b2"]);
+        expect(values).toEqual(["", "b1", "b2"]);
       });
 
       test("selects all subdomains", () => {
-        expect(subdomainFilter.value).toEqual("*");
+        expect(subdomainFilter.value).toEqual("");
       });
 
       test("fires an event with the selected domain and null subdomain", () => {
@@ -175,14 +224,14 @@ describe("after selecting a domain", () => {
         });
 
         test("selects all subdomains", () => {
-          expect(subdomainFilter.value).toEqual("*");
+          expect(subdomainFilter.value).toEqual("");
         });
       });
     });
 
     describe("after clearing the top level domain", () => {
       beforeEach(() => {
-        domainFilter.value = "*";
+        domainFilter.value = "";
         domainFilter.dispatchEvent(new Event("change"));
       });
 

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -11,8 +11,6 @@ from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.select import Select
 
-
-
 TMP_DIR = Path(__file__).parent / "../../tmp"
 
 
@@ -130,16 +128,25 @@ class SearchPage(Page):
     def domain_select(self) -> WebElement:
         return Select(self.selenium.find_element(By.ID, "id_domain"))
 
+    def subdomain_select(self) -> WebElement:
+        return Select(self.selenium.find_element(By.ID, "id_subdomain"))
+
     def select_domain(self, domain) -> WebElement:
         select = self.domain_select()
+        return select.select_by_visible_text(domain)
+
+    def select_subdomain(self, domain) -> WebElement:
+        select = self.subdomain_select()
+        print(f"Selecting subdomain {domain}")
         return select.select_by_visible_text(domain)
 
     def get_selected_domain(self) -> WebElement:
         select = self.domain_select()
         return select.first_selected_option
 
-    def domain_option(self, name) -> WebElement:
-        return self.selenium.find_element(By.XPATH, f"//option[ text() = '{name}' ]")
+    def get_selected_subdomain(self) -> WebElement:
+        select = self.subdomain_select()
+        return select.first_selected_option
 
     def sort_label(self, name) -> WebElement:
         return self.selenium.find_element(By.XPATH, f"//label[ text() = '{name}' ]")

--- a/tests/selenium/test_search_scenarios.py
+++ b/tests/selenium/test_search_scenarios.py
@@ -1,14 +1,15 @@
 import re
 
 import pytest
+from data_platform_catalogue.search_types import ResultType
+
+from tests.conftest import generate_page, mock_search_response
 
 from .helpers import check_for_accessibility_issues
-from tests.conftest import mock_search_response, generate_page
-from data_platform_catalogue.search_types import ResultType
 
 
 @pytest.mark.slow
-class TestSearchWithoutJavascriptAndCss:
+class TestSearch:
     """
     Test interacting with the search form through the browser,
     as a user would
@@ -70,12 +71,15 @@ class TestSearchWithoutJavascriptAndCss:
         Interacts with the filters on the left hand side
         """
         domain = "HMPPS"
+        subdomain = "Prisons"
         self.start_on_the_search_page()
         self.select_domain(domain)
+        self.select_subdomain(subdomain)
         self.click_apply_filters()
         self.verify_i_am_on_the_search_page()
         self.verify_i_have_results()
         self.verify_domain_selected(domain)
+        self.verify_subdomain_selected(subdomain)
 
     def test_pagination(self):
         """
@@ -109,8 +113,10 @@ class TestSearchWithoutJavascriptAndCss:
         interact with the search page.
         """
         domain = "HMPPS"
+        subdomain = "Prisons"
         self.start_on_the_search_page()
         self.select_domain(domain)
+        self.select_subdomain(subdomain)
         self.click_apply_filters()
         self.enter_a_query_and_submit("nomis")
         self.click_sort_option("Ascending")
@@ -119,6 +125,7 @@ class TestSearchWithoutJavascriptAndCss:
         self.verify_i_have_results()
         self.verify_the_search_bar_has_value("nomis")
         self.verify_domain_selected(domain)
+        self.verify_subdomain_selected(subdomain)
         self.verify_sort_selected("Ascending")
 
     def test_adding_a_query_resets_pagination(self):
@@ -157,6 +164,7 @@ class TestSearchWithoutJavascriptAndCss:
         self.verify_domain_selected(domain)
         self.click_clear_selected_filter(domain)
         self.verify_unselected_domain()
+        self.verify_unselected_subdomain()
 
     def test_clear_all_filters(self):
         """
@@ -250,6 +258,9 @@ class TestSearchWithoutJavascriptAndCss:
     def select_domain(self, domain):
         self.search_page.select_domain(domain)
 
+    def select_subdomain(self, domain):
+        self.search_page.select_subdomain(domain)
+
     def click_sort_option(self, sortby):
         self.search_page.sort_label(sortby).click()
 
@@ -271,9 +282,17 @@ class TestSearchWithoutJavascriptAndCss:
         selected_domain = self.search_page.get_selected_domain().text
         assert selected_domain == domain
 
+    def verify_subdomain_selected(self, domain):
+        selected_domain = self.search_page.get_selected_subdomain().text
+        assert selected_domain == domain
+
     def verify_unselected_domain(self):
         selected_domain = self.search_page.get_selected_domain().text
-        assert selected_domain == "All Domains"
+        assert selected_domain == "All domains"
+
+    def verify_unselected_subdomain(self):
+        selected_domain = self.search_page.get_selected_subdomain().text
+        assert selected_domain == "All subdomains"
 
     def verify_selected_filters_shown(self, domains):
         actual = {i.text for i in self.search_page.selected_filter_tags()}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,4 +1,5 @@
 from types import GeneratorType
+from unittest.mock import patch
 
 import pytest
 from data_platform_catalogue.search_types import (
@@ -6,9 +7,9 @@ from data_platform_catalogue.search_types import (
     SearchResponse,
     SearchResult,
 )
-from unittest.mock import patch
-from home.service.search import SearchForm, SearchService, domains_with_their_subdomains
+
 from home.service.glossary import GlossaryService
+from home.service.search import SearchForm, SearchService, domains_with_their_subdomains
 
 
 class TestSearchService:
@@ -43,6 +44,7 @@ class TestSearchService:
             "analytical_platform": (
                 "?query=test&"
                 "domain=urn%3Ali%3Adomain%3AHMCTS&"
+                "subdomain=&"
                 "classifications=OFFICIAL&"
                 "sort=ascending&"
                 "clear_filter=False&"
@@ -54,6 +56,7 @@ class TestSearchService:
             "OFFICIAL": (
                 "?query=test&"
                 "domain=urn%3Ali%3Adomain%3AHMCTS&"
+                "subdomain=&"
                 "where_to_access=analytical_platform&"
                 "sort=ascending&"
                 "clear_filter=False&"
@@ -201,18 +204,24 @@ class TestGlossaryService:
 
 
 @pytest.mark.parametrize(
-    "domain, expected_subdomains",
+    "domain, subdomain, expected_subdomains",
     [
-        ("does-not-exist", []),
+        ("does-not-exist", "", []),
         (
             "urn:li:domain:HMPPS",
+            "",
             [
                 "urn:li:domain:HMPPS",
                 "urn:li:domain:2feb789b-44d3-4412-b998-1f26819fabf9",
                 "urn:li:domain:abe153c1-416b-4abb-be7f-6accf2abb10a",
             ],
         ),
+        (
+            "urn:li:domain:HMPPS",
+            "urn:li:domain:2feb789b-44d3-4412-b998-1f26819fabf9",
+            ["urn:li:domain:2feb789b-44d3-4412-b998-1f26819fabf9"],
+        ),
     ],
 )
-def test_domain_expansion(domain, expected_subdomains):
-    assert domains_with_their_subdomains(domain) == expected_subdomains
+def test_domain_expansion(domain, subdomain, expected_subdomains):
+    assert domains_with_their_subdomains(domain, subdomain) == expected_subdomains


### PR DESCRIPTION
When selecting a domain, a user may select a top-level domain and a subdomain.

When the subdomain is selected, `subdomain` is passed as an additional form value.

If this is present, we need to:

- Use this as the sole domain filter
- Preserve the selected value
- Add the subdomain to the label shown in "Selected filters"
- Exclude the subdomain field from the clear link used in "Selected filters"

Please review carefully - the logic is very awkward.