### PR TITLE
fix template so table details are shown in details pages

### DIFF
--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -37,9 +37,12 @@
           Description
         </h3>
         <div class="govuk-body">
-          No description available.
+          {% if table.description %}
+            {{table.description}}
+          {% else %}
+            No description available.
+          {% endif %}
         </div>
-
       </div>
     </div>
     <div class="govuk-grid-column-one-third">

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -31,7 +31,7 @@
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Registered by:</dt>
             <dd class="govuk-summary-list__value">
-              {{result.metadata.maintainer_display_name}}
+              TBC
             </dd>
           </div>
           <div class="govuk-summary-list__row">
@@ -47,12 +47,12 @@
             </dd>
           </div>
           {% if result.matches %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Matched fields</dt>
-            <dd class="govuk-summary-list__value">
-              {{ result.matches|lookup:readable_match_reasons|join:", " }}
-            </dd>
-          </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Matched fields</dt>
+              <dd class="govuk-summary-list__value">
+                {{ result.matches|lookup:readable_match_reasons|join:", " }}
+              </dd>
+            </div>
           {% endif %}
         </dl>
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">


### PR DESCRIPTION
Very small one to quickly fix the table description not being loaded to the details page 

(also removed a property that doesnt exist anymore from search results template as weirdly this errored for me locally)