### PR TITLE
Add ip access restriction to the `/metrics` path only

### DIFF
--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -3,9 +3,20 @@ kind: Ingress
 metadata:
   name: find-moj-data-ingress
   annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+        location /metrics {
+          allow 195.59.75.0/24;
+          allow 194.33.192.0/25;
+          allow 194.33.193.0/25;
+          allow 194.33.196.0/25;
+          allow 194.33.197.0/25;
+          allow 51.149.250.0/24;
+          allow 51.149.251.0/24;
+          allow 35.176.93.186/32;
+          deny all;
+        }
     external-dns.alpha.kubernetes.io/set-identifier: find-moj-data-ingress-${NAMESPACE}-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    nginx.ingress.kubernetes.io/whitelist-source-range: 195.59.75.0/24,194.33.192.0/25,194.33.193.0/25,194.33.196.0/25,194.33.197.0/25,51.149.250.0/24,51.149.251.0/24,35.176.93.186/32
 spec:
   ingressClassName: default
   tls:


### PR DESCRIPTION
Moves IP address restriction to the `/metrics` path.

### Note
IP addresses specified are the existing whilst I test, this will be reduced to only the Prometheus server / NAT ip's once clarified.