### PR TITLE
Make h1_value optional

### DIFF
--- a/home/templatetags/page_title.py
+++ b/home/templatetags/page_title.py
@@ -5,7 +5,9 @@ register = template.Library()
 
 
 @register.filter
-def render_title(h1_value: str) -> str:
+def render_title(h1_value: str = None) -> str:
     """Renders a compliant page title for  based on the h1 value,
     service name and gov uk suffix."""
-    return f"{h1_value} - {settings.SERVICE_NAME} - {settings.GOV_UK_SUFFIX}"
+    title = [h1_value] if h1_value else []
+    title = title + [settings.SERVICE_NAME, settings.GOV_UK_SUFFIX]
+    return " - ".join(title)


### PR DESCRIPTION
Error pages use base.html, which requires a variable h1_value. I've set a default. There was another issue I think to do with an entity when I searched for "Prison" I also meant to look at after this.

#307 