### PR TITLE
Condensed metadata component

### DIFF
--- a/templates/details_data_product.html
+++ b/templates/details_data_product.html
@@ -31,47 +31,36 @@
       <div class="govuk-body">
           {{result.description|markdown:3}}
       </div>
-      <dl class="govuk-summary-list govuk-summary-list--no-border">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Last updated date</dt>
-          <dd class="govuk-summary-list__value">
-            {% if result.last_updated %}
-            {{result.last_updated | date:"jS F Y"}} ({{result.last_updated|naturaltime}})
-            {% endif %}
-          </dd>
-        </div>
+      <ul class="govuk-list govuk-body">
+        <li>
+          <span class="govuk-!-font-weight-bold">Last updated date:</span>
+          {% if result.last_updated %}
+          {{result.last_updated | date:"jS F Y"}} ({{result.last_updated|naturaltime}})
+          {% endif %}
+        </li>
 
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Refresh period</dt>
-          <dd class="govuk-summary-list__value">
+        <li>
+          <span class="govuk-!-font-weight-bold">Refresh period:</span>
+        </li>
 
-          </dd>
-        </div>
-
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Retention period</dt>
-          <dd class="govuk-summary-list__value">
-            {% if table.retention_period_in_days is None %}
-              Permanent
-            {% else %}
-              {{result.metadata.retention_period_in_days|intcomma}} days
-            {% endif %}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Domain</dt>
-          <dd class="govuk-summary-list__value">
+        <li>
+          <span class="govuk-!-font-weight-bold">Retention period:</span>
+          {% if table.retention_period_in_days is None %}
+            Permanent
+          {% else %}
+            {{result.metadata.retention_period_in_days|intcomma}} days
+          {% endif %}
+        </li>
+        <li>
+          <span class="govuk-!-font-weight-bold">Domain:</span>
           {{result.metadata.domain_name}}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Tags</dt>
-          <dd class="govuk-summary-list__value">
+        </li>
+        <li>
+          <span class="govuk-!-font-weight-bold">Tags:</span>
           {{ result.tags |join:", " }}
-          </dd>
         </div>
-      </dl>
-    </div>
+      </li>
+    </ul>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/templates/details_data_product.html
+++ b/templates/details_data_product.html
@@ -31,7 +31,7 @@
       <div class="govuk-body">
           {{result.description|markdown:3}}
       </div>
-      <ul class="govuk-list govuk-body">
+      <ul class="govuk-list govuk-body" id="metadata-property-list">
         <li>
           <span class="govuk-!-font-weight-bold">Last updated date:</span>
           {% if result.last_updated %}

--- a/templates/details_dataset.html
+++ b/templates/details_dataset.html
@@ -35,51 +35,36 @@
             <h2 class="govuk-heading-s govuk-!-margin-top-3">
                 Description
             </h2>
-            <p class="govuk-body">
+            <div class="govuk-body">
                 {{table.description|markdown:3}}
-            </p>
-            <dl class="govuk-summary-list govuk-summary-list--no-border">
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Last updated date</dt>
-                <dd class="govuk-summary-list__value">
-                  {% if result.last_updated %}
-                  {{result.last_updated | date:"jS F Y"}} ({{result.last_updated|naturaltime}})
-                  {% endif %}
-                </dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  Retention period
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  {% if table.retention_period_in_days is None %}
-                  Permanent
-                  {% else %}
-                  {{table.retention_period_in_days|intcomma}} days
-                  {% endif %}
-                </dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Refresh period</dt>
-                <dd class="govuk-summary-list__value">
-        
-                </dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Domain</dt>
-                <dd class="govuk-summary-list__value">
+            </div>
+            <ul class="govuk-list govuk-body">
+              <li>
+                <span class="govuk-!-font-weight-bold">Last updated date:</span>
+                {% if result.last_updated %}
+                {{result.last_updated | date:"jS F Y"}} ({{result.last_updated|naturaltime}})
+                {% endif %}
+              </li>
+              <li>
+                <span class="govuk-!-font-weight-bold">Retention period:</span>
+                {% if table.retention_period_in_days is None %}
+                Permanent
+                {% else %}
+                {{table.retention_period_in_days|intcomma}} days
+                {% endif %}
+              </li>
+              <li>
+                <span class="govuk-!-font-weight-bold">Refresh period:</span>
+              </li>
+              <li>
+                <span class="govuk-!-font-weight-bold">Domain:</span>
                 {{result.metadata.domain_name}}
-                </dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  Tags
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  {{result.tags | join:', '}}
-                </dd>
-              </div>
-            </dl>
+              </li>
+              <li>
+                <span class="govuk-!-font-weight-bold">Tags:</span>
+                {{result.tags | join:', '}}
+              </li>
+            </ul>
         </div>
     </div>
     <div class="govuk-grid-column-one-third">

--- a/templates/details_dataset.html
+++ b/templates/details_dataset.html
@@ -38,7 +38,7 @@
             <div class="govuk-body">
                 {{table.description|markdown:3}}
             </div>
-            <ul class="govuk-list govuk-body">
+            <ul class="govuk-list govuk-body" id="metadata-property-list">
               <li>
                 <span class="govuk-!-font-weight-bold">Last updated date:</span>
                 {% if result.last_updated %}

--- a/templates/details_dataset.html
+++ b/templates/details_dataset.html
@@ -26,7 +26,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <span class="govuk-caption-m">Dataset</span>
-        <h2 class="govuk-heading-l">Some dataset</h2>
+        <h2 class="govuk-heading-l">{{table.name}}</h2>
     </div>
 </div>
 <div class="govuk-grid-row">

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -72,7 +72,7 @@ class DataProductDetailsPage(Page):
         return self.selenium.find_element(By.TAG_NAME, "h2")
 
     def data_product_details(self):
-        return self.selenium.find_element(By.TAG_NAME, "dl")
+        return self.selenium.find_element(By.ID, "metadata-property-list")
 
     def data_product_tables(self):
         return self.selenium.find_element(By.TAG_NAME, "table")


### PR DESCRIPTION
## Description

This PR condenses the metadata displayed on both details pages, so there is less whitespace between items.

Rather than using the GOV.UK summary list component, we're just using a regular list.

Figma: https://www.figma.com/file/zTOVhHRnWfxRJqH6Gr8cIc/Catalogue-sketches?type=design&node-id=415-3214&mode=design&t=UQKg4FYZpaX5nC6P-0

The second commit adds in the correct dataset name, as previously it was hardcoded.

## Before

![Screenshot 2024-03-13 at 16 50 46](https://github.com/ministryofjustice/find-moj-data/assets/87579/948a5035-87a4-42d1-83ea-aea038ef9dfe)
![Screenshot 2024-03-13 at 16 51 15](https://github.com/ministryofjustice/find-moj-data/assets/87579/fab079f5-e9da-4e44-9160-b949405d515d)

## After

![Screenshot 2024-03-13 at 16 44 17](https://github.com/ministryofjustice/find-moj-data/assets/87579/f4c8b3c1-ba59-4d7a-aa95-9be4d63fbe86)
![Screenshot 2024-03-13 at 16 50 15](https://github.com/ministryofjustice/find-moj-data/assets/87579/f2c24d4f-34fb-4542-8007-c46f40c7f130)
