### PR TITLE
Fmd 181 display tags as links

### DIFF
--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -119,6 +119,8 @@ class SearchForm(forms.Form):
     clear_filter = forms.BooleanField(initial=False, required=False)
     clear_label = forms.BooleanField(initial=False, required=False)
 
+    tags = forms.CharField(required=False)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.initial["sort"] = "relevance"

--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -6,6 +6,7 @@ from django import forms
 
 from ..models.domain_model import Domain, DomainModel
 from ..service.search_facet_fetcher import SearchFacetFetcher
+from ..service.search_tag_fetcher import SearchTagFetcher
 
 
 def get_domain_choices() -> list[Domain]:
@@ -45,6 +46,11 @@ def get_entity_types():
             if entity.name != "GLOSSARY_TERM"
         ]
     )
+
+
+def get_tags():
+    tags = SearchTagFetcher().fetch()
+    return tags
 
 
 class SelectWithOptionAttribute(forms.Select):
@@ -119,7 +125,7 @@ class SearchForm(forms.Form):
     clear_filter = forms.BooleanField(initial=False, required=False)
     clear_label = forms.BooleanField(initial=False, required=False)
 
-    tags = forms.CharField(required=False)
+    tags = forms.MultipleChoiceField(choices=get_tags, required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -80,7 +80,7 @@ class SearchService(GenericService):
         sort = form_data.get("sort", "relevance")
         domain = form_data.get("domain", "")
         subdomain = form_data.get("subdomain", "")
-        tag = form_data.get("tags", "")
+        tags = form_data.get("tags", "")
         domains_and_subdomains = domains_with_their_subdomains(
             domain, subdomain, self.domain_model
         )
@@ -93,8 +93,10 @@ class SearchService(GenericService):
             filter_value.append(MultiSelectFilter("domains", domains_and_subdomains))
         if where_to_access:
             filter_value.append(MultiSelectFilter("customProperties", where_to_access))
-        if tag:
-            filter_value.append(MultiSelectFilter("tags", [f"urn:li:tag:{tag}"]))
+        if tags:
+            filter_value.append(
+                MultiSelectFilter("tags", [f"urn:li:tag:{tag}" for tag in tags])
+            )
 
         page_for_search = str(int(page) - 1)
         if sort == "ascending":
@@ -150,11 +152,11 @@ class SearchService(GenericService):
                 remove_filter_hrefs["Where To Access"] = where_to_access_clear_href
 
             if tags:
-                tags_clear_href = {
-                    tags: self.form.encode_without_filter(
-                        filter_name="tags", filter_value=tags
+                tags_clear_href = {}
+                for tag in tags:
+                    tags_clear_href[tag] = self.form.encode_without_filter(
+                        filter_name="tags", filter_value=tag
                     )
-                }
                 remove_filter_hrefs["Tags"] = tags_clear_href
         else:
             remove_filter_hrefs = None

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -80,6 +80,7 @@ class SearchService(GenericService):
         sort = form_data.get("sort", "relevance")
         domain = form_data.get("domain", "")
         subdomain = form_data.get("subdomain", "")
+        tag = form_data.get("tags", "")
         domains_and_subdomains = domains_with_their_subdomains(
             domain, subdomain, self.domain_model
         )
@@ -92,6 +93,8 @@ class SearchService(GenericService):
             filter_value.append(MultiSelectFilter("domains", domains_and_subdomains))
         if where_to_access:
             filter_value.append(MultiSelectFilter("customProperties", where_to_access))
+        if tag:
+            filter_value.append(MultiSelectFilter("tags", [f"urn:li:tag:{tag}"]))
 
         page_for_search = str(int(page) - 1)
         if sort == "ascending":
@@ -122,6 +125,7 @@ class SearchService(GenericService):
             domain = self.form.cleaned_data.get("domain", "")
             entity_types = self.form.cleaned_data.get("entity_types", [])
             where_to_access = self.form.cleaned_data.get("where_to_access", [])
+            tags = self.form.cleaned_data.get("tags", [])
             remove_filter_hrefs = {}
             if domain:
                 remove_filter_hrefs["domain"] = self._generate_domain_clear_href()
@@ -144,6 +148,14 @@ class SearchService(GenericService):
                         )
                     )
                 remove_filter_hrefs["Where To Access"] = where_to_access_clear_href
+
+            if tags:
+                tags_clear_href = {
+                    tags: self.form.encode_without_filter(
+                        filter_name="tags", filter_value=tags
+                    )
+                }
+                remove_filter_hrefs["Tags"] = tags_clear_href
         else:
             remove_filter_hrefs = None
 

--- a/home/service/search_facet_fetcher.py
+++ b/home/service/search_facet_fetcher.py
@@ -8,7 +8,7 @@ class SearchFacetFetcher(GenericService):
     def __init__(self):
         self.client = self._get_catalogue_client()
         self.cache_key = "search_facets"
-        self.cache_timeout_seconds = 5
+        self.cache_timeout_seconds = 300
 
     def fetch(self) -> SearchFacets:
         """

--- a/home/service/search_tag_fetcher.py
+++ b/home/service/search_tag_fetcher.py
@@ -1,0 +1,24 @@
+from django.core.cache import cache
+
+from .base import GenericService
+
+
+class SearchTagFetcher(GenericService):
+    def __init__(self):
+        self.client = self._get_catalogue_client()
+        self.cache_key = "search_tags"
+        self.cache_timeout_seconds = 5
+
+    def fetch(self) -> list:
+        """
+        Fetch a static list of options that is independent of the search query
+        and any applied filters. Values are cached for 5 seconds to avoid
+        unnecessary queries.
+        """
+        result = cache.get(self.cache_key)
+        if not result:
+            result = self.client.get_tags()
+
+            cache.set(self.cache_key, result, timeout=self.cache_timeout_seconds)
+
+        return result

--- a/home/service/search_tag_fetcher.py
+++ b/home/service/search_tag_fetcher.py
@@ -7,7 +7,7 @@ class SearchTagFetcher(GenericService):
     def __init__(self):
         self.client = self._get_catalogue_client()
         self.cache_key = "search_tags"
-        self.cache_timeout_seconds = 5
+        self.cache_timeout_seconds = 300
 
     def fetch(self) -> list:
         """

--- a/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
+++ b/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
@@ -3,6 +3,30 @@ import logging
 from importlib.resources import files
 from typing import Sequence
 
+from datahub.configuration.common import ConfigurationError
+from datahub.emitter import mce_builder
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+from datahub.ingestion.source.common.subtypes import (
+    DatasetContainerSubTypes,
+    DatasetSubTypes,
+)
+from datahub.metadata import schema_classes
+from datahub.metadata.com.linkedin.pegasus2avro.common import DataPlatformInstance
+from datahub.metadata.schema_classes import (
+    ChangeTypeClass,
+    ContainerClass,
+    ContainerPropertiesClass,
+    DatasetPropertiesClass,
+    DomainPropertiesClass,
+    DomainsClass,
+    OtherSchemaClass,
+    SchemaFieldClass,
+    SchemaFieldDataTypeClass,
+    SchemaMetadataClass,
+    SubTypesClass,
+)
+
 from data_platform_catalogue.client.exceptions import (
     AspectDoesNotExist,
     ConnectivityError,
@@ -38,29 +62,6 @@ from data_platform_catalogue.search_types import (
     SearchFacets,
     SearchResponse,
     SortOption,
-)
-from datahub.configuration.common import ConfigurationError
-from datahub.emitter import mce_builder
-from datahub.emitter.mcp import MetadataChangeProposalWrapper
-from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
-from datahub.ingestion.source.common.subtypes import (
-    DatasetContainerSubTypes,
-    DatasetSubTypes,
-)
-from datahub.metadata import schema_classes
-from datahub.metadata.com.linkedin.pegasus2avro.common import DataPlatformInstance
-from datahub.metadata.schema_classes import (
-    ChangeTypeClass,
-    ContainerClass,
-    ContainerPropertiesClass,
-    DatasetPropertiesClass,
-    DomainPropertiesClass,
-    DomainsClass,
-    OtherSchemaClass,
-    SchemaFieldClass,
-    SchemaFieldDataTypeClass,
-    SchemaMetadataClass,
-    SubTypesClass,
 )
 
 logger = logging.getLogger(__name__)
@@ -210,6 +211,7 @@ class DataHubCatalogueClient:
         result_types: Sequence[ResultType] = (
             ResultType.TABLE,
             ResultType.CHART,
+            ResultType.DATABASE,
         ),
         filters: Sequence[MultiSelectFilter] = (),
     ) -> SearchFacets:
@@ -223,6 +225,10 @@ class DataHubCatalogueClient:
     def get_glossary_terms(self, count: int = 1000) -> SearchResponse:
         """Wraps the client's glossary terms query"""
         return self.search_client.get_glossary_terms(count)
+
+    def get_tags(self, count: int = 2000):
+        """Wraps the client's get tags query"""
+        return self.search_client.get_tags(count)
 
     def get_table_details(self, urn) -> Table:
         if self.check_entity_exists_by_urn(urn):

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getChartDetails.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getChartDetails.graphql
@@ -5,6 +5,17 @@ query getChartDetails($urn: String!) {
     platform {
       name
     }
+    tags {
+      tags {
+        tag {
+          urn
+          properties {
+            name
+            description
+          }
+        }
+      }
+    }
     domain {
       domain {
         urn

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getTags.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getTags.graphql
@@ -1,0 +1,16 @@
+query getTags(
+    $count: Int!
+) {
+searchAcrossEntities(
+    input: {types: TAG, query: "*", start: 0, count: $count}
+) {
+    start
+    count
+    total
+    searchResults {
+    entity {
+        urn
+    }
+    }
+}
+}

--- a/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
@@ -83,6 +83,13 @@ def parse_tags(entity: dict[str, Any]) -> list[TagRef]:
     tags = []
     for tag in outer_tags.get("tags", []):
         properties = tag.get("tag", {}).get("properties", {})
+        # This is needed because tags cerated by dbt seemily don't have properties
+        # populated
+        if not properties and tag.get("tag", {}).get("urn"):
+            properties = {
+                "name": tag.get("tag", {}).get("urn").replace("urn:li:tag:", "")
+            }
+
         if properties:
             tags.append(
                 TagRef(

--- a/lib/datahub-client/data_platform_catalogue/entities.py
+++ b/lib/datahub-client/data_platform_catalogue/entities.py
@@ -347,7 +347,7 @@ class Entity(BaseModel):
     tags: list[TagRef] = Field(
         default_factory=list,
         description="Additional tags to add.",
-        examples=[[TagRef(display_name="ESDA", urn="urn:li:tag:PII")]],
+        examples=[[TagRef(display_name="ESDA", urn="urn:li:tag:ESDA")]],
     )
     glossary_terms: list[GlossaryTermRef] = Field(
         default_factory=list,
@@ -383,6 +383,18 @@ class Entity(BaseModel):
         description="Fields to add to DataHub custom properties",
         default_factory=CustomEntityProperties,
     )
+    tags_to_display: list[str] = Field(
+        description="a list of tag display_names where tags starting 'dc_' are filtered out",  # noqa: E501
+        init=False,
+        default=[],
+    )
+
+    def model_post_init(self, __context):
+        self.tags_to_display = [
+            tag.display_name
+            for tag in self.tags
+            if not tag.display_name.startswith("dc_")
+        ]
 
 
 class Database(Entity):

--- a/lib/datahub-client/data_platform_catalogue/search_types.py
+++ b/lib/datahub-client/data_platform_catalogue/search_types.py
@@ -68,11 +68,13 @@ class SearchResult:
     glossary_terms: list[GlossaryTermRef] = field(default_factory=list)
     last_modified: datetime | None = None
     created: datetime | None = None
-    tags_to_display: list[TagRef] = field(init=False)
+    tags_to_display: list[str] = field(init=False)
 
     def __post_init__(self):
         self.tags_to_display = [
-            tag for tag in self.tags if not tag.display_name.startswith("dc_")
+            tag.display_name
+            for tag in self.tags
+            if not tag.display_name.startswith("dc_")
         ]
 
 

--- a/lib/datahub-client/tests/client/datahub/test_search.py
+++ b/lib/datahub-client/tests/client/datahub/test_search.py
@@ -1085,7 +1085,7 @@ def test_get_tags(mock_graph, searcher):
         "searchAcrossEntities": {
             "start": 0,
             "count": 200,
-            "total": 47,
+            "total": 3,
             "searchResults": [
                 {"entity": {"urn": "urn:li:tag:tag1"}},
                 {"entity": {"urn": "urn:li:tag:tag2"}},

--- a/lib/datahub-client/tests/client/datahub/test_search.py
+++ b/lib/datahub-client/tests/client/datahub/test_search.py
@@ -1077,3 +1077,28 @@ def test_tag_to_display(tags, result):
     )
 
     assert test_search_result.tags_to_display == result
+
+
+def test_get_tags(mock_graph, searcher):
+
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 200,
+            "total": 47,
+            "searchResults": [
+                {"entity": {"urn": "urn:li:tag:tag1"}},
+                {"entity": {"urn": "urn:li:tag:tag2"}},
+                {"entity": {"urn": "urn:li:tag:tag3"}},
+            ],
+        }
+    }
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.get_tags()
+
+    assert response == [
+        ("tag1", "urn:li:tag:tag1"),
+        ("tag2", "urn:li:tag:tag2"),
+        ("tag3", "urn:li:tag:tag3"),
+    ]

--- a/lib/datahub-client/tests/client/datahub/test_search.py
+++ b/lib/datahub-client/tests/client/datahub/test_search.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
+
 from data_platform_catalogue.client.search import SearchClient
 from data_platform_catalogue.entities import (
     AccessInformation,
@@ -1075,4 +1076,4 @@ def test_tag_to_display(tags, result):
         created=None,
     )
 
-    assert [t.display_name for t in test_search_result.tags_to_display] == result
+    assert test_search_result.tags_to_display == result

--- a/templates/details_chart.html
+++ b/templates/details_chart.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load markdown %}
 {% load humanize %}
+{% load future %}
 
 {% block breadcrumbs %}
     <div class="govuk-breadcrumbs">
@@ -48,7 +49,14 @@
                         <span class="govuk-!-font-weight-bold">Domain:</span>
                     </li>
                     <li>
-                        <span class="govuk-!-font-weight-bold">Tags:</span>
+                        {% if chart.tags_to_display %}
+                            <li>
+                                <span class="govuk-!-font-weight-bold">Tags:</span>
+                                {% for tag in chart.tags_to_display %}
+                                    <a href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            </li>
+                        {% endif %}
                     </li>
                 </ul>
             </div>

--- a/templates/details_chart.html
+++ b/templates/details_chart.html
@@ -53,7 +53,7 @@
                             <li>
                                 <span class="govuk-!-font-weight-bold">Tags:</span>
                                 {% for tag in chart.tags_to_display %}
-                                    <a href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                                    <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
                                 {% endfor %}
                             </li>
                         {% endif %}

--- a/templates/details_database.html
+++ b/templates/details_database.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load markdown %}
 {% load humanize %}
+{% load future %}
 
 {% block breadcrumbs %}
   <div class="govuk-breadcrumbs">
@@ -44,10 +45,12 @@
               <span class="govuk-!-font-weight-bold">Domain:</span>
               {{database.domain.display_name}}
             </li>
-            {% if result.tags_to_display %}
+            {% if database.tags_to_display %}
               <li>
                 <span class="govuk-!-font-weight-bold">Tags:</span>
-                {{ database.tags|lookup:'display_name'|join:", " }}
+                {% for tag in database.tags_to_display %}
+                  <a href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                {% endfor %}
               </li>
             {% endif %}
           </ul>

--- a/templates/details_database.html
+++ b/templates/details_database.html
@@ -49,7 +49,7 @@
               <li>
                 <span class="govuk-!-font-weight-bold">Tags:</span>
                 {% for tag in database.tags_to_display %}
-                  <a href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                  <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
                 {% endfor %}
               </li>
             {% endif %}

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load markdown %}
 {% load humanize %}
+{% load future %}
 
 {% block breadcrumbs %}
   <div class="govuk-breadcrumbs">
@@ -42,6 +43,27 @@
             No description available.
           {% endif %}
         </div>
+        <ul class="govuk-list govuk-body" id="metadata-property-list">
+          {% if table.last_modified %}
+            <li>
+              <span class="govuk-!-font-weight-bold">Last updated date:</span>
+              {{table.last_modified | date:"jS F Y"}} ({{table.last_modified|naturaltime}})
+            </li>
+          {% endif %}
+
+          <li>
+            <span class="govuk-!-font-weight-bold">Domain:</span>
+            {{table.domain.display_name}}
+          </li>
+          {% if table.tags_to_display %}
+            <li>
+              <span class="govuk-!-font-weight-bold">Tags:</span>
+              {% for tag in table.tags_to_display %}
+                <a href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+              {% endfor %}
+            </li>
+          {% endif %}
+        </ul>
       </div>
     </div>
     <div class="govuk-grid-column-one-third">
@@ -78,16 +100,16 @@
         <p class="govuk-body">The schema for this table is not available.</p>
       {% endif %}
       {% if has_lineage %}
-      <h2 class="govuk-heading-m">Lineage</h2>
-      <div class="govuk-body-m" >
-        If you are interested to find out what data were used to create this table or if this table is used to create any further tables, you can see that information via the lineage.
-      </div class="govuk-body-m">  
-      <div class="govuk-body">
-            <a href="{{lineage_url}}" class="govuk-link">
-              View lineage in DataHub
-            </a>
+        <h2 class="govuk-heading-m">Lineage</h2>
+        <div class="govuk-body-m" >
+          If you are interested to find out what data were used to create this table or if this table is used to create any further tables, you can see that information via the lineage.
+        </div class="govuk-body-m">
+        <div class="govuk-body">
+          <a href="{{lineage_url}}" class="govuk-link">
+            View lineage in DataHub
+          </a>
         </div>
-  {% endif %}
-  </div>
+      {% endif %}
+    </div>
 
 {% endblock content %}

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -59,7 +59,7 @@
             <li>
               <span class="govuk-!-font-weight-bold">Tags:</span>
               {% for tag in table.tags_to_display %}
-                <a href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
               {% endfor %}
             </li>
           {% endif %}

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -46,7 +46,7 @@
             <dd class="govuk-summary-list__value">
               {% if result.tags_to_display %}
                 {% for tag in result.tags_to_display %}
-                  <a href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                  <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
                 {% endfor %}
               {% endif %}
             </dd>

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -1,5 +1,6 @@
 {% load markdown %}
 {% load humanize %}
+{% load future %}
 <div id="search-results">
   {% for result in highlighted_results %}
     <div class="govuk-grid-row">
@@ -35,14 +36,24 @@
             </dd>
           </div>
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Domain name</dt>
+            <dt class="govuk-summary-list__key">Domain:</dt>
             <dd class="govuk-summary-list__value">
               {{result.metadata.domain_name}}
             </dd>
           </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Tags:</dt>
+            <dd class="govuk-summary-list__value">
+              {% if result.tags_to_display %}
+                {% for tag in result.tags_to_display %}
+                  <a href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+              {% endif %}
+            </dd>
+          </div>
           {% if result.matches %}
             <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">Matched fields</dt>
+              <dt class="govuk-summary-list__key">Matched fields:</dt>
               <dd class="govuk-summary-list__value">
                 {{ result.matches|lookup:readable_match_reasons|join:", " }}
               </dd>

--- a/templates/partial/selected_filters.html
+++ b/templates/partial/selected_filters.html
@@ -7,11 +7,13 @@
         </div>
         <div class="moj-filter__heading-action">
             <p>
-                <a class="govuk-link govuk-link--no-visited-state"
-                   href="{% url 'home:search' %}{% query_string domain=None entity_types=None where_to_access=None %}"
-                   id="clear_filter">
-                    Clear filter
-                </a>
+                {% if label_clear_href|get_keys|length > 0 %}
+                    <a class="govuk-link govuk-link--no-visited-state"
+                       href="{% url 'home:search' %}{% query_string domain=None entity_types=None where_to_access=None tags=None%}"
+                       id="clear_filter">
+                        Clear filter
+                    </a>
+                {% endif %}
             </p>
         </div>
     </div>

--- a/templates/partial/selected_filters.html
+++ b/templates/partial/selected_filters.html
@@ -7,7 +7,7 @@
         </div>
         <div class="moj-filter__heading-action">
             <p>
-                {% if label_clear_href|get_keys|length > 0 %}
+                {% if remove_filter_hrefs|get_keys|length > 0 %}
                     <a class="govuk-link govuk-link--no-visited-state"
                        href="{% url 'home:search' %}{% query_string domain=None entity_types=None where_to_access=None tags=None%}"
                        id="clear_filter">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ from home.models.domain_model import DomainModel
 from home.service.details import DatabaseDetailsService
 from home.service.search import SearchService
 from home.service.search_facet_fetcher import SearchFacetFetcher
+from home.service.search_tag_fetcher import SearchTagFetcher
 
 fake = Faker()
 
@@ -269,6 +270,7 @@ def mock_catalogue(request, example_database):
     mock_get_glossary_terms_response(mock_catalogue)
     mock_get_table_details_response(mock_catalogue)
     mock_get_database_details_response(mock_catalogue, example_database)
+    mock_get_tags_response(mock_catalogue)
 
     yield mock_catalogue
 
@@ -299,6 +301,14 @@ def mock_search_response(mock_catalogue, total_results=0, page_results=()):
 
 def mock_search_facets_response(mock_catalogue, domains):
     mock_catalogue.search_facets.return_value = SearchFacets({"domains": domains})
+
+
+def mock_get_tags_response(mock_catalogue):
+    mock_catalogue.get_tags.return_value = [
+        ("tag-1", "urn:li:tag:tag-1"),
+        ("tag-2", "urn:li:tag:tag-2"),
+        ("tag-3", "urn:li:tag:tag-3"),
+    ]
 
 
 def mock_get_glossary_terms_response(mock_catalogue):
@@ -354,6 +364,11 @@ def search_facets():
 
 
 @pytest.fixture
+def search_tags():
+    return SearchTagFetcher().fetch()
+
+
+@pytest.fixture
 def valid_domain(search_facets):
     return DomainModel(search_facets).top_level_domains[0]
 
@@ -369,6 +384,7 @@ def valid_form(valid_domain):
             "sort": "ascending",
             "clear_filter": False,
             "clear_label": False,
+            "tags": ["tag-1"],
         }
     )
     assert valid_form.is_valid()

--- a/tests/home/service/test_search.py
+++ b/tests/home/service/test_search.py
@@ -70,7 +70,7 @@ class TestSearchService:
             )
         }
 
-        assert search_context["label_clear_href"]["Tags"] == {
+        assert search_context["remove_filter_hrefs"]["Tags"] == {
             "tag-1": (
                 "?query=test&"
                 f"domain={quote(valid_domain.urn)}&"

--- a/tests/home/service/test_search.py
+++ b/tests/home/service/test_search.py
@@ -39,7 +39,8 @@ class TestSearchService:
                 "entity_types=TABLE&"
                 "sort=ascending&"
                 "clear_filter=False&"
-                "clear_label=False"
+                "clear_label=False&"
+                "tags=tag-1"
             )
         }
 
@@ -51,7 +52,8 @@ class TestSearchService:
                 "entity_types=TABLE&"
                 "sort=ascending&"
                 "clear_filter=False&"
-                "clear_label=False"
+                "clear_label=False&"
+                "tags=tag-1"
             )
         }
 
@@ -61,6 +63,20 @@ class TestSearchService:
                 f"domain={quote(valid_domain.urn)}&"
                 "subdomain=&"
                 "where_to_access=analytical_platform&"
+                "sort=ascending&"
+                "clear_filter=False&"
+                "clear_label=False&"
+                "tags=tag-1"
+            )
+        }
+
+        assert search_context["label_clear_href"]["Tags"] == {
+            "tag-1": (
+                "?query=test&"
+                f"domain={quote(valid_domain.urn)}&"
+                "subdomain=&"
+                "where_to_access=analytical_platform&"
+                "entity_types=TABLE&"
                 "sort=ascending&"
                 "clear_filter=False&"
                 "clear_label=False"

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -24,7 +24,8 @@ class TestSearchForm:
             "entity_types=TABLE&"
             "sort=ascending&"
             "clear_filter=False&"
-            "clear_label=False"
+            "clear_label=False&"
+            "tags=tag-1"
         )
 
     def test_form_encode_without_filter_for_two_filters(self):


### PR DESCRIPTION
This PR ensures entities that have tags (starting non `dc_`), have those tags presented in the search and details pages as a comma separated list. It also makes these tags clickable links to a search page returning all entities with that same tag that was clicked, and that the clicked tag is present in the selected filters box.

Also adds in a new search method in the client, `get_tags()` which returns all tags in datahub. I looked at using the facet query but doesn't look like it can return more than 20 results and we already have more than 20 tags from cadet alone.

It doesn't add an independent filter component but should allow for this to be added without too much pain.

https://github.com/ministryofjustice/find-moj-data/issues/181

