### PR TITLE
Add a details component with search query tips

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -21,6 +21,22 @@
           </div>
         </div>
       </form>
+      <details class="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Search query tips
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <ul class="govuk-list govuk-list--bullet">
+            <li><p>Use multiple words to narrow down your search.</p><p>For example: <strong>prisons probation</strong> matches data mentioning "prisons" AND "probation".</p></li>
+            <li><p>Separate words with a pipe to broaden your search.</p><p>For example: <strong>prisons | probation</strong> matches data mentioning "prisons" OR "probation".</p></li>
+            <li><p>Quote phrases to require an exact match.</p><p>For example: <strong>"case management"</strong> matches the exact phrase "case management" but not either word on its own.</p></li>
+            <li><p>Use a minus sign to exclude words.</p><p>For example: <strong>courts -magistrates</strong> excludes any results that mention "magistrates".</p></li>
+          </ul>
+          <p><a href="https://datahubproject.io/docs/how/search/#advanced-queries">More search query examples</a></p>
+        </div>
+      </details>
     </div>
   </div>
   <div class="govuk-grid-row">


### PR DESCRIPTION
Provide some query examples highlighting some of the supported syntax, and link to the full documentation in Datahub.

This should help mitigate the sometimes unintuitive default behaviour of requiring that ALL search terms match (https://github.com/ministryofjustice/find-moj-data/issues/248)

This behaviour is how Datahub have configured search, and to change it we would have to customise the Elasticsearch query.

This copy has not been reviewed by a content designer yet - it will probably need another iteration.

### Collapsed
<img width="843" alt="Screenshot 2024-04-30 at 15 08 40" src="https://github.com/ministryofjustice/find-moj-data/assets/87579/68bcdab2-9f65-4288-bf02-840012480e00">

### Expanded
<img width="791" alt="Screenshot 2024-04-30 at 15 08 46" src="https://github.com/ministryofjustice/find-moj-data/assets/87579/a520f3f2-33c1-4bcf-a8ac-7309a30d7b64">
