### PR TITLE
Make search a search input, and style its close button

### DIFF
--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -75,7 +75,9 @@ class SearchForm(forms.Form):
         max_length=100,
         strip=False,
         required=False,
-        widget=forms.TextInput(attrs={"class": "govuk-input search-input"}),
+        widget=forms.TextInput(
+            attrs={"class": "govuk-input search-input", "type": "search"}
+        ),
     )
     domain = forms.ChoiceField(
         choices=get_domain_choices,

--- a/scss/search.scss
+++ b/scss/search.scss
@@ -1,31 +1,54 @@
+// Base enhancements to search fields
+.govuk-input[type="search"] {
+  &:focus {
+    z-index: 1;
+  }
+
+  // Enhance the close button.
+  // Note: this is a non-standard CSS feature and will not do anything in Firefox.
+  // https://caniuse.com/mdn-css_selectors_-webkit-search-cancel-button
+  &::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    background-image: url("/static/assets/images/icon-close-cross-black.svg");
+    background-position: center;
+    background-repeat: no-repeat;
+    cursor: pointer;
+    height: 15px;
+    margin-left: 0;
+    margin-right: 2px;
+    width: 15px;
+  }
+}
+
+// Variant with search button adjacent to the input
 .search-container {
-    display: flex;
+  display: flex;
 }
 .search-icon {
-    height: 100%;
+  height: 100%;
 }
 
 .search-button {
-    background: #1d70b8;
-    border: 0;
-    color: #fff;
-    cursor: pointer;
-    height: 40px;
-    margin-bottom: 0;
-    padding: 0;
-    width: 40px;
+  background: #1d70b8;
+  border: 0;
+  color: #fff;
+  cursor: pointer;
+  height: 40px;
+  margin-bottom: 0;
+  padding: 0;
+  width: 40px;
 }
 
-.govuk-input.search-input {
-    border-right-width: 0;
+.govuk-input.search-input[type="search"] {
+  border-right-width: 0;
+
+  &:focus {
+    border-right-width: 2px;
+    z-index: 1;
+  }
 }
 
 .search-button:focus {
-    box-shadow: inset 0 0 0 4px #0b0c0c;
-    outline: 3px solid #fd0
-}
-
-.search-input:focus {
-    border-right-width: 2px;
-    z-index: 1
+  box-shadow: inset 0 0 0 4px #0b0c0c;
+  outline: 3px solid #fd0;
 }

--- a/static/assets/js/enhanced-glossary.js
+++ b/static/assets/js/enhanced-glossary.js
@@ -3,7 +3,7 @@ export const init = () => {
   jsRequired.style.display = "block";
 
   const input = document.getElementById("filter-input");
-  input.addEventListener("keyup", updateResults);
+  input.addEventListener("input", updateResults);
 };
 
 const updateResults = () => {

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -10,7 +10,7 @@
         <div class="govuk-grid-column-three-quarters">
             <div class="govuk-form-group govuk-!-margin-bottom-8 js-required">
                 <label for="filter-input" class="govuk-label govuk-visually-hidden-focusable">Filter this page (the content will be updated as you type)</label>
-                <input class="govuk-input" id="filter-input" placeholder="Filter this page">
+                <input class="govuk-input" id="filter-input" type="search" placeholder="Filter this page">
             </div>
         </div>
     </div>

--- a/tests/javascript/test_enhanced_glossary.js
+++ b/tests/javascript/test_enhanced_glossary.js
@@ -3,7 +3,7 @@ import { expect, test } from "@jest/globals";
 
 const simplifiedPage = `
 <div class="js-required">
-<input class="govuk-input" id="filter-input" placeholder="Filter this page">
+<input type="search" class="govuk-input" id="filter-input" placeholder="Filter this page">
 <div id="things" class="term-group">
   <h2>Things</h2>
   <p>Bla bla bla</p>
@@ -40,7 +40,7 @@ beforeEach(() => {
 
 test("everything is shown when the filter is empty", () => {
   filter.value = "";
-  filter.dispatchEvent(new Event("keyup"));
+  filter.dispatchEvent(new Event("input"));
 
   expect(things).not.toHaveClass("govuk-!-display-none");
   expect(apple).not.toHaveClass("govuk-!-display-none");
@@ -49,7 +49,7 @@ test("everything is shown when the filter is empty", () => {
 
 test("filtering to a term by its prefix", () => {
   filter.value = "ap";
-  filter.dispatchEvent(new Event("keyup"));
+  filter.dispatchEvent(new Event("input"));
 
   expect(things).not.toHaveClass("govuk-!-display-none");
   expect(apple).not.toHaveClass("govuk-!-display-none");
@@ -58,7 +58,7 @@ test("filtering to a term by its prefix", () => {
 
 test("filtering out all terms within a group", () => {
   filter.value = "carrot";
-  filter.dispatchEvent(new Event("keyup"));
+  filter.dispatchEvent(new Event("input"));
 
   expect(things).toHaveClass("govuk-!-display-none");
   expect(apple).toHaveClass("govuk-!-display-none");


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/find-moj-data/issues/459

This allows searches to be cancelled by clicking the cross or pressing escape.

This should be used both for the plain styled search on the glossary page, and the combined input + icon variant on the search page.

This is loosely based on the GOV.UK component: https://components.publishing.service.gov.uk/component-guide/search However, I've used the close icon already present in the MOJ design system.

In the case of the glossary, clearing the search triggers a refresh of the results. In the case of the search page, it does nothing until you search again or apply filters. We will likely revisit this soon - it would be useful to enhance this page so that the results refresh automatically without a full submit of the form.

<img width="903" alt="Screenshot 2024-06-24 at 10 20 41" src="https://github.com/ministryofjustice/find-moj-data/assets/87579/269ec4e9-7faf-4b76-a884-bd75fe030bec">

![Screenshot 2024-06-24 at 10 17 29](https://github.com/ministryofjustice/find-moj-data/assets/87579/87fb1a70-bb5d-4536-a503-fd160c463994)
