### PR TITLE
Show when stuff is an ESDA

### DIFF
--- a/home/service/details.py
+++ b/home/service/details.py
@@ -17,6 +17,11 @@ class DatabaseDetailsService(GenericService):
             raise ObjectDoesNotExist(urn)
 
         self.result = search_results.page_results[0]
+
+        self.is_esda = any(
+            term.display_name == "ESDA" for term in self.result.glossary_terms
+        )
+
         self.entities_in_database = self._get_database_entities()
         self.context = self._get_context()
 
@@ -48,6 +53,7 @@ class DatabaseDetailsService(GenericService):
             "result_type": "Database",
             "tables": self.entities_in_database,
             "h1_value": "Details",
+            "is_esda": self.is_esda,
         }
 
         return context

--- a/lib/datahub-client/pyproject.toml
+++ b/lib/datahub-client/pyproject.toml
@@ -12,7 +12,7 @@ max-line-length = 120
 name = "ministryofjustice-data-platform-catalogue"
 version = "1.0.1"
 description = "Wrapper around Datahub supporting custom properties for the Find MOJ Data service."
-authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
+authors = ["MOJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"
 readme = "README.md"
 packages = [{ include = "data_platform_catalogue" }]

--- a/templates/details_database.html
+++ b/templates/details_database.html
@@ -33,34 +33,25 @@
             {{result.description|markdown:3}}
           </div>
           <ul class="govuk-list govuk-body" id="metadata-property-list">
+            {% if result.last_modified %}
             <li>
               <span class="govuk-!-font-weight-bold">Last updated date:</span>
-              {% if result.last_modified %}
-                {{result.last_modified | date:"jS F Y"}} ({{result.last_modified|naturaltime}})
-              {% endif %}
+              {{result.last_modified | date:"jS F Y"}} ({{result.last_modified|naturaltime}})
             </li>
+            {% endif %}
 
-            <li>
-              <span class="govuk-!-font-weight-bold">Refresh period:</span>
-            </li>
-
-            <li>
-              <span class="govuk-!-font-weight-bold">Retention period:</span>
-              {% if table.retention_period_in_days is None %}
-                Permanent
-              {% else %}
-                {{result.metadata.retention_period_in_days|intcomma}} days
-              {% endif %}
-            </li>
             <li>
               <span class="govuk-!-font-weight-bold">Domain:</span>
               {{result.metadata.domain_name}}
             </li>
+            {% if result.tags_to_display %}
             <li>
               <span class="govuk-!-font-weight-bold">Tags:</span>
               {{ result.tags_to_display|lookup:'display_name'|join:", " }}
             </li>
+            {% endif %}
           </ul>
+          {% include "partial/esda_info.html" with is_esda=is_esda %}
         </div>
       </div>
 

--- a/templates/partial/esda_info.html
+++ b/templates/partial/esda_info.html
@@ -1,6 +1,6 @@
 {% if is_esda %}
 
-<p>This is an MoJ Essential Shared Data Asset (ESDA).</p>
+<p>This is an MOJ Essential Shared Data Asset (ESDA).</p>
     <details class="govuk-details">
     <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">

--- a/templates/partial/esda_info.html
+++ b/templates/partial/esda_info.html
@@ -1,0 +1,19 @@
+{% if is_esda %}
+
+<p>This is an MoJ Essential Shared Data Asset (ESDA).</p>
+    <details class="govuk-details">
+    <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+        What are ESDAs?
+        </span>
+    </summary>
+    <div class="govuk-details__text">
+    An ESDA is:
+    <ul class="govuk-list govuk-list--bullet">
+        <li>data provided by a government department or agency to another government department or agency to support an essential process or purpose which is the responsibility of the receiving organisation; or</li>
+        <li>data acquired by a government department or agency from another government department or agency to support an essential process or purpose, which is the responsibility of the acquiring organisation.</li>
+    </ul>
+    </div>
+    </details>
+
+{% endif %}


### PR DESCRIPTION
This only applies to a handful of assets, so in the case that a database is an ESDA, we will display this extra paragraph with a details component. This copy ideally needs to be rewritten in plain english at some point.

I've also removed metadata fields we have not populated yet (these will always display as blank) - this should be improved as part of https://github.com/ministryofjustice/find-moj-data/issues/423

We are deliberately not adding the ESDA notice on the search results page as we want this to be more concise. If we decide to show tags / glossary terms on the results page, we could potentially include ESDA there but at the moment we're not showing this.

![Screenshot 2024-06-12 at 11 38 54](https://github.com/ministryofjustice/find-moj-data/assets/87579/3be114b5-554e-4188-ab99-89198d62cc5c)
