### PR TITLE
Remove phase banner

### DIFF
--- a/templates/base/navigation.html
+++ b/templates/base/navigation.html
@@ -11,7 +11,16 @@
 
       </svg>
 
-      <a class="moj-header__link moj-header__link--service-name" href="#">Find MOJ data</a>
+      <a class="moj-header__link moj-header__link--service-name" href="#">Find MOJ data
+      {% if ENV == "dev" or ENV is None %}&nbsp;
+      <strong class="govuk-tag govuk-tag--yellow">Development</strong>
+      {% endif %}
+      {% if ENV == "test" %}&nbsp;
+      <strong class="govuk-tag govuk-tag--green">{{ ENV|title }}</strong>
+      {% endif %}
+      {% if ENV == "preprod" %}&nbsp;
+        <strong class="govuk-tag govuk-tag--blue">{{ ENV|title }}</strong>
+      {% endif %}</a>
     </div>
     <div class="moj-header__content">
 
@@ -28,28 +37,6 @@
     </div>
   </div>
 </header>
-  <div class="govuk-phase-banner" role="region">
-    <div class="govuk-width-container">
-    <p class="govuk-phase-banner__content">
-      <strong class="govuk-tag govuk-phase-banner__content__tag">Beta</strong>
-      {% if ENV == "dev" %}
-        <strong class="govuk-tag govuk-tag--yellow govuk-phase-banner__content__tag">{{ ENV|title }}</strong>
-      {% endif %}
-      {% if ENV == "test" %}
-        <strong class="govuk-tag govuk-tag--green govuk-phase-banner__content__tag">{{ ENV|title }}</strong>
-      {% endif %}
-      {% if ENV == "preprod" %}
-        <strong class="govuk-tag govuk-tag--blue govuk-phase-banner__content__tag">{{ ENV|title }}</strong>
-      {% endif %}
-  <!--<span class="govuk-phase-banner__text">
-    This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
-  </span>-->
-      <span class="govuk-phase-banner__text">
-        This service is currently in development and feedback is being gathered through user research.
-      </span>
-    </p>
-    </div>
-  </div>
 </div>
 
 
@@ -86,28 +73,6 @@
       </nav>
 
     </div>
-    <!-- <div class="moj-primary-navigation__search">
-
-      <div class="moj-search moj-search--ondark moj-search--inline">
-        <form action="" method="get">
-
-          <div class="govuk-form-group">
-            <label class="govuk-label moj-search__label govuk-visually-hidden" for="search-1">
-              Search
-            </label>
-
-            <input class="govuk-input moj-search__input " id="search-1" name="search-1" type="search">
-
-          </div>
-
-          <button type="submit" class="govuk-button moj-search__button " data-module="govuk-button">
-            Search
-          </button>
-
-        </form>
-      </div>
-
-    </div> -->
   </div>
 
 </div>


### PR DESCRIPTION
The consensus is that there is no strong need for this in an internal service, so we're scrapping it.

I've moved the environment label to the header - this is still useful for the team, and is not rendered on production environments, so won't affect end users.

![Screenshot 2024-06-17 at 17 02 17](https://github.com/ministryofjustice/find-moj-data/assets/87579/61ff5448-013e-477c-832b-34c3951c9b29)
