### PR TITLE
Fix rendering of some details pages

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -47,13 +47,13 @@ jobs:
         run: poetry run pytest --cov -m 'not slow' --doctest-modules
 
       - name: Prepare Selenium
-      # https://github.com/marketplace/actions/setup-chromedriver
+        # https://github.com/marketplace/actions/setup-chromedriver
         uses: nanasess/setup-chromedriver@v2.2.2
 
       - name: run selenium tests
         id: slow-tests
         if: steps.fast-tests.outcome == 'success'
-        run: poetry run pytest -m 'slow'
+        run: poetry run pytest -m 'slow' --axe-version 4.9.0
 
   javascript:
     runs-on: ubuntu-latest

--- a/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
+++ b/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
@@ -335,7 +335,7 @@ class DataHubCatalogueClient:
             platformSchema=OtherSchemaClass(rawSchema=""),
             fields=[
                 SchemaFieldClass(
-                    fieldPath=f"{column.name}",
+                    fieldPath=f"{column.display_name}",
                     type=SchemaFieldDataTypeClass(
                         type=DATAHUB_DATA_TYPE_MAPPING[column.type]  # type: ignore
                     ),

--- a/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
@@ -51,7 +51,11 @@ def parse_created_and_modified(
     properties: dict[str, Any]
 ) -> Tuple[datetime | None, datetime | None]:
     created = properties.get("created")
-    modified = properties.get("lastModified", {}).get("time")
+    modified = (properties.get("lastModified") or {}).get("time")
+    if created == 0:
+        created = None
+    if modified == 0:
+        modified = None
 
     if created is not None:
         created = datetime.fromtimestamp(created / 1000, timezone.utc)

--- a/lib/datahub-client/data_platform_catalogue/entities.py
+++ b/lib/datahub-client/data_platform_catalogue/entities.py
@@ -39,8 +39,7 @@ class Column(BaseModel):
     """
 
     name: str = Field(
-        pattern=r"^[\w.]+$",
-        description="The name of a column as it appears in the table.",
+        description="The column name or dotted path that identifies the column within the schema. This uses Datahub's FieldPath encoding scheme, and may include type and versioning information.",
     )
     display_name: str = Field(description="A user-friendly version of the name")
     type: str = Field(

--- a/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
+++ b/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+import pytest
 from data_platform_catalogue.client.graphql_helpers import (
     parse_columns,
     parse_created_and_modified,
@@ -199,16 +200,41 @@ def test_parse_relations_blank():
     assert result == {RelationshipType.PARENT: []}
 
 
-def test_parse_created_and_modified():
+@pytest.mark.parametrize(
+    "raw_created,raw_last_modified,expected_created,expected_modified",
+    [
+        (
+            1710426920000,
+            {"time": 1710426921000, "actor": "Shakira"},
+            datetime(2024, 3, 14, 14, 35, 20, tzinfo=timezone.utc),
+            datetime(2024, 3, 14, 14, 35, 21, tzinfo=timezone.utc),
+        ),
+        (
+            0,
+            {"time": 0, "actor": "Shakira"},
+            None,
+            None,
+        ),
+        (
+            None,
+            None,
+            None,
+            None,
+        ),
+    ],
+)
+def test_parse_created_and_modified(
+    raw_created, raw_last_modified, expected_created, expected_modified
+):
     properties = {
-        "created": 1710426920000,
-        "lastModified": {"time": 1710426921000, "actor": "Shakira"},
+        "created": raw_created,
+        "lastModified": raw_last_modified,
     }
 
     created, modified = parse_created_and_modified(properties)
 
-    assert created == datetime(2024, 3, 14, 14, 35, 20, tzinfo=timezone.utc)
-    assert modified == datetime(2024, 3, 14, 14, 35, 21, tzinfo=timezone.utc)
+    assert created == expected_created
+    assert modified == expected_modified
 
 
 def test_parse_properties():

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -89,7 +89,7 @@
           <tbody class="govuk-table__body">
             {% for column in table.column_details %}
               <tr class="govuk-table__row">
-                <td class="govuk-table__cell">{{column.name}}</td>
+                <td class="govuk-table__cell">{{column.display_name}}</td>
                 <td class="govuk-table__cell column-description">{{column.description|default:''|markdown:3|truncatechars_html:300}}</td>
                 <td class="govuk-table__cell">{{column.type|title}}</td>
                 <td class="govuk-table__cell">{{column.nullable|yesno|upper}}</td>

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -11,7 +11,7 @@
       </li>
       {% if parent_entity %}
         <li class="govuk-breadcrumbs__list-item">
-          <a class="govuk-breadcrumbs__link" href="{% url 'home:details' result_type=dataset_parent_type urn=parent_entity.id %}">{{parent_entity.name}}</a>
+          <a class="govuk-breadcrumbs__link" href="{% url 'home:details' result_type=dataset_parent_type urn=parent_entity.urn %}">{{parent_entity.name}}</a>
         </li>
       {% endif %}
       <li class="govuk-breadcrumbs__list-item">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ from faker import Faker
 
 from home.forms.search import SearchForm
 from home.service.details import DatabaseDetailsService
-from home.service.glossary import GlossaryService
 from home.service.search import SearchService
 
 fake = Faker()
@@ -26,11 +25,17 @@ fake = Faker()
 
 def pytest_addoption(parser):
     parser.addoption("--chromedriver-path", action="store")
+    parser.addoption("--axe-version", action="store")
 
 
 @pytest.fixture
 def chromedriver_path(request):
     return request.config.getoption("--chromedriver-path")
+
+
+@pytest.fixture
+def axe_version(request):
+    return request.config.getoption("--axe-version") or "latest"
 
 
 def generate_search_result(

--- a/tests/selenium/helpers.py
+++ b/tests/selenium/helpers.py
@@ -1,8 +1,8 @@
 import subprocess
 
 
-def check_for_accessibility_issues(url, chromedriver_path=None):
-    command = ["npx", "@axe-core/cli"]
+def check_for_accessibility_issues(url, chromedriver_path=None, axe_version="latest"):
+    command = ["npx", f"@axe-core/cli@{axe_version}"]
 
     if chromedriver_path:
         command.extend(["--chromedriver-path", chromedriver_path])

--- a/tests/selenium/test_search_scenarios.py
+++ b/tests/selenium/test_search_scenarios.py
@@ -26,6 +26,7 @@ class TestSearch:
         table_details_page,
         glossary_page,
         chromedriver_path,
+        axe_version,
         page_titles,
     ):
         self.selenium = selenium
@@ -37,6 +38,7 @@ class TestSearch:
         self.glossary_page = glossary_page
         self.chromedriver_path = chromedriver_path
         self.page_titles = page_titles
+        self.axe_version = axe_version
 
     def verify_glossary_link_from_homepage_works(self):
         self.start_on_the_home_page()
@@ -177,13 +179,17 @@ class TestSearch:
     def test_automated_accessibility_home(self):
         self.start_on_the_home_page()
         check_for_accessibility_issues(
-            self.selenium.current_url, chromedriver_path=self.chromedriver_path
+            self.selenium.current_url,
+            chromedriver_path=self.chromedriver_path,
+            axe_version=self.axe_version,
         )
 
     def test_automated_accessibility_search(self):
         self.start_on_the_search_page()
         check_for_accessibility_issues(
-            self.selenium.current_url, chromedriver_path=self.chromedriver_path
+            self.selenium.current_url,
+            chromedriver_path=self.chromedriver_path,
+            axe_version=self.axe_version,
         )
 
     def test_search_to_details(self, mock_catalogue):


### PR DESCRIPTION
Resolves https://github.com/orgs/ministryofjustice/projects/57/views/5?pane=issue&itemId=61705328#:~:text=not%20always%20parseable-,%23303,-Edit

Fixes on this branch:

1. Fix links to the parent entity in breadcrumbs (id attribute changed to URN)
2. Make sure selenium tests call out to an up to date version of axe-core, instead of using the same cached version forever
3. Remove incorrect validation on Column.name, and use Column.display_name instead for rendering
4. Do not render timestamps of '0' (January 1st 1970)