### PR TITLE
Edit parse properties to convert some None values to

### DIFF
--- a/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
@@ -16,6 +16,8 @@ from data_platform_catalogue.entities import (
     UsageRestrictions,
 )
 
+PROPERTIES_EMPTY_STRING_FIELDS = ("description", "externalUrl")
+
 
 def parse_owner(entity: dict[str, Any]) -> OwnerRef:
     """
@@ -93,6 +95,13 @@ def parse_properties(
     properties = entity["properties"] or {}
     editable_properties = entity.get("editableProperties") or {}
     properties.update(editable_properties)
+
+    for key in PROPERTIES_EMPTY_STRING_FIELDS:
+        try:
+            properties[key] = properties[key] or ""
+        except KeyError:
+            pass
+
     custom_properties_dict = {
         i["key"]: i["value"] or "" for i in properties.get("customProperties", [])
     }

--- a/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
+++ b/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
@@ -275,3 +275,46 @@ def test_parse_properties():
         ),
         data_summary=DataSummary(row_count=100),
     )
+
+
+def test_parse_properties_with_none_values():
+    entity = {
+        "properties": {
+            "customProperties": [
+                {"key": "dpia_required", "value": False},
+                {"key": "dpia_location", "value": ""},
+                {"key": "data_sensitivity_level", "value": "OFFICIAL"},
+                {"key": "where_to_access_dataset", "value": "analytical_platform"},
+                {"key": "source_dataset_name", "value": ""},
+                {"key": "s3_location", "value": "s3://databucket/"},
+                {"key": "row_count", "value": 100},
+                {"key": "Not_IN", "value": "dddd"},
+            ],
+            "name": "test",
+            "description": None,
+            "externalUrl": None,
+
+        },
+        "editableProperties": {"edit1": "q"},
+    }
+    properties, custom_properties = parse_properties(entity)
+
+    assert properties == {
+        "name": "test",
+        "description": "",
+        "edit1": "q",
+        "externalUrl": "",
+    }
+
+    assert custom_properties == CustomEntityProperties(
+        usage_restrictions=UsageRestrictions(
+            dpia_required=False,
+            dpia_location="",
+        ),
+        access_information=AccessInformation(
+            where_to_access_dataset="analytical_platform",
+            source_dataset_name="",
+            s3_location="s3://databucket/",
+        ),
+        data_summary=DataSummary(row_count=100),
+    )


### PR DESCRIPTION
🐛 fix for https://github.com/ministryofjustice/find-moj-data/issues/327

- updated `parse_properties` to look for fields requiring default of "" and convert it if filed was explicitly set to `None`. Found 2 examples: `descritpion` and `externalUrl`.
- Added a unit test case for this
- Added test evidence of the fix working on the APP

