### PR TITLE
Markdown in column descriptions

### DIFF
--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -89,7 +89,7 @@
             {% for column in table.column_details %}
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell">{{column.name}}</td>
-                <td class="govuk-table__cell column-description">{{column.description|default:''}}</td>
+                <td class="govuk-table__cell column-description">{{column.description|default:''|markdown}}</td>
                 <td class="govuk-table__cell">{{column.type|title}}</td>
                 <td class="govuk-table__cell">{{column.nullable|yesno|upper}}</td>
               </tr>

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -89,7 +89,7 @@
             {% for column in table.column_details %}
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell">{{column.name}}</td>
-                <td class="govuk-table__cell">{{column.description|default:''}}</td>
+                <td class="govuk-table__cell column-description">{{column.description|default:''}}</td>
                 <td class="govuk-table__cell">{{column.type|title}}</td>
                 <td class="govuk-table__cell">{{column.nullable|yesno|upper}}</td>
               </tr>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from data_platform_catalogue.client import BaseCatalogueClient
-from data_platform_catalogue.entities import TableMetadata, RelationshipType
+from data_platform_catalogue.entities import RelationshipType, TableMetadata
 from data_platform_catalogue.search_types import (
     FacetOption,
     ResultType,
@@ -20,7 +20,7 @@ from django.test import Client
 from faker import Faker
 
 from home.forms.search import SearchForm
-from home.service.details import DataProductDetailsService, DatabaseDetailsService
+from home.service.details import DatabaseDetailsService, DataProductDetailsService
 from home.service.glossary import GlossaryService
 from home.service.search import SearchService
 
@@ -140,6 +140,7 @@ def mock_catalogue():
         page_results=generate_page(page_size=1, result_type=ResultType.TABLE),
         total_results=1,
     )
+    mock_get_table_details_response(mock_catalogue)
 
     yield mock_catalogue
 
@@ -151,6 +152,21 @@ def mock_list_database_tables_response(mock_catalogue, total_results, page_resul
         total_results=total_results, page_results=page_results
     )
     mock_catalogue.list_database_tables.return_value = search_response
+
+
+def mock_get_table_details_response(mock_catalogue):
+    mock_catalogue.get_table_details.return_value = TableMetadata(
+        name="abc",
+        description="abc",
+        retention_period_in_days=0,
+        column_details=[
+            {
+                "name": "foo",
+                "description": "description **with markdown**",
+                "type": "string",
+            }
+        ],
+    )
 
 
 def mock_search_response(mock_catalogue, total_results=0, page_results=()):

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -11,7 +11,7 @@ from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.select import Select
 
-TMP_DIR = Path(__file__).parent / "../../tmp"
+TMP_DIR = (Path(__file__).parent / "../../tmp").resolve()
 
 
 @pytest.fixture(scope="session")
@@ -53,6 +53,7 @@ def screenshotter(request, selenium: RemoteWebDriver):
 
     elif ("call" not in report) or report["call"].failed:
         timestamp = datetime.datetime.now().strftime(r"%Y%m%d%H%M%S")
+        TMP_DIR.mkdir(exist_ok=True)
         path = str(TMP_DIR / f"{timestamp}-{testname}-failed.png")
         total_height = selenium.execute_script(
             "return document.body.parentNode.scrollHeight"
@@ -79,6 +80,20 @@ class DataProductDetailsPage(Page):
 
     def data_product_tables(self):
         return self.selenium.find_element(By.TAG_NAME, "table")
+
+    def table_link(self):
+        return self.selenium.find_element(By.LINK_TEXT, "Table details")
+
+
+class TableDetailsPage(Page):
+    def caption(self):
+        return self.selenium.find_element(By.CSS_SELECTOR, ".govuk-caption-m").text
+
+    def column_descriptions(self):
+        return [
+            c.text
+            for c in self.selenium.find_elements(By.CSS_SELECTOR, ".column-description")
+        ]
 
 
 class HomePage(Page):
@@ -222,3 +237,8 @@ def search_page(selenium) -> SearchPage:
 @pytest.fixture
 def details_data_product_page(selenium) -> DataProductDetailsPage:
     return DataProductDetailsPage(selenium)
+
+
+@pytest.fixture
+def table_details_page(selenium) -> TableDetailsPage:
+    return TableDetailsPage(selenium)

--- a/tests/selenium/test_search_scenarios.py
+++ b/tests/selenium/test_search_scenarios.py
@@ -349,5 +349,5 @@ class TestSearch:
     def verify_i_am_on_the_table_details_page(self):
         assert self.table_details_page.caption() == "Table"
         assert self.table_details_page.column_descriptions() == [
-            "description **with markdown**"
+            "description with markdown"
         ]

--- a/tests/selenium/test_search_scenarios.py
+++ b/tests/selenium/test_search_scenarios.py
@@ -23,6 +23,7 @@ class TestSearch:
         home_page,
         search_page,
         details_data_product_page,
+        table_details_page,
         chromedriver_path,
     ):
         self.selenium = selenium
@@ -30,6 +31,7 @@ class TestSearch:
         self.home_page = home_page
         self.search_page = search_page
         self.details_data_product_page = details_data_product_page
+        self.table_details_page = table_details_page
         self.chromedriver_path = chromedriver_path
 
     def verify_glossary_link_from_homepage_works(self):
@@ -199,9 +201,9 @@ class TestSearch:
             self.selenium.current_url, chromedriver_path=self.chromedriver_path
         )
 
-    def test_search_to_data_product_details(self, mock_catalogue):
+    def test_search_to_details(self, mock_catalogue):
         """
-        Users can search a data product and got to its details page
+        Users can search and drill down into details
         """
         mock_search_response(
             mock_catalogue=mock_catalogue,
@@ -214,6 +216,8 @@ class TestSearch:
         self.verify_i_am_on_the_details_page(item_name)
         self.verify_data_product_details()
         self.verify_data_product_tables_listed()
+        self.click_on_table()
+        self.verify_i_am_on_the_table_details_page()
 
     def start_on_the_home_page(self):
         self.selenium.get(f"{self.live_server_url}")
@@ -338,3 +342,12 @@ class TestSearch:
     def verify_data_product_details(self):
         data_product_details = self.details_data_product_page.data_product_details()
         assert data_product_details.text
+
+    def click_on_table(self):
+        self.details_data_product_page.table_link().click()
+
+    def verify_i_am_on_the_table_details_page(self):
+        assert self.table_details_page.caption() == "Table"
+        assert self.table_details_page.column_descriptions() == [
+            "description **with markdown**"
+        ]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -56,6 +56,14 @@ class TestDetailsView:
         assert response.status_code == 404
 
 
+class TestTableView:
+    def test_table(self, client):
+        response = client.get(
+            reverse("home:details", kwargs={"id": "fake", "result_type": "table"})
+        )
+        assert response.status_code == 200
+
+
 class TestChartView:
     def test_chart(self, client):
         response = client.get(


### PR DESCRIPTION
Column descriptions may contain markdown, so render them through the markdown filter when displaying them.

This should help with (but not resolve) the problem reported in https://github.com/ministryofjustice/find-moj-data/issues/240