### PR TITLE
Add tags to display

### DIFF
--- a/lib/datahub-client/data_platform_catalogue/client/search.py
+++ b/lib/datahub-client/data_platform_catalogue/client/search.py
@@ -79,7 +79,7 @@ class SearchClient:
         # This is the tag that any and every entity we want to present in search results
         # now must have.
         display_in_catalogue_filter = MultiSelectFilter(
-            filter_name="tags", included_values=["urn:li:tag:display_in_catalogue"]
+            filter_name="tags", included_values=["urn:li:tag:dc_display_in_catalogue"]
         )
 
         filters.append(display_in_catalogue_filter)

--- a/lib/datahub-client/data_platform_catalogue/search_types.py
+++ b/lib/datahub-client/data_platform_catalogue/search_types.py
@@ -65,6 +65,10 @@ class SearchResult:
     tags: list[str] = field(default_factory=list)
     last_modified: datetime | None = None
     created: datetime | None = None
+    tags_to_display: list[str] = field(init=False)
+
+    def __post_init__(self):
+        self.tags_to_display = [tag for tag in self.tags if not tag.startswith("dc_")]
 
 
 @dataclass

--- a/lib/datahub-client/tests/client/datahub/test_search.py
+++ b/lib/datahub-client/tests/client/datahub/test_search.py
@@ -1111,3 +1111,47 @@ def test_list_database_tables(mock_graph, searcher):
     )
 
     assert response == expected
+
+
+@pytest.mark.parametrize(
+    "tags, result",
+    [
+        (["test0-tag", "dc_dc"], ["test0-tag"]),
+        (["dc_test0-tag", "dc_dc"], []),
+        (["dbt_dc", "dc_dc"], ["dbt_dc"]),
+        (["dbt:dc_", "tagger"], ["dbt:dc_", "tagger"]),
+    ],
+)
+def test_tag_to_display(tags, result):
+    test_search_result = SearchResult(
+        urn="urn:li:dataset:(urn:li:dataPlatform:athena,test_db.test_table,PROD)",
+        result_type=ResultType.TABLE,
+        name="test_table",
+        display_name="test_table",
+        fully_qualified_name="test_db.test_table",
+        description="just for test",
+        matches={},
+        metadata={
+            "owner": "",
+            "owner_email": "",
+            "total_parents": 0,
+            "parents": [],
+            "domain_name": "",
+            "domain_id": "",
+            "entity_types": {
+                "entity_type": "Dataset",
+                "entity_sub_types": ["Table"],
+            },
+            "dpia_required": None,
+            "dpia_location": "",
+            "where_to_access_dataset": "",
+            "source_dataset_name": "",
+            "s3_location": "",
+            "row_count": "",
+        },
+        tags=tags,
+        last_modified=None,
+        created=None,
+    )
+
+    assert test_search_result.tags_to_display == result

--- a/templates/details_database.html
+++ b/templates/details_database.html
@@ -58,7 +58,7 @@
             </li>
             <li>
               <span class="govuk-!-font-weight-bold">Tags:</span>
-              {{ result.tags |join:", " }}
+              {{ result.tags_to_display |join:", " }}
             </div>
           </li>
         </ul>


### PR DESCRIPTION
This PR does a couple of things:

1. It changes the tag used in all search filters from `display_in_catalogue` to `dc_display_in_catalogue`
2. It implements a new property, `tags_to_display`, in the `search_types.SearchResults` class. This is populated in a post init and makes a list useing the tags property but excludes any tag with the prefix `dc_`. 