### PR TITLE
Stop showing "TBC" as "Database Name" in search results

### DIFF
--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -43,12 +43,6 @@
             </dd>
           </div>
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Database name:</dt>
-            <dd class="govuk-summary-list__value">
-              TBC
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">First created:</dt>
             <dd class="govuk-summary-list__value">
               {% if result.metadata.creation_date %}


### PR DESCRIPTION
This has been there since the beginning of the prototype, but it's not included in the most recent designs, and it's hardcoded to TBC.

Since this is currently not adding any value, we may as well get rid of it. In the next iteration we may change how we display search result titles and add back in the fully qualified name or database name, but we can do this once we know what we want to show.

What's left:

<img width="683" alt="Screenshot 2024-04-03 at 16 43 30" src="https://github.com/ministryofjustice/find-moj-data/assets/87579/1d5c328f-ae83-46a4-9c89-ccca924538a7">

Note: this still doesn't match the figma designs - but we have a related ticket on this topic: https://github.com/ministryofjustice/find-moj-data/issues/194