### PR TITLE
DP-455 show selected filters only when filters have been applied

### DIFF
--- a/home/service/search.py
+++ b/home/service/search.py
@@ -117,14 +117,14 @@ class SearchService(GenericService):
 
         return Paginator(pages_list, items_per_page)
 
-    def _generate_label_clear_ref(self) -> dict[str, dict[str, str]] | None:
+    def _generate_remove_filter_hrefs(self) -> dict[str, dict[str, str]] | None:
         if self.form.is_bound:
             domain = self.form.cleaned_data.get("domain", "")
             entity_types = self.form.cleaned_data.get("entity_types", [])
             where_to_access = self.form.cleaned_data.get("where_to_access", [])
-            label_clear_href = {}
+            remove_filter_hrefs = {}
             if domain:
-                label_clear_href["domain"] = self._generate_domain_clear_href()
+                remove_filter_hrefs["domain"] = self._generate_domain_clear_href()
             if entity_types:
                 entity_types_clear_href = {}
                 for entity_type in entity_types:
@@ -133,7 +133,7 @@ class SearchService(GenericService):
                             filter_name="entity_types", filter_value=entity_type
                         )
                     )
-                label_clear_href["Entity Types"] = entity_types_clear_href
+                remove_filter_hrefs["Entity Types"] = entity_types_clear_href
 
             if where_to_access:
                 where_to_access_clear_href = {}
@@ -143,11 +143,11 @@ class SearchService(GenericService):
                             filter_name="where_to_access", filter_value=access
                         )
                     )
-                label_clear_href["Where To Access"] = where_to_access_clear_href
+                remove_filter_hrefs["Where To Access"] = where_to_access_clear_href
         else:
-            label_clear_href = None
+            remove_filter_hrefs = None
 
-        return label_clear_href
+        return remove_filter_hrefs
 
     def _generate_domain_clear_href(
         self,
@@ -185,7 +185,7 @@ class SearchService(GenericService):
             "results_per_page": items_per_page,
             "total_results_str": total_results,
             "total_results": self.results.total_results,
-            "label_clear_href": self._generate_label_clear_ref(),
+            "remove_filter_hrefs": self._generate_remove_filter_hrefs(),
             "readable_match_reasons": self._get_match_reason_display_names(),
         }
 

--- a/templates/partial/filter.html
+++ b/templates/partial/filter.html
@@ -10,7 +10,7 @@
       </div>
     </div>
     <div class="moj-filter__content">
-      {% if label_clear_href|get_keys|length > 0 %}
+      {% if remove_filter_hrefs|get_keys|length > 0 %}
         {% include "partial/selected_filters.html" %}
       {% endif %}
       <div class="moj-filter__options">

--- a/templates/partial/filter.html
+++ b/templates/partial/filter.html
@@ -10,7 +10,9 @@
       </div>
     </div>
     <div class="moj-filter__content">
-      {% include "partial/selected_filters.html" %}
+      {% if label_clear_href|get_keys|length > 0 %}
+        {% include "partial/selected_filters.html" %}
+      {% endif %}
       <div class="moj-filter__options">
         <a href="#search-results" class="govuk-skip-link extra-skip-link" data-module="govuk-skip-link">Skip to results</a>
         <button form="searchform" class="govuk-button" data-module="govuk-button" data-test-id="apply-filters">
@@ -24,10 +26,10 @@
               {{form.domain}}
             </div>
             {% if form.subdomain.choices %}
-            <div class="govuk-form-group js-required">
-              <label class="govuk-label" for="{{form.subdomain.id_for_label}}">Subdomain</label>
-              {{form.subdomain}}
-            </div>
+              <div class="govuk-form-group js-required">
+                <label class="govuk-label" for="{{form.subdomain.id_for_label}}">Subdomain</label>
+                {{form.subdomain}}
+              </div>
             {% endif %}
           </fieldset>
         </div>

--- a/templates/partial/selected_filters.html
+++ b/templates/partial/selected_filters.html
@@ -15,12 +15,12 @@
             </p>
         </div>
     </div>
-    {% for key in label_clear_href|get_keys %}
-        {% if label_clear_href|get_item:key|length > 0 %}
+    {% for key in remove_filter_hrefs|get_keys %}
+        {% if remove_filter_hrefs|get_item:key|length > 0 %}
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0">{{key|title}}</h3>
             <ul class="moj-filter-tags">
                 <input type="hidden" name="clear_label" value="">
-                {% for label, href in label_clear_href|get_items:key %}
+                {% for label, href in remove_filter_hrefs|get_items:key %}
                     <li><a class="moj-filter__tag govuk-link" href="{{ href }}">
                         <span data-test-id="selected-domain-label">{{label|format_label}}</span> <span class="govuk-visually-hidden">Remove this filter</span>
                     </a></li>

--- a/templates/partial/selected_filters.html
+++ b/templates/partial/selected_filters.html
@@ -7,29 +7,25 @@
         </div>
         <div class="moj-filter__heading-action">
             <p>
-                {% if label_clear_href|get_keys|length > 0 %}
-                    <a class="govuk-link govuk-link--no-visited-state"
-                       href="{% url 'home:search' %}{% query_string domain=None entity_types=None where_to_access=None %}"
-                       id="clear_filter">
-                        Clear filter
-                    </a>
-                {% endif %}
+                <a class="govuk-link govuk-link--no-visited-state"
+                   href="{% url 'home:search' %}{% query_string domain=None entity_types=None where_to_access=None %}"
+                   id="clear_filter">
+                    Clear filter
+                </a>
             </p>
         </div>
     </div>
-    {% if label_clear_href|get_keys|length > 0 %}
-        {% for key in label_clear_href|get_keys %}
-            {% if label_clear_href|get_item:key|length > 0 %}
-                <h3 class="govuk-heading-s govuk-!-margin-bottom-0">{{key|title}}</h3>
-                <ul class="moj-filter-tags">
-                    <input type="hidden" name="clear_label" value="">
-                    {% for label, href in label_clear_href|get_items:key %}
-                        <li><a class="moj-filter__tag govuk-link" href="{{ href }}">
-                            <span data-test-id="selected-domain-label">{{label|format_label}}</span> <span class="govuk-visually-hidden">Remove this filter</span>
-                        </a></li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-        {% endfor %}
-    {% endif %}
+    {% for key in label_clear_href|get_keys %}
+        {% if label_clear_href|get_item:key|length > 0 %}
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0">{{key|title}}</h3>
+            <ul class="moj-filter-tags">
+                <input type="hidden" name="clear_label" value="">
+                {% for label, href in label_clear_href|get_items:key %}
+                    <li><a class="moj-filter__tag govuk-link" href="{{ href }}">
+                        <span data-test-id="selected-domain-label">{{label|format_label}}</span> <span class="govuk-visually-hidden">Remove this filter</span>
+                    </a></li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% endfor %}
 </div>

--- a/tests/home/service/test_search.py
+++ b/tests/home/service/test_search.py
@@ -31,8 +31,8 @@ class TestSearchService:
     def test_get_context_h1_value(self, search_context):
         assert search_context["h1_value"] == "Search"
 
-    def test_get_context_label_clear_href(self, search_context, valid_domain):
-        assert search_context["label_clear_href"]["domain"] == {
+    def test_get_context_remove_filter_hrefs(self, search_context, valid_domain):
+        assert search_context["remove_filter_hrefs"]["domain"] == {
             valid_domain.label: (
                 "?query=test&"
                 "where_to_access=analytical_platform&"
@@ -43,7 +43,7 @@ class TestSearchService:
             )
         }
 
-        assert search_context["label_clear_href"]["Where To Access"] == {
+        assert search_context["remove_filter_hrefs"]["Where To Access"] == {
             "analytical_platform": (
                 "?query=test&"
                 f"domain={quote(valid_domain.urn)}&"
@@ -55,7 +55,7 @@ class TestSearchService:
             )
         }
 
-        assert search_context["label_clear_href"]["Entity Types"] == {
+        assert search_context["remove_filter_hrefs"]["Entity Types"] == {
             "Table": (
                 "?query=test&"
                 f"domain={quote(valid_domain.urn)}&"


### PR DESCRIPTION
- Only displays the selected filter elements when applied filters are present.
- Removes redundant `if` statements in `selected_filters.html` partial template
- Renamed `label_clear_href` to `remove_filter_hrefs` references throughout for clarity
- Updated tests