### PR TITLE
Tidy empty search results page

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -140,6 +140,7 @@ DATABASES = {
 SERVICE_NAME = "Find MOJ Data"
 GOV_UK_SUFFIX = "GOV.UK"
 
+MAX_RESULTS = 10_000
 
 LOGGING = {
     "version": 1,  # the dictConfig format version

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -40,6 +40,10 @@ class SearchService(GenericService):
         self.domain_model = DomainModel()
         self.stemmer = PorterStemmer()
         self.form = form
+        if self.form.is_bound:
+            self.form_data = self.form.cleaned_data
+        else:
+            self.form_data = {}
         self.page = page
         self.client = self._get_catalogue_client()
         self.results = self._get_search_results(page, items_per_page)
@@ -65,10 +69,7 @@ class SearchService(GenericService):
         return chosen_entities if chosen_entities else default_entities
 
     def _get_search_results(self, page: str, items_per_page: int) -> SearchResponse:
-        if self.form.is_bound:
-            form_data = self.form.cleaned_data
-        else:
-            form_data = {}
+        form_data = self.form_data
 
         query = form_data.get("query", "")
         sort = form_data.get("sort", "relevance")
@@ -172,7 +173,7 @@ class SearchService(GenericService):
             "page_range": self.paginator.get_elided_page_range(
                 self.page, on_each_side=2, on_ends=1
             ),
-            "number_of_words": len(self.form.cleaned_data["query"].split()),
+            "number_of_words": len(self.form_data.get("query", "").split()),
             "paginator": self.paginator,
             "total_results": total_results,
             "label_clear_href": self._generate_label_clear_ref(),

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -8,6 +8,7 @@ from data_platform_catalogue.search_types import (
     SearchResponse,
     SortOption,
 )
+from django.conf import settings
 from django.core.paginator import Paginator
 from nltk.stem import PorterStemmer
 
@@ -157,6 +158,10 @@ class SearchService(GenericService):
         }
 
     def _get_context(self) -> dict[str, Any]:
+        if self.results.total_results >= settings.MAX_RESULTS:
+            total_results = f"{settings.MAX_RESULTS}+"
+        else:
+            total_results = str(self.results.total_results)
 
         context = {
             "form": self.form,
@@ -167,8 +172,9 @@ class SearchService(GenericService):
             "page_range": self.paginator.get_elided_page_range(
                 self.page, on_each_side=2, on_ends=1
             ),
+            "number_of_words": len(self.form.cleaned_data["query"].split()),
             "paginator": self.paginator,
-            "total_results": self.results.total_results,
+            "total_results": total_results,
             "label_clear_href": self._generate_label_clear_ref(),
             "readable_match_reasons": self._get_match_reason_display_names(),
         }

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -195,7 +195,7 @@ class SearchService(GenericService):
             )
             for result in highlighted_results.page_results:
                 result.description = self._add_mark_tags(
-                    result.description, query_word_highlighting_pattern
+                    result.description or "", query_word_highlighting_pattern
                 )
             return highlighted_results
 

--- a/home/templatetags/lookup.py
+++ b/home/templatetags/lookup.py
@@ -1,6 +1,12 @@
+from typing import Any
+
 from home.templatetags.markdown import register
 
 
 @register.filter
-def lookup(value_list, lookup_dict):
-    return sorted([lookup_dict.get(item, "") for item in value_list])
+def lookup(value_list, lookup_dict) -> list[Any]:
+    """
+    Return a list of values by doing a dictionary lookup using elements of the input list as keys.
+    Ignore any that are not in the list.
+    """
+    return sorted([lookup_dict[item] for item in value_list if item in lookup_dict])

--- a/lib/datahub-client/data_platform_catalogue/client/search.py
+++ b/lib/datahub-client/data_platform_catalogue/client/search.py
@@ -137,7 +137,10 @@ class SearchClient:
             name = field.get("name")
             value = field.get("value")
             if name == "customProperties" and value != "":
-                name, value = value.split("=")
+                try:
+                    name, value = value.split("=")
+                except ValueError:
+                    continue
             matched_fields[name] = value
         return matched_fields
 

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -37,35 +37,9 @@
           Description
         </h3>
         <div class="govuk-body">
-          {{table.description|markdown:3}}
+          No description available.
         </div>
-        <ul class="govuk-list govuk-body" id="metadata-property-list">
-          <li>
-            <span class="govuk-!-font-weight-bold">Last updated date:</span>
-            {% if table.last_modified %}
-              {{table.last_modified | date:"jS F Y"}} ({{table.last_modified|naturaltime}})
-            {% endif %}
-          </li>
-          <li>
-            <span class="govuk-!-font-weight-bold">Retention period:</span>
-            {% if table.retention_period_in_days is None %}
-              Permanent
-            {% else %}
-              {{table.retention_period_in_days|intcomma}} days
-            {% endif %}
-          </li>
-          <li>
-            <span class="govuk-!-font-weight-bold">Refresh period:</span>
-          </li>
-          <li>
-            <span class="govuk-!-font-weight-bold">Domain:</span>
-            {{table.domain.display_name}}
-          </li>
-          <li>
-            <span class="govuk-!-font-weight-bold">Tags:</span>
-            {{table.tags | join:', '}}
-          </li>
-        </ul>
+        
       </div>
     </div>
     <div class="govuk-grid-column-one-third">

--- a/templates/partial/no_results.html
+++ b/templates/partial/no_results.html
@@ -1,0 +1,7 @@
+<h2 class="govuk-heading-l govuk-!-display-inline-block" id="result-count">No results found</h2>
+{% if number_of_words > 1 %}
+<p>Try including less words in your search query.</p>
+<p>If you want to include results for multiple things, separate words with pipe characters. For example: <strong>prisons | probation</strong> matches data mentioning "prisons" OR "probation".</p>
+{% else %}
+<p>If you didn't find what you are looking for, make sure that all words are spelled correctly.</p>
+{% endif %}

--- a/templates/partial/pagination.html
+++ b/templates/partial/pagination.html
@@ -1,4 +1,5 @@
 {% load future %}
+{% if results %}
 <nav class="govuk-pagination" role="navigation" aria-label="Pagination">
     {% if page_obj.has_previous %}
         <div class="govuk-pagination__prev">
@@ -34,3 +35,4 @@
         </div>
     {% endif %}
 </nav>
+{% endif %}

--- a/templates/partial/sort.html
+++ b/templates/partial/sort.html
@@ -1,3 +1,4 @@
+{% if results %}
 <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
@@ -13,3 +14,4 @@
         </div>
     </fieldset>
 </div>
+{% endif %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -42,7 +42,11 @@
   <div class="govuk-grid-row">
     {% include "partial/filter.html" %}
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-l govuk-!-display-inline-block" id="result-count">{{total_results|intcomma}} Results</h2>
+      {% if results %}
+      <h2 class="govuk-heading-l govuk-!-display-inline-block" id="result-count">{{total_results|intcomma}} results</h2>
+      {% else %}
+      {% include "partial/no_results.html" %}
+      {% endif %}
       {% include "partial/sort.html" %}
       {% include "partial/search_result.html" %}
       {% include "partial/pagination.html" %}

--- a/tests/home/service/test_search.py
+++ b/tests/home/service/test_search.py
@@ -19,7 +19,7 @@ class TestSearchService:
 
     def test_get_context_search_result(self, mock_catalogue, search_context):
         assert search_context["results"] == mock_catalogue.search().page_results
-        assert search_context["total_results"] == 100
+        assert search_context["total_results"] == "100"
 
     def test_get_context_paginator(self, search_context):
         assert search_context["page_obj"].number == 1

--- a/tests/home/templatetags/test_lookup.py
+++ b/tests/home/templatetags/test_lookup.py
@@ -1,0 +1,16 @@
+import pytest
+
+from home.templatetags.lookup import lookup
+
+
+@pytest.mark.parametrize(
+    "input_list, lookup_dict, output_list",
+    [
+        ([], {}, []),
+        ([], {"foo": "bar"}, []),
+        ([1, 2], {"foo": "bar"}, []),
+        (["a", "b"], {"b": "c"}, ["c"]),
+    ],
+)
+def test_lookup(input_list, lookup_dict, output_list):
+    assert lookup(input_list, lookup_dict) == output_list

--- a/tests/selenium/test_search_scenarios.py
+++ b/tests/selenium/test_search_scenarios.py
@@ -252,7 +252,7 @@ class TestSearch:
 
     def verify_i_have_results(self):
         result_count = self.search_page.result_count().text
-        assert re.match(r"[1-9]\d* Results", result_count)
+        assert re.match(r"[1-9]\d* results", result_count)
 
     def click_on_the_first_result(self):
         first_result = self.search_page.first_search_result()


### PR DESCRIPTION
Related to https://github.com/orgs/ministryofjustice/projects/57/views/5?pane=issue&itemId=60708103 we want to gracefully handle the case where the search returns no results.

In this case there is no point rendering a "1" from the pagination, and we can skip the sort controls as well. I've introduced a partial so we can show a helpful message here. Given our research participants struggled with long queries in particular, we can nudge them towards shorter queries here (this will change if we later customise the search configuration)

In the process I also fixed a couple of bugs:
- I noticed than when we have > 10,000 results we just get 10,000 back, so I've formatted this as "10,000+"
- The "Matched fields" value was breaking when processing some custom properties set via DBT

<img width="314" alt="Screenshot 2024-05-08 at 13 51 28" src="https://github.com/ministryofjustice/find-moj-data/assets/87579/59b6b7cb-2956-471f-9654-5084b589765c">
<img width="689" alt="Screenshot 2024-05-08 at 14 11 28" src="https://github.com/ministryofjustice/find-moj-data/assets/87579/d7f7e397-199c-422d-a1e0-bf3885de7d0a">
<img width="709" alt="Screenshot 2024-05-08 at 14 12 17" src="https://github.com/ministryofjustice/find-moj-data/assets/87579/b6e1aa5d-f6dd-493b-859e-561c3a505fbc">
