### PR TITLE
Update search term pattern matching

### DIFF
--- a/home/service/search.py
+++ b/home/service/search.py
@@ -173,15 +173,9 @@ class SearchService(GenericService):
             return highlighted_results
 
         else:
-            pattern = f"({re.escape(query)})"
+            pattern = re.compile(rf"(\w*{query}\w*)", flags=re.IGNORECASE)
             for result in highlighted_results.page_results:
-                result.description = re.sub(
-                    pattern,
-                    r"<mark>\1</mark>",
-                    result.description,
-                    flags=re.IGNORECASE,
-                )
-
+                result.description = pattern.sub(r"<mark>\1</mark>", result.description)
             return highlighted_results
 
     def _get_match_reason_display_names(self):

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -173,10 +173,22 @@ class SearchService(GenericService):
             return highlighted_results
 
         else:
-            pattern = re.compile(rf"(\w*{query}\w*)", flags=re.IGNORECASE)
+            query_word_highlighting_pattern = (
+                self._compile_query_word_highlighting_pattern(query)
+            )
             for result in highlighted_results.page_results:
-                result.description = pattern.sub(r"<mark>\1</mark>", result.description)
+                result.description = self._add_mark_tags(
+                    result.description, query_word_highlighting_pattern
+                )
             return highlighted_results
+
+    @staticmethod
+    def _compile_query_word_highlighting_pattern(query: str) -> re.compile:
+        return re.compile(rf"(\w*{query}\w*)", flags=re.IGNORECASE)
+
+    @staticmethod
+    def _add_mark_tags(description: str, pattern: re.compile) -> str:
+        return pattern.sub(r"<mark>\1</mark>", description)
 
     def _get_match_reason_display_names(self):
         return {

--- a/tests/home/service/test_search.py
+++ b/tests/home/service/test_search.py
@@ -3,7 +3,8 @@ from types import GeneratorType
 
 import pytest
 
-from home.service.search import domains_with_their_subdomains
+from home.forms.search import SearchForm
+from home.service.search import SearchService, domains_with_their_subdomains
 
 
 class TestSearchService:
@@ -95,9 +96,11 @@ class TestSearchService:
             == marked_description
         )
 
-    def test_highlight_results_no_query(self, search_service):
-        search_service.form.cleaned_data = {"query": ""}
-        search_service._highlight_results()
+    def test_highlight_results_no_query(self):
+        form = SearchForm(data={"query": ""})
+        assert form.is_valid()
+
+        search_service = SearchService(form=form, page="1")
 
         assert (
             search_service.results.page_results
@@ -105,8 +108,10 @@ class TestSearchService:
         )
 
     def test_highlight_results_with_query(self, search_service):
-        search_service.form.cleaned_data = {"query": "a"}
-        search_service._highlight_results()
+        form = SearchForm(data={"query": "a"})
+        assert form.is_valid()
+
+        search_service = SearchService(form=form, page="1")
 
         assert (
             search_service.results.page_results


### PR DESCRIPTION
This PR adds the following:

- support for matching and highlighting entire worlds from a partial search term
- separates generation of a compiled query pattern from `_highlight_results`  into a static method
- separates the `re.sub` application of the mark tags from `_highlight_results`  into a static method
- adds tests to validate `re.compile` pattern generation
- adds parametrized test to validate mark tag generation for case insensitive and multiple word occurrence scenarios
- refactors `highlight_results` test for both query and non query scenarios