### PR TITLE
use stringData for unencoded secret strings

### DIFF
--- a/deployments/templates/secrets.yml
+++ b/deployments/templates/secrets.yml
@@ -3,6 +3,6 @@ kind: Secret
 metadata:
   name: "find-moj-data-secrets"
 type: Opaque
-data:
+stringData:
   secret-key: "${SECRET_KEY}"
   catalogue-token: "${CATALOGUE_TOKEN}"


### PR DESCRIPTION
We're passing unencoded secrets to the deployments/templates/secrets.yml, which is only supported when using the `stringData` key. This PR updates the config to use this key.