### PR TITLE
Widen table columns in metadata spec

### DIFF
--- a/scss/base.scss
+++ b/scss/base.scss
@@ -28,6 +28,11 @@ mark {
     }
 }
 
+.wide-table {
+    table-layout: fixed;
+    width: 100%;
+    overflow-wrap: break-word;
+}
 
 @import './glossary';
 @import './details';

--- a/templates/metadata_specification.html
+++ b/templates/metadata_specification.html
@@ -26,24 +26,24 @@
             </a>
         </p>
         {% for entity, schema_json in entities.items %}
-        <table class="govuk-table">
+        <table class="govuk-table wide-table">
             <caption class="govuk-table__caption govuk-table__caption--m" id="{{ schema_json.title }}">
                 {{schema_json.title}}
             </caption>
             <caption class="govuk-table__caption govuk-!-font-weight-regular">{{schema_json.description}}</caption>
             <thead class="govuk-table__head">
               <tr class="govuk-table__row">
-                <th scope="col" class="govuk-table__header">Field</th>
-                <th scope="col" class="govuk-table__header">Field Description</th>
-                <th scope="col" class="govuk-table__header">Examples</th>
+                <th scope="col" class="govuk-table__header govuk-!-width-one-third">Field</th>
+                <th scope="col" class="govuk-table__header govuk-!-width-one-third">Field Description</th>
+                <th scope="col" class="govuk-table__header govuk-!-width-one-third">Examples</th>
               </tr>
             </thead>
             <tbody class="govuk-table__body">
               {% for _, description in schema_json.properties.items %}
               <tr class="govuk-table__row">
-                <td class="govuk-table__cell">{{ description|format_metadata_field_type }}</td>
-                <td class="govuk-table__cell">{{ description.description }}</td>
-                <td class="govuk-table__cell column-description">{{ description.examples|join:", " }}</td>
+                <td class="govuk-table__cell govuk-!-width-one-third">{{ description|format_metadata_field_type }}</td>
+                <td class="govuk-table__cell govuk-!-width-one-third">{{ description.description }}</td>
+                <td class="govuk-table__cell govuk-!-width-one-third">{{ description.examples|join:", " }}</td>
               </tr>
               {%endfor%}
             </tbody>


### PR DESCRIPTION
Fix each column to 1/3 of the available space.
This makes the description a bit more readable.