### PR TITLE
Added environment name to alpha banner

### DIFF
--- a/.github/workflows/deploy-generic.yml
+++ b/.github/workflows/deploy-generic.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Prepare Helm deployment
         id: prepare-helm-deployment
         env:
+          ENV: ${{ inputs.env }}
           CATALOGUE_URL: ${{ vars.CATALOGUE_URL }}
           DEBUG: ${{ vars.DEBUG }}
           DJANGO_ALLOWED_HOSTS: ${{ vars.DJANGO_ALLOWED_HOSTS }}

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+def env(request):
+    return {'env': settings.ENV}

--- a/core/settings.py
+++ b/core/settings.py
@@ -54,6 +54,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "core.context_processors.env",
             ],
         },
     },
@@ -119,6 +120,7 @@ with open(SAMPLE_SEARCH_RESULTS_FILENAME) as f:
 # Catalog settings
 CATALOGUE_URL = os.environ.get("CATALOGUE_URL")
 CATALOGUE_TOKEN = os.environ.get("CATALOGUE_TOKEN")
+ENV = os.environ.get("ENV")
 
 # session
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -22,6 +22,8 @@ spec:
               containerPort: 8000
               protocol: TCP
           env:
+            - name: ENV
+              value: "${ENV}"
             - name: CATALOGUE_URL
               value: "${CATALOGUE_URL}"
             - name: DEBUG

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -16,8 +16,14 @@
   <div class="govuk-phase-banner" role="region">
     <p class="govuk-phase-banner__content">
       <strong class="govuk-tag govuk-phase-banner__content__tag">Alpha</strong>
-      {% if env != "prod" %}
-        <strong class="govuk-tag govuk-phase-banner__content__tag">{{ env|title }}</strong>
+      {% if env == "dev" %}
+        <strong class="govuk-tag govuk-tag--yellow govuk-phase-banner__content__tag">{{ env|title }}</strong>
+      {% endif %}
+      {% if env == "test" %}
+        <strong class="govuk-tag govuk-tag--green govuk-phase-banner__content__tag">{{ env|title }}</strong>
+      {% endif %}
+      {% if env == "preprod" %}
+        <strong class="govuk-tag govuk-tag--blue govuk-phase-banner__content__tag">{{ env|title }}</strong>
       {% endif %}
       <!--<span class="govuk-phase-banner__text">
         This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -15,13 +15,14 @@
 <div class="govuk-width-container app-width-container">
   <div class="govuk-phase-banner" role="region">
     <p class="govuk-phase-banner__content">
-      <strong class="govuk-tag govuk-phase-banner__content__tag">Alpha
-      </strong>
+      {% if env != "prod" %}
+        <strong class="govuk-tag govuk-phase-banner__content__tag">{{ env }}</strong>
+      {% endif %}
       <!--<span class="govuk-phase-banner__text">
         This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
       </span>-->
       <span class="govuk-phase-banner__text">
-        This service is currently under development and feedback is being gathered through user research.
+        This service is currently in Alpha and feedback is being gathered through user research.
       </span>
     </p>
   </div>

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -15,14 +15,15 @@
 <div class="govuk-width-container app-width-container">
   <div class="govuk-phase-banner" role="region">
     <p class="govuk-phase-banner__content">
+      <strong class="govuk-tag govuk-phase-banner__content__tag">Alpha</strong>
       {% if env != "prod" %}
-        <strong class="govuk-tag govuk-phase-banner__content__tag">{{ env }}</strong>
+        <strong class="govuk-tag govuk-phase-banner__content__tag">{{ env|title }}</strong>
       {% endif %}
       <!--<span class="govuk-phase-banner__text">
         This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
       </span>-->
       <span class="govuk-phase-banner__text">
-        This service is currently in Alpha and feedback is being gathered through user research.
+        This service is currently in development and feedback is being gathered through user research.
       </span>
     </p>
   </div>


### PR DESCRIPTION
https://github.com/ministryofjustice/find-moj-data/issues/153
- I added the environment string as a setting then to each view via a context processor, which Django suggest as a way of making variables available to all templates https://docs.djangoproject.com/en/5.0/ref/templates/api/#writing-your-own-context-processors