### PR TITLE
Improve captions on details pages

### DIFF
--- a/templates/details_data_product.html
+++ b/templates/details_data_product.html
@@ -91,7 +91,7 @@
                       {{ table.description|markdown:3 }}
                     {% endif %}
                   </td>
-                  <td class="govuk-table__cell">  <a href="{% url 'home:details' result_type=table_type id=table.urn %}" class="govuk-link">Schema details</a></td>
+                  <td class="govuk-table__cell">  <a href="{% url 'home:details' result_type=table_type id=table.urn %}" class="govuk-link">Table details</a></td>
                 </tr>
               {% endwith %}
             {% endfor %}

--- a/templates/details_data_product.html
+++ b/templates/details_data_product.html
@@ -70,6 +70,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
+        {% if tables %}
         <table class="govuk-table">
           <caption class="govuk-table__caption govuk-table__caption--m">Data product content</caption>
           <thead class="govuk-table__head">
@@ -97,6 +98,10 @@
             {% endfor %}
           </tbody>
         </table>
+        {% else %}
+        <h2 class="govuk-heading-m">Data product content</h2>
+        <p class="govuk-body">This data product is missing table information.</p>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/templates/details_data_product.html
+++ b/templates/details_data_product.html
@@ -20,7 +20,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <span class="govuk-caption-m">Data product</span>
-      <h2 class="govuk-heading-l">{{result.name}}</h2>
+      <h1 class="govuk-heading-l">{{result.name}}</h1>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/templates/details_database.html
+++ b/templates/details_database.html
@@ -20,7 +20,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <span class="govuk-caption-m">Database</span>
-      <h2 class="govuk-heading-l">{{result.name}}</h2>
+      <h1 class="govuk-heading-l">{{result.name}}</h1>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/templates/details_database.html
+++ b/templates/details_database.html
@@ -70,6 +70,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
+        {% if tables %}
         <table class="govuk-table">
           <caption class="govuk-table__caption govuk-table__caption--m">Database content</caption>
           <thead class="govuk-table__head">
@@ -97,6 +98,10 @@
             {% endfor %}
           </tbody>
         </table>
+        {% else %}
+        <h2 class="govuk-heading-m">Database content</h2>
+        <p class="govuk-body">This database is missing table information.</p>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/templates/details_database.html
+++ b/templates/details_database.html
@@ -91,7 +91,7 @@
                       {{ table.description|markdown:3 }}
                     {% endif %}
                   </td>
-                  <td class="govuk-table__cell">  <a href="{% url 'home:details' result_type=table_type id=table.urn %}" class="govuk-link">Schema details</a></td>
+                  <td class="govuk-table__cell">  <a href="{% url 'home:details' result_type=table_type id=table.urn %}" class="govuk-link">Table details</a></td>
                 </tr>
               {% endwith %}
             {% endfor %}

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -97,7 +97,7 @@
           </tbody>
         </table>
       {% else %}
-        <h2 class="govuk-heading-m">Schema</h2>
+        <h2 class="govuk-heading-m">Table schema</h2>
         <p class="govuk-body">The schema for this table is not available.</p>
       {% endif %}
 

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -76,7 +76,7 @@
     <div class="govuk-grid-column-full">
       {% if table.column_details %}
         <table class="govuk-table">
-          <caption class="govuk-table__caption govuk-table__caption--m">Schema</caption>
+          <caption class="govuk-table__caption govuk-table__caption--m">Table schema</caption>
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th scope="col" class="govuk-table__header">Column name</th>

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -26,7 +26,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <span class="govuk-caption-m">Table</span>
-      <h2 class="govuk-heading-l">{{table.name}}</h2>
+      <h1 class="govuk-heading-l">{{table.name}}</h1>
     </div>
   </div>
   <div class="govuk-grid-row">

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -68,6 +68,9 @@ class Page:
 
 
 class DataProductDetailsPage(Page):
+    def primary_heading(self):
+        return self.selenium.find_element(By.TAG_NAME, "h1")
+
     def secondary_heading(self):
         return self.selenium.find_element(By.TAG_NAME, "h2")
 

--- a/tests/selenium/test_search_scenarios.py
+++ b/tests/selenium/test_search_scenarios.py
@@ -263,9 +263,9 @@ class TestSearch:
     def verify_i_am_on_the_details_page(self, item_name):
         assert item_name in self.selenium.title
 
-        secondary_heading_text = self.details_data_product_page.secondary_heading().text
+        heading_text = self.details_data_product_page.primary_heading().text
 
-        assert secondary_heading_text == item_name
+        assert heading_text == item_name
 
     def enter_a_query_and_submit(self, query):
         search_bar = self.search_page.search_bar()


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/find-moj-data/issues/198

![Screenshot 2024-04-09 at 13 39 12](https://github.com/ministryofjustice/find-moj-data/assets/87579/85d28cae-093e-4297-b8e9-c795a8ff7406)

This PR also makes a few other small tweaks:
- Fix the heading structure so we have an h1 on these pages
- Use "table" rather than "schema" as the link text when linking to the table details
- Don't render a table of tables if there are no tables
