### PR TITLE
Create a new version of the library for release

### DIFF
--- a/.github/workflows/publish-datahub-client.yml
+++ b/.github/workflows/publish-datahub-client.yml
@@ -1,0 +1,47 @@
+---
+name: Release Datahub Client library
+
+on:
+  push:
+    tags:
+      - "datahub-client-v*.*.*"
+
+permissions: read-all
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lib/datahub-client
+    environment:
+      name: datahub-client-pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - name: Set up Python 3.10
+        id: setup_python
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        id: install_poetry
+        run: |
+          curl -sSL "https://install.python-poetry.org" | python3 -
+          echo "${HOME}/.poetry/bin" >>"${GITHUB_PATH}"
+
+      - name: Build a distribution
+        id: build_distribution
+        run: |
+          poetry build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
+        with:
+          packages-dir: python-libraries/data-platform-catalogue/dist

--- a/lib/datahub-client/CHANGELOG.md
+++ b/lib/datahub-client/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] 2024-05-07
+
+Change of build repo and several bug fixes following the refactor.
+
 ## [1.0.0] 2024-04-23
 
 Large refactor of DatahubClient with breaking changes.

--- a/lib/datahub-client/pyproject.toml
+++ b/lib/datahub-client/pyproject.toml
@@ -10,7 +10,7 @@ max-line-length = 120
 
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "1.0.0"
+version = "1.0.1"
 description = "Wrapper around Datahub supporting custom properties for the Find MOJ Data service."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
Pypi trusted publisher is set up with the following configuration:

Repository: ministryofjustice/find-moj-data
Workflow: publish-datahub-client.yml
Environment name: datahub-client-pypi