### PR TITLE
match condition to esda display_name in datahub

### DIFF
--- a/home/service/details.py
+++ b/home/service/details.py
@@ -21,7 +21,8 @@ class DatabaseDetailsService(GenericService):
         self.result = search_results.page_results[0]
 
         self.is_esda = any(
-            term.display_name == "ESDA" for term in self.result.glossary_terms
+            term.display_name == "Essential Shared Data Asset (ESDA)"
+            for term in self.result.glossary_terms
         )
 
         self.entities_in_database = self._get_database_entities()


### PR DESCRIPTION
Esda glossary term wasn't being recognised by fmd, as the returned display name was longer than just esda. This PR aligns the display name in fmd with that held in datahub glossary