### PR TITLE
Fmd 348 metadata spec

### DIFF
--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -45,7 +45,7 @@ spec:
             - name: AZURE_REDIRECT_URI
               value: "$AZURE_REDIRECT_URI"
             - name: AZURE_AUTHORITY
-              value: "$AZURE_AUTHORITY"
+              value: "$AZURE_AUTHORITY"      
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/home/forms/domain_model.py
+++ b/home/forms/domain_model.py
@@ -1,5 +1,5 @@
-from typing import NamedTuple
 import os
+from typing import NamedTuple
 
 
 class Domain(NamedTuple):

--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -1,10 +1,10 @@
 from copy import deepcopy
 from urllib.parse import urlencode
 
+from data_platform_catalogue.search_types import ResultType
 from django import forms
 
 from .domain_model import Domain, DomainModel
-from data_platform_catalogue.search_types import ResultType
 
 
 def get_domain_choices() -> list[Domain]:
@@ -35,10 +35,13 @@ def get_where_to_access_choices():
 
 
 def get_entity_types():
-    return sorted([
-        (entity.name, entity.name.replace("_", " ").lower().title())
-        for entity in ResultType if entity.name != "GLOSSARY_TERM"
-    ])
+    return sorted(
+        [
+            (entity.name, entity.name.replace("_", " ").lower().title())
+            for entity in ResultType
+            if entity.name != "GLOSSARY_TERM"
+        ]
+    )
 
 
 class SelectWithOptionAttribute(forms.Select):

--- a/home/service/metadata_specification.py
+++ b/home/service/metadata_specification.py
@@ -1,0 +1,44 @@
+from data_platform_catalogue.entities import (
+    AccessInformation,
+    Chart,
+    Column,
+    ColumnRef,
+    CustomEntityProperties,
+    Database,
+    DataSummary,
+    DomainRef,
+    Entity,
+    EntityRef,
+    Governance,
+    OwnerRef,
+    Table,
+    TagRef,
+    UsageRestrictions,
+)
+
+
+class MetadataSpecificationService:
+    def __init__(self):
+        self.context = self._get_context()
+
+    def _get_context(self):
+        return {
+            "h1_value": "Metadata Specification",
+            "entities": {
+                "Table": Table.model_json_schema(),
+                "Database": Database.model_json_schema(),
+                "Chart": Chart.model_json_schema(),
+                "CustomEntityProperties": CustomEntityProperties.model_json_schema(),
+                "UsageRestrictions": UsageRestrictions.model_json_schema(),
+                "AccessInformation": AccessInformation.model_json_schema(),
+                "EntityRef": EntityRef.model_json_schema(),
+                "Governance": Governance.model_json_schema(),
+                "OwnerRef": OwnerRef.model_json_schema(),
+                "DomainRef": DomainRef.model_json_schema(),
+                "Column": Column.model_json_schema(),
+                "ColumnRef": ColumnRef.model_json_schema(),
+                "TagRef": TagRef.model_json_schema(),
+                "DataSummary": DataSummary.model_json_schema(),
+                "Entity": Entity.model_json_schema(),
+            },
+        }

--- a/home/templatetags/format_metadata_field_type.py
+++ b/home/templatetags/format_metadata_field_type.py
@@ -1,0 +1,18 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def format_metadata_field_type(value: dict) -> str:
+    if value.get("title"):
+        title = value["title"]
+        if value.get("type"):
+            type_string = value["type"]
+        if value.get("anyOf"):
+            type_string = " or ".join(item["type"] for item in value["anyOf"])
+        output = f"{title} ({type_string})"
+    if value.get("allOf"):
+        linked_entity = value["allOf"][0]["$ref"].split("/")[2]
+        output = f"{linked_entity} (object)"
+    return output

--- a/home/templatetags/snippets.py
+++ b/home/templatetags/snippets.py
@@ -54,7 +54,7 @@ def _align_snippet(snippet, max_chars):
     Align a snippet to a few words before start_mark_idx
     """
     start_mark_idx = snippet.find("<mark>")
-    end_mark_idx = snippet[start_mark_idx + 1 :].find("</mark>")
+    end_mark_idx = snippet[start_mark_idx + 1:].find("</mark>")
 
     # If the mark is at the beginning of the first remaining paragraph,
     # no further alignment is required.

--- a/home/urls.py
+++ b/home/urls.py
@@ -8,6 +8,15 @@ urlpatterns = [
     path("", views.home_view, name="home"),
     path("search", views.search_view, name="search"),
     path("glossary", views.glossary_view, name="glossary"),
-    path("details/<str:result_type>/<str:urn>", views.details_view, name="details"),
+    path(
+        "metadata_specification",
+        views.metadata_specification_view,
+        name="metadata_specification",
+    ),
+    path(
+        "details/<str:result_type>/<str:urn>",
+        views.details_view,
+        name="details",
+    ),
     path("pagination/<str:page>", views.search_view, name="pagination"),
 ]

--- a/home/views.py
+++ b/home/views.py
@@ -9,6 +9,7 @@ from home.service.details import (
     DatasetDetailsService,
 )
 from home.service.glossary import GlossaryService
+from home.service.metadata_specification import MetadataSpecificationService
 from home.service.search import SearchService
 
 
@@ -83,3 +84,10 @@ def search_view(request, page: str = "1"):
 def glossary_view(request):
     glossary_service = GlossaryService()
     return render(request, "glossary.html", glossary_service.context)
+
+
+def metadata_specification_view(request):
+    metadata_specification = MetadataSpecificationService()
+    return render(
+        request, "metadata_specification.html", metadata_specification.context
+    )

--- a/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
+++ b/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
@@ -235,7 +235,7 @@ class DataHubCatalogueClient:
             else:
                 relations = {}
             return Table(
-                urn=None,
+                urn=urn,
                 display_name=display_name,
                 name=name,
                 fully_qualified_name=qualified_name,

--- a/lib/datahub-client/data_platform_catalogue/entities.py
+++ b/lib/datahub-client/data_platform_catalogue/entities.py
@@ -17,9 +17,16 @@ class EntityRef(BaseModel):
     A reference to another entity in the metadata graph.
     """
 
-    urn: str = Field(description="The identifier of the entity being linked to.")
+    urn: str = Field(
+        description="The identifier of the entity being linked to.",
+        examples=[
+            "urn:li:chart:(justice-data,absconds)",
+            "urn:li:glossaryTerm:f045591e-182a-45fd-9b06-ebbc222606d6",
+        ],
+    )
     display_name: str = Field(
-        description="Display name that can be used for link text."
+        description="Display name that can be used for link text.",
+        examples=["absconds", "Common platform"],
     )
 
 
@@ -28,9 +35,22 @@ class ColumnRef(BaseModel):
     A reference to a column in a table
     """
 
-    name: str = Field(description="The column name as it appears in the table")
-    display_name: str = Field(description="A user-friendly version of the name")
-    table: EntityRef = Field(description="Reference to the table the column belongs to")
+    name: str = Field(
+        description="The column name or dotted path that identifies the column within the schema. This uses Datahub's FieldPath encoding scheme, and may include type and versioning information.",
+        examples=["custody_id", "table_name.custody_id"],
+    )
+    display_name: str = Field(
+        description="A user-friendly version of the name", examples=["custody_id"]
+    )
+    table: EntityRef = Field(
+        description="Reference to the table the column belongs to",
+        examples=[
+            EntityRef(
+                urn="urn:li:dataset:(urn:li:dataPlatform:dbt,delius.custody_dates,PROD)",
+                display_name="delius.custody_dates",
+            )
+        ],
+    )
 
 
 class Column(BaseModel):
@@ -40,15 +60,26 @@ class Column(BaseModel):
 
     name: str = Field(
         description="The column name or dotted path that identifies the column within the schema. This uses Datahub's FieldPath encoding scheme, and may include type and versioning information.",
+        examples=["parole_elibility_date", "table_name.custody_id"],
     )
-    display_name: str = Field(description="A user-friendly version of the name")
+    display_name: str = Field(
+        description="A user-friendly version of the name",
+        examples=["parole_elibility_date"],
+    )
     type: str = Field(
         description="The data type of the column as it appears in the table",
+        examples=["timestamp", "int"],
     )
-    description: str = Field(description="A description of the column")
-    nullable: bool = Field(description="Whether the field is nullable or not")
+    description: str = Field(
+        description="A description of the column",
+        examples=["Unique identifier for custody event"],
+    )
+    nullable: bool = Field(
+        description="Whether the field is nullable or not", examples=[True, False]
+    )
     is_primary_key: bool = Field(
-        description="Whether the field is part of the primary key"
+        description="Whether the field is part of the primary key",
+        examples=[True, False],
     )
     foreign_keys: list[ColumnRef] = Field(
         description="References to columns in other tables", default_factory=list
@@ -61,10 +92,16 @@ class OwnerRef(BaseModel):
     """
 
     display_name: str = Field(
-        description="The full name of the user as it should be displayed"
+        description="The full name of the user as it should be displayed",
+        examples=["John Doe", "Jane Smith"],
     )
-    email: str = Field("Contact email for the user")
-    urn: str = Field("Unique identifier for the user")
+    email: str = Field(
+        description="Contact email for the user", examples=["john.doe@justice.gov.uk"]
+    )
+    urn: str = Field(
+        description="Unique identifier for the user",
+        examples=["urn:li:corpuser:jane.smith"],
+    )
 
 
 class Governance(BaseModel):
@@ -73,10 +110,26 @@ class Governance(BaseModel):
     """
 
     data_owner: OwnerRef = Field(
-        description="The senior individual responsible for the data."
+        description="The senior individual responsible for the data.",
+        examples=[
+            OwnerRef(
+                display_name="John Doe",
+                email="jogn.doe@justice.gov.uk",
+                urn="urn:li:corpuser:john.doe",
+            )
+        ],
     )
     data_stewards: list[OwnerRef] = Field(
-        description="Experts who manage the data day-to-day."
+        description="Experts who manage the data day-to-day.",
+        examples=[
+            [
+                OwnerRef(
+                    display_name="Jane Smith",
+                    email="jane.smith@justice.gov.uk",
+                    urn="urn:li:corpuser:jane.smith",
+                )
+            ]
+        ],
     )
 
 
@@ -85,12 +138,10 @@ class DomainRef(BaseModel):
     Reference to a domain that entities belong to
     """
 
-    display_name: str = Field(
-        description="Display name", json_schema_extra={"example": "HMPPS"}
-    )
+    display_name: str = Field(description="Display name", examples=["HMPPS"])
     urn: str = Field(
         description="The identifier of the domain.",
-        json_schema_extra={"example": "urn:li:domain:HMCTS"},
+        examples=["urn:li:domain:HMCTS"],
     )
 
 
@@ -100,11 +151,12 @@ class TagRef(BaseModel):
     """
 
     display_name: str = Field(
-        description="Human friendly tag name", json_schema_extra={"example": "PII"}
+        description="Human friendly tag name",
+        examples=["PII"],
     )
     urn: str = Field(
         description="The identifier of the tag",
-        json_schema_extra={"example": "urn:li:tag:PII"},
+        examples=["urn:li:tag:PII"],
     )
 
 
@@ -116,9 +168,10 @@ class UsageRestrictions(BaseModel):
     dpia_required: bool | None = Field(
         description="Bool for if a data privacy impact assessment (DPIA) is required to access this database",
         default=None,
+        examples=[True, False],
     )
     dpia_location: str = Field(
-        description="Where to find the DPIA document", default=""
+        description="Where to find the DPIA document", default="", examples=["OneTrust"]
     )
 
 
@@ -131,11 +184,21 @@ class AccessInformation(BaseModel):
     where_to_access_dataset: str = Field(
         description="User-friendly description of where the data can be accessed",
         default="",
+        examples=["Analytical Platform"],
     )
     source_dataset_name: str = Field(
-        description="The name of a dataset this data was derived from", default=""
+        description="The name of a dataset this data was derived from",
+        default="",
+        examples=["stg_xhibit_bw_history"],
     )
-    s3_location: str = Field(description="Location of the data in s3", default="")
+    s3_location: str = Field(
+        description="Location of the data in s3",
+        default="",
+        examples=[
+            "s3://calculate-release-dates/data/database_name=dbf2e4/table_name=approved_dates/",
+            "s3://alpha-hmpps-reports-data",
+        ],
+    )
 
 
 class DataSummary(BaseModel):
@@ -144,7 +207,9 @@ class DataSummary(BaseModel):
     """
 
     row_count: int | str = Field(
-        description="Row count when the metadata was last updated", default=""
+        description="Row count when the metadata was last updated",
+        default="",
+        examples=["123", 123],
     )
 
 
@@ -172,37 +237,66 @@ class Entity(BaseModel):
     """
 
     urn: str | None = Field(
-        "Unique identifier for the entity. Relates to Datahub's urn"
+        description="Unique identifier for the entity. Relates to Datahub's urn",
+        examples=["urn:li:tag:PII", "urn:li:chart:(justice-data,absconds)"],
     )
-    display_name: str | None = Field("Display name of the entity")
-    name: str = Field("Actual name of the entity in its source platform")
+    display_name: str | None = Field(
+        description="Display name of the entity", examples=["Absconds"]
+    )
+    name: str = Field(
+        description="Actual name of the entity in its source platform",
+        examples=["Absconds"],
+    )
     fully_qualified_name: str | None = Field(
-        "Fully qualified name of the entity in its source platform"
+        description="Fully qualified name of the entity in its source platform",
+        examples=["database.absconds", "Absconds"],
     )
     description: str = Field(
         description="Detailed description about what functional area this entity is representing, what purpose it has"
         " and business related information.",
+        examples=[
+            "This entity has one row for each sentence in a court. Note that only the primary sentence is recorded rather than the secondary sentence."
+        ],
     )
     relationships: dict[RelationshipType, list[EntityRef]] = Field(
         default={},
         description="References to related entities in the metadata graph, such as platform or parent entities",
+        examples=[
+            [
+                {
+                    RelationshipType.PARENT: [
+                        EntityRef(
+                            urn="urn:li:dataset:(urn:li:dataPlatform:dbt,delius.custody_dates,PROD)",
+                            display_name="delius.custody_dates",
+                        )
+                    ]
+                }
+            ]
+        ],
     )
-    domain: DomainRef = Field(description="The domain this entity belongs to.")
+    domain: DomainRef = Field(
+        description="The domain this entity belongs to.",
+        examples=[DomainRef(display_name="HMPPS", urn="urn:li:domain:HMCTS")],
+    )
     governance: Governance = Field(description="Information about governance")
     tags: list[TagRef] = Field(
         default_factory=list,
         description="Additional tags to add.",
+        examples=[[TagRef(display_name="ESDA", urn="urn:li:tag:PII")]],
     )
     last_modified: Optional[datetime] = Field(
         description="When the metadata was last updated in the catalogue",
         default=None,
+        examples=[datetime(2011, 10, 2, 3, 0, 0)],
     )
     created: Optional[datetime] = Field(
         description="When the data entity was first created",
         default=None,
+        examples=[datetime(2011, 10, 2, 3, 0, 0)],
     )
     platform: EntityRef = Field(
         description="The platform that an entity should belong to, e.g. Glue, Athena, DBT. Should exist in datahub",
+        examples=[EntityRef(urn="urn:li:dataPlatform:kafka", display_name="Kafka")],
     )
     custom_properties: CustomEntityProperties = Field(
         description="Fields to add to DataHub custom properties",
@@ -213,20 +307,50 @@ class Entity(BaseModel):
 class Database(Entity):
     """For source system databases"""
 
+    urn: str | None = Field(
+        description="Unique identifier for the entity. Relates to Datahub's urn",
+        examples=["urn:li:container:my_database"],
+    )
+
 
 class Table(Entity):
-    """A table in a database or a tabular dataset"""
+    """A table in a database or a tabular dataset. DataHub calls them datasets."""
 
+    urn: str | None = Field(
+        description="Unique identifier for the entity. Relates to Datahub's urn",
+        examples=[
+            "urn:li:dataset:(urn:li:dataPlatform:redshift,public.table,DEV)"
+        ],
+    )
     column_details: list[Column] = Field(
         description="A list of objects which relate to columns in your data, each list item will contain, a name of"
-        " the column, data type of the column and description of the column."
+        " the column, data type of the column and description of the column.",
+        examples=[
+            [
+                Column(
+                    name="custody_id",
+                    display_name="custody_id",
+                    type="int",
+                    description="unique ID for custody",
+                    nullable=False,
+                    is_primary_key=True,
+                ),
+            ]
+        ],
     )
 
 
 class Chart(Entity):
     """A visualisation of a dataset"""
 
-    external_url: str = Field("URL to view the chart")
+    urn: str | None = Field(
+        description="Unique identifier for the entity. Relates to Datahub's urn",
+        examples=["urn:li:chart:(justice-data,absconds)"],
+    )
+    external_url: str = Field(
+        description="URL to view the chart",
+        examples=["https://data.justice.gov.uk/prisons/public-protection/absconds"],
+    )
 
 
 class Domain(Entity):

--- a/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
+++ b/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
@@ -293,7 +293,6 @@ def test_parse_properties_with_none_values():
             "name": "test",
             "description": None,
             "externalUrl": None,
-
         },
         "editableProperties": {"edit1": "q"},
     }

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -24,6 +24,7 @@ mark {
 .column-description {
     @include govuk-media-query($from: desktop) {
         max-width: $govuk-page-width / 2;
+        overflow-wrap: break-word;
     }
 }
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -9,5 +9,8 @@
   <p class="govuk-body">
     <a href="{% url 'home:glossary' %}" class="govuk-link">Glossary</a>.
   </p>
+  <p class="govuk-body">
+    <a href="{% url 'home:metadata_specification' %}" class="govuk-link">Metadata Specification</a>.
+  </p>
 
 {% endblock content %}

--- a/templates/metadata_specification.html
+++ b/templates/metadata_specification.html
@@ -1,0 +1,54 @@
+{% extends "base/base.html" %}
+{% load markdown %}
+{% load static %}
+{% load format_metadata_field_type %}
+
+{% block content %}
+
+<h1 class="govuk-heading-l">{{h1_value}}</h1>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter" id="sticky-sidebar">
+        <ul class="govuk-list">
+            {% for entity, schema_json in entities.items %}
+                <li class="term-group">
+                    <div><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="#{{ entity }}">
+                        <strong>{{ schema_json.title }}</strong>
+                    </a></div>
+                </li>
+            {%endfor%}
+        </ul>
+    </div>
+    <div class="govuk-grid-column-three-quarters" id="metadata-content">
+        <p class="govuk-body">
+            These classes are used by find-moj-data to represent persisted entities and validate user-generated entities.
+            Classes build upon <a href="https://datahubproject.io/docs/metadata-modeling/metadata-model/#the-core-entities">
+                DataHub's metadata model.
+            </a>
+        </p>
+        {% for entity, schema_json in entities.items %}
+        <table class="govuk-table">
+            <caption class="govuk-table__caption govuk-table__caption--m" id="{{ schema_json.title }}">
+                {{schema_json.title}}
+            </caption>
+            <caption class="govuk-table__caption govuk-!-font-weight-regular">{{schema_json.description}}</caption>
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Field</th>
+                <th scope="col" class="govuk-table__header">Field Description</th>
+                <th scope="col" class="govuk-table__header">Examples</th>
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+              {% for _, description in schema_json.properties.items %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ description|format_metadata_field_type }}</td>
+                <td class="govuk-table__cell">{{ description.description }}</td>
+                <td class="govuk-table__cell column-description">{{ description.examples|join:", " }}</td>
+              </tr>
+              {%endfor%}
+            </tbody>
+          </table>
+        {%endfor%}
+    </div>
+</div>
+{% endblock content %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,11 @@ from django.conf import settings
 import pytest
 from data_platform_catalogue.client.datahub_client import DataHubCatalogueClient
 from data_platform_catalogue.entities import (
+    AccessInformation,
     Column,
     ColumnRef,
     CustomEntityProperties,
+    DataSummary,
     DomainRef,
     EntityRef,
     Governance,
@@ -18,6 +20,7 @@ from data_platform_catalogue.entities import (
     RelationshipType,
     Table,
     TagRef,
+    UsageRestrictions,
 )
 from data_platform_catalogue.search_types import (
     FacetOption,

--- a/tests/home/service/test_details.py
+++ b/tests/home/service/test_details.py
@@ -1,10 +1,10 @@
 from data_platform_catalogue.entities import (
     Chart,
-    EntityRef,
-    RelationshipType,
-    Governance,
     DomainRef,
+    EntityRef,
+    Governance,
     OwnerRef,
+    RelationshipType,
 )
 from data_platform_catalogue.search_types import ResultType
 
@@ -64,7 +64,10 @@ class TestDatabaseDetailsService:
 class TestDetailsChartService:
     def test_get_context(self, mock_catalogue):
         chart_metadata = Chart(
+            urn="urn:li:chart:(justice-data,test)",
             name="test",
+            display_name="test",
+            fully_qualified_name="test",
             description="test",
             external_url="https://www.test.com",
             domain=DomainRef(urn="LAA", display_name="LAA"),
@@ -78,7 +81,7 @@ class TestDetailsChartService:
                     )
                 ],
             ),
-            platform=EntityRef(urn="", display_name="")
+            platform=EntityRef(urn="", display_name=""),
         )
         mock_catalogue.get_chart_details.return_value = chart_metadata
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -54,3 +54,9 @@ class TestGlossaryView:
     def test_details(self, client):
         response = client.get(reverse("home:glossary"))
         assert response.status_code == 200
+
+
+class TestMetadataSpecificationView:
+    def test_details(self, client):
+        response = client.get(reverse("home:metadata_specification"))
+        assert response.status_code == 200

--- a/tests/users/models/test_user.py
+++ b/tests/users/models/test_user.py
@@ -6,6 +6,7 @@ import pytest
 
 @pytest.mark.django_db
 class TestUserModel:
+
     def test_create_user(self):
         user_model = get_user_model()
 


### PR DESCRIPTION
- Added a page to display the metadata spec formed from the pydantic classes
- The page is dynamically created, but could be statically compiled as it won't change within a version.
- Missing at the moment is an indication as to which fields are filled in by the service user. There is not a concept of this in Pydantic. This can be left out of this page for now.
- The dataset registration page would make it clear which fields the user supplies. 
- Loads of examples for Pydantic classes have been added. As `Entity` subclasses have different URNs I have overloaded the urn attribute on subclasses eg the `Chart` class to display a chart urn example. 
- Something to consider: should fields with types that are classes eg `Entity.Domain` have examples or should the example be a link to the `Domain` class?
- Fixed a bug in `get_table_details` where `urn` isn't passed to `Table()`
- How can text wrapping on examples work better?