### PR TITLE
Limit column descriptions temporarily

### DIFF
--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -89,7 +89,7 @@
             {% for column in table.column_details %}
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell">{{column.name}}</td>
-                <td class="govuk-table__cell column-description">{{column.description|default:''|markdown}}</td>
+                <td class="govuk-table__cell column-description">{{column.description|default:''|markdown:3|truncatechars_html:300}}</td>
                 <td class="govuk-table__cell">{{column.type|title}}</td>
                 <td class="govuk-table__cell">{{column.nullable|yesno|upper}}</td>
               </tr>


### PR DESCRIPTION
This is a partial workaround for https://github.com/ministryofjustice/find-moj-data/issues/240

A more flexible solution would be to provide a "Show more" button, but I'm going to look at that separately, as I'm not sure how much work it would be to implement.

In some cases we have very long descriptions associated with columns. Datahub has no restrictions on what we can store here, however our layout has some issues with long text:

1. It is hard to scan through the column list if a single column takes up the whole page
2. If a column description contains a markdown table, we don't render that as a table inside the table
3. If we have unparsed markdown with no natural line breaks (such as a column header) then the table grows to encompass its width

This workaround allows the problem page to render properly until these problems are addressed.