### PR TITLE
Fmd 217 error pages

### DIFF
--- a/templates/400.html
+++ b/templates/400.html
@@ -1,0 +1,17 @@
+{% extends "base/base.html" %}
+{% load static %}
+
+{% block content %}
+
+<div class="govuk-width-container">
+    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">Bad request</h1>
+        </div>
+      </div>
+    </main>
+  </div>
+
+
+{% endblock content %}

--- a/templates/400.html
+++ b/templates/400.html
@@ -13,5 +13,4 @@
     </main>
   </div>
 
-
 {% endblock content %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,22 @@
+{% extends "base/base.html" %}
+{% load static %}
+
+{% block content %}
+
+<div class="govuk-width-container">
+    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">Page not found</h1>
+          <p class="govuk-body">
+            If you typed the web address, check it is correct.
+          </p>
+          <p class="govuk-body">
+            If you pasted the web address, check you copied the entire address.
+          </p>
+        </div>
+      </div>
+    </main>
+  </div>
+
+{% endblock content %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -11,6 +11,9 @@
           <p class="govuk-body">
             There is a problem with the server.
           </p>
+          <p class="govuk-body">
+            If the server problems persist, <a href="https://moj.enterprise.slack.com/archives/C03QZ776JVA" class="govuk-link">contact the find-moj-data team on Slack.</a>
+          </p>
         </div>
       </div>
     </main>

--- a/templates/500.html
+++ b/templates/500.html
@@ -3,7 +3,6 @@
 
 {% block content %}
 
-  <a onclick="history.back()" class="govuk-back-link">Back</a>
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
       <div class="govuk-grid-row">
@@ -16,6 +15,5 @@
       </div>
     </main>
   </div>
-
 
 {% endblock content %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,21 @@
+{% extends "base/base.html" %}
+{% load static %}
+
+{% block content %}
+
+  <a onclick="history.back()" class="govuk-back-link">Back</a>
+  <div class="govuk-width-container">
+    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">Server error</h1>
+          <p class="govuk-body">
+            There is a problem with the server.
+          </p>
+        </div>
+      </div>
+    </main>
+  </div>
+
+
+{% endblock content %}


### PR DESCRIPTION
* Added 404 error template with gov.uk content
* Added 500 error template (this is what gets triggered as a catch-all for all datahub errors at the moment)
* Added 400 error template