### PR TITLE
Replace all underscores with spaces in the search query

### DIFF
--- a/home/service/search.py
+++ b/home/service/search.py
@@ -71,7 +71,7 @@ class SearchService(GenericService):
     def _get_search_results(self, page: str, items_per_page: int) -> SearchResponse:
         form_data = self.form_data
 
-        query = form_data.get("query", "")
+        query = form_data.get("query", "").replace("_", " ")
         sort = form_data.get("sort", "relevance")
         domain = form_data.get("domain", "")
         subdomain = form_data.get("subdomain", "")

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -71,6 +71,7 @@ class SearchService(GenericService):
     def _get_search_results(self, page: str, items_per_page: int) -> SearchResponse:
         form_data = self.form_data
 
+        # Workaround for https://github.com/datahub-project/datahub/issues/10505
         query = form_data.get("query", "").replace("_", " ")
         sort = form_data.get("sort", "relevance")
         domain = form_data.get("domain", "")


### PR DESCRIPTION
- This is a workaround for the search behaviour having underscores forcing an "OR" for all words
- This will be reverted when the search behaviour aligns again with expectations