### PR TITLE
Change sentry dsn env var to avoid datahub telemetry clash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ DJANGO_LOG_LEVEL=INFO
 CATALOGUE_TOKEN=mycatalogtoken
 CATALOGUE_URL=https://datahub-catalogue-dev.apps.live.cloud-platform.service.justice.gov.uk/api/gms
 
+# Sentry Variables
+SENTRY_DSN_WORKAROUND=< obtain from onepassword >
+
 # Azure Variables (Examples)
 AZURE_AUTH_ENABLED=true # any string value other than true to disable Azure authentication
 AZURE_CLIENT_ID=< obtain from onepassword >

--- a/.github/workflows/deploy-generic.yml
+++ b/.github/workflows/deploy-generic.yml
@@ -88,7 +88,7 @@ jobs:
           DEBUG: ${{ vars.DEBUG }}
           DJANGO_ALLOWED_HOSTS: ${{ vars.DJANGO_ALLOWED_HOSTS }}
           DJANGO_LOG_LEVEL: ${{ vars.DJANGO_LOG_LEVEL }}
-          SENTRY_DSN: ${{ vars.SENTRY_DSN }}
+          SENTRY_DSN_WORKAROUND: ${{ vars.SENTRY_DSN_WORKAROUND }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
           CATALOGUE_TOKEN: ${{ secrets.CATALOGUE_TOKEN }}
           IMAGE_TAG: ${{ github.sha }}

--- a/core/settings.py
+++ b/core/settings.py
@@ -185,7 +185,7 @@ ENABLE_ANALYTICS: bool = (
 
 # Sentry Configuration
 sentry_sdk.init(
-    dsn=os.environ.get("SENTRY_DSN"),
+    dsn=os.environ.get("SENTRY_DSN_WORKAROUND"),
     enable_tracing=True,
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.

--- a/core/settings.py
+++ b/core/settings.py
@@ -185,7 +185,7 @@ ENABLE_ANALYTICS: bool = (
 
 # Sentry Configuration
 sentry_sdk.init(
-    dsn=os.environ.get("SENTRY_DSN_WORKAROUND"),
+    dsn=os.environ.get("SENTRY_DSN_WORKAROUND"), # Datahub overwrites with this variable unless it is renamed, causing Sentry to tag issues with the incorrect environment
     enable_tracing=True,
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -32,8 +32,8 @@ spec:
               value: "${DJANGO_ALLOWED_HOSTS}"
             - name: DJANGO_LOG_LEVEL
               value: "${DJANGO_LOG_LEVEL}"
-            - name: SENTRY_DSN
-              value: "${SENTRY_DSN}"
+            - name: SENTRY_DSN_WORKAROUND
+              value: "${SENTRY_DSN_WORKAROUND}"
             - name: ENABLE_ANALYTICS
               value: "${ENABLE_ANALYTICS}"
             - name: ANALYTICS_ID


### PR DESCRIPTION
Removed the existing `SENTRY_DSN` environment variable and set a new one of `SENTRY_DSN_WORKAROUND` to avoid the clash with the datahub telemetry code invoking the sentry_sdk init method with the standard variable.