### PR TITLE
Search and browse from the home page

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+    "bracketSameLine": true
+}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,9 +118,9 @@
         "filename": "templates/base/base.html",
         "hashed_secret": "f6538b22f89b1e2b05570de751f2932c6bca9969",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 32
       }
     ]
   },
-  "generated_at": "2024-06-24T11:27:46Z"
+  "generated_at": "2024-06-25T08:49:19Z"
 }

--- a/home/views.py
+++ b/home/views.py
@@ -3,6 +3,7 @@ from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import render
 
 from home.forms.search import SearchForm
+from home.models.domain_model import DomainModel
 from home.service.details import (
     ChartDetailsService,
     DatabaseDetailsService,
@@ -11,11 +12,12 @@ from home.service.details import (
 from home.service.glossary import GlossaryService
 from home.service.metadata_specification import MetadataSpecificationService
 from home.service.search import SearchService
+from home.service.search_facet_fetcher import SearchFacetFetcher
 
 
 def home_view(request):
-    context = {}
-    context["h1_value"] = "Home"
+    facets = SearchFacetFetcher().fetch()
+    context = {"domains": DomainModel(facets), "h1_value": "Home"}
     return render(request, "home.html", context)
 
 

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -8,6 +8,7 @@ $govuk-global-styles: true;
 @import "node_modules/govuk-frontend/dist/govuk/all";
 @import "node_modules/@ministryofjustice/frontend/moj/all";
 @import "./components/search";
+@import "./components/masthead";
 @import "./glossary";
 @import "./details";
 
@@ -47,4 +48,9 @@ code {
   border-radius: 2px; /* Rounded corners */
   padding: 1px 3px; /* Padding around the text */
   color: govuk-colour("black");
+}
+
+.main-wrapper-with-masthead {
+  @extend .govuk-main-wrapper;
+  padding-top: govuk-spacing(3);
 }

--- a/scss/components/README.md
+++ b/scss/components/README.md
@@ -28,7 +28,11 @@ See `enhanced-glossary.js`.
 ```html
 <div class="fmj-search govuk-form-group">
   <label for="filter-input" class="govuk-label">Filter this page</label>
-  <input class="govuk-input" type="search" placeholder="Filter this page" />
+  <input
+    id="filter-input"
+    class="govuk-input"
+    type="search"
+    placeholder="Filter this page" />
 </div>
 ```
 
@@ -45,7 +49,7 @@ This variant submits the form when the button is pressed or the user presses ent
       >Search query</label
     >
     <input class="search-input govuk-input" type="search" />
-    <button type="submit">
+    <button id="search-input" type="submit">
       <svg
         aria-hidden="true"
         focusable="false"
@@ -57,11 +61,7 @@ This variant submits the form when the button is pressed or the user presses ent
           d="M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z"
           fill="currentColor"></path>
       </svg>
-      <label
-        for="search-button"
-        class="govuk-label govuk-visually-hidden-focusable"
-        >Search</label
-      >
+      <label class="govuk-label govuk-visually-hidden-focusable">Search</label>
     </button>
   </div>
 </form>
@@ -78,7 +78,7 @@ Use this variant on a blue background to change the button colour to black.
   >
   <div
     class="fmj-search fmj-search--compact fmj-search--on-govuk-blue govuk-form-group">
-    <input class="search-input govuk-input" type="search" />
+    <input id="search-input" class="search-input govuk-input" type="search" />
     <button type="submit">
       <svg
         aria-hidden="true"
@@ -91,11 +91,7 @@ Use this variant on a blue background to change the button colour to black.
           d="M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z"
           fill="currentColor"></path>
       </svg>
-      <label
-        for="search-button"
-        class="govuk-label govuk-visually-hidden-focusable"
-        >Search</label
-      >
+      <label class="govuk-label govuk-visually-hidden-focusable">Search</label>
     </button>
   </div>
 </form>

--- a/scss/components/README.md
+++ b/scss/components/README.md
@@ -15,6 +15,7 @@ It's intended for use as a service-wide search or as a way of filtering long man
 
 - Clearable via the "X" button or pressing escape
 - Focusable, with a focus outline
+- Highlight the button on hover
 
 ## Usage
 

--- a/scss/components/README.md
+++ b/scss/components/README.md
@@ -1,30 +1,25 @@
-# Search component
+# Custom components for Find MOJ Data
+
+## Search component
 
 This enhances a [GOV.UK text input](https://design-system.service.gov.uk/components/text-input/) to act as a search input.
 
 It's intended for use as a service-wide search or as a way of filtering long manuals or lists.
 
-## Similar components elsewhere
-
-- [GOV.UK publishing components search](https://components.publishing.service.gov.uk/component-guide/search)
-- [Explore education statistics search](https://github.com/dfe-analytical-services/explore-education-statistics/blob/8a9aa729636eade2808895ad71a56bcb984d3c53/src/explore-education-statistics-common/src/components/form/FormSearchBar.module.scss)
-- [MOJ search](https://design-patterns.service.justice.gov.uk/components/search/) and [icon](https://github.com/dfe-analytical-services/explore-education-statistics/blob/8a9aa729636eade2808895ad71a56bcb984d3c53/src/explore-education-statistics-common/src/components/SearchIcon.tsx#L4)
-- [MOJ filter](https://design-patterns.service.justice.gov.uk/components/filter/)
-
-## Expected behaviours
+### Expected behaviours
 
 - Clearable via the "X" button or pressing escape
 - Focusable, with a focus outline
-- Highlight the button on hover
+- Highlights the button on hover
 
-## Usage
+### Usage
 
 The search box should:
 
 - be used inside a form or other element with `role="search"`, to indicate it as a [search landmark](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/).
 - have a visually hidden label to identify the search functionality
 
-### With no search icon
+#### With no search icon
 
 This variant should be used only for search-as-you-type behaviour that does not require submitting a form.
 
@@ -37,7 +32,7 @@ See `enhanced-glossary.js`.
 </div>
 ```
 
-### With an integrated search button
+#### With an integrated search button
 
 This variant submits the form when the button is pressed or the user presses enter.
 
@@ -57,12 +52,10 @@ This variant submits the form when the button is pressed or the user presses ent
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 36 36"
         width="40"
-        height="40"
-      >
+        height="40">
         <path
           d="M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z"
-          fill="currentColor"
-        ></path>
+          fill="currentColor"></path>
       </svg>
       <label
         for="search-button"
@@ -73,3 +66,69 @@ This variant submits the form when the button is pressed or the user presses ent
   </div>
 </form>
 ```
+
+## Blue background variant
+
+Use this variant on a blue background to change the button colour to black.
+
+```html
+<form action="" method="get" role="search" class="govuk-!-margin-bottom-4">
+  <label for="search-input" class="govuk-label govuk-label--m"
+    >Search query</label
+  >
+  <div
+    class="fmj-search fmj-search--compact fmj-search--on-govuk-blue govuk-form-group">
+    <input class="search-input govuk-input" type="search" />
+    <button type="submit">
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 36 36"
+        width="40"
+        height="40">
+        <path
+          d="M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z"
+          fill="currentColor"></path>
+      </svg>
+      <label
+        for="search-button"
+        class="govuk-label govuk-visually-hidden-focusable"
+        >Search</label
+      >
+    </button>
+  </div>
+</form>
+```
+
+### Similar components elsewhere
+
+- [GOV.UK publishing components search](https://components.publishing.service.gov.uk/component-guide/search)
+- [Explore education statistics search](https://github.com/dfe-analytical-services/explore-education-statistics/blob/8a9aa729636eade2808895ad71a56bcb984d3c53/src/explore-education-statistics-common/src/components/form/FormSearchBar.module.scss)
+- [MOJ search](https://design-patterns.service.justice.gov.uk/components/search/) and [icon](https://github.com/dfe-analytical-services/explore-education-statistics/blob/8a9aa729636eade2808895ad71a56bcb984d3c53/src/explore-education-statistics-common/src/components/SearchIcon.tsx#L4)
+- [MOJ filter](https://design-patterns.service.justice.gov.uk/components/filter/)
+
+## Masthead component
+
+The masthead is an extended header with search included.
+
+### Usage
+
+```html
+<div class="fmj-masthead">
+  <div class="govuk-width-container app-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl fmj-masthead__title">Find MOJ Data</h1>
+        <h2 class="govuk-heading-m fmj-masthead__title">
+          Search metadata catalogue
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Similar components elsewhere
+
+- [GOV.UK Design system documentation](https://github.com/alphagov/govuk-design-system/blob/b3223714d8f2e9564b7e9d2ca703a3f902bf1ce8/src/stylesheets/components/_masthead.scss)

--- a/scss/components/_masthead.scss
+++ b/scss/components/_masthead.scss
@@ -1,8 +1,8 @@
 // Based on https://github.com/alphagov/govuk-design-system/blob/b3223714d8f2e9564b7e9d2ca703a3f902bf1ce8/src/stylesheets/components/_masthead.scss
 
 .fmj-masthead {
-  @include govuk-responsive-padding(6, "top");
-  @include govuk-responsive-padding(6, "bottom");
+  @include govuk-responsive-padding(8, "top");
+  @include govuk-responsive-padding(8, "bottom");
   border-bottom: 1px solid govuk-colour("blue");
   color: govuk-colour("white");
   background-color: govuk-colour("blue");

--- a/scss/components/_masthead.scss
+++ b/scss/components/_masthead.scss
@@ -1,9 +1,15 @@
+// Based on https://github.com/alphagov/govuk-design-system/blob/b3223714d8f2e9564b7e9d2ca703a3f902bf1ce8/src/stylesheets/components/_masthead.scss
+
 .fmj-masthead {
   @include govuk-responsive-padding(6, "top");
   @include govuk-responsive-padding(6, "bottom");
   border-bottom: 1px solid govuk-colour("blue");
   color: govuk-colour("white");
   background-color: govuk-colour("blue");
+
+  label {
+    color: govuk-colour("white");
+  }
 }
 
 .fmj-masthead__title {

--- a/scss/components/_masthead.scss
+++ b/scss/components/_masthead.scss
@@ -1,0 +1,17 @@
+.fmj-masthead {
+  @include govuk-responsive-padding(6, "top");
+  @include govuk-responsive-padding(6, "bottom");
+  border-bottom: 1px solid govuk-colour("blue");
+  color: govuk-colour("white");
+  background-color: govuk-colour("blue");
+}
+
+.fmj-masthead__title {
+  color: govuk-colour("white");
+  @include govuk-responsive-margin(6, "bottom");
+}
+
+.fmj-masthead__description {
+  @include govuk-font(24);
+  margin-bottom: 0;
+}

--- a/scss/components/_search.scss
+++ b/scss/components/_search.scss
@@ -48,10 +48,27 @@
     margin-bottom: 0;
     padding: 0;
     width: 40px;
-  }
 
-  button:focus {
-    box-shadow: inset 0 0 0 4px govuk-colour("black");
-    outline: 3px solid govuk-colour("yellow");
+    &:hover {
+      background-color: lighten(govuk-colour("blue"), 5%);
+    }
+
+    &:focus {
+      box-shadow: inset 0 0 0 4px govuk-colour("black");
+      outline: 3px solid govuk-colour("yellow");
+    }
+  }
+}
+
+// Variant for blue backgrounds
+.fmj-search--on-govuk-blue {
+  button {
+    background-color: govuk-colour("black");
+    border: 0;
+    color: govuk-colour("white");
+
+    &:hover {
+      background-color: lighten(govuk-colour("black"), 5%);
+    }
   }
 }

--- a/scss/components/_search.scss
+++ b/scss/components/_search.scss
@@ -62,13 +62,20 @@
 
 // Variant for blue backgrounds
 .fmj-search--on-govuk-blue {
+  .govuk-input[type="search"] {
+    border-width: 0;
+
+    &:focus {
+      border-width: 2px;
+    }
+  }
+
   button {
-    background-color: govuk-colour("black");
-    border: 0;
-    color: govuk-colour("white");
+    background-color: #d2e2f1;
+    color: govuk-colour("blue");
 
     &:hover {
-      background-color: lighten(govuk-colour("black"), 5%);
+      background-color: lighten(#d2e2f1, 5%);
     }
   }
 }

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -9,20 +9,21 @@
       document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     </script>
     {% block skiplinks %}
-    <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+      <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
     {% endblock %}
 
     {% include "base/navigation.html" %}
-    <div class="govuk-width-container app-width-container">
-      {% block breadcrumbs %}
-      {% endblock breadcrumbs %}
+    {% block main %}
+      <div class="govuk-width-container app-width-container">
+        {% block breadcrumbs %}
+        {% endblock breadcrumbs %}
 
-      <main class="govuk-main-wrapper" id="main-content" role="main">
-        {% block content %}
-        {% endblock content %}
-      </main>
-
-    </div>
+        <main class="govuk-main-wrapper" id="main-content" role="main">
+          {% block content %}
+          {% endblock content %}
+        </main>
+      </div>
+    {% endblock main %}
     {% include "base/footer.html" %}
     <script type="module" src="{% static 'assets/js/govuk-frontend.min.js' %}"></script>
     <script src="{% static 'assets/js/moj-frontend.min.js' %}"></script>
@@ -39,8 +40,8 @@
     {% block scripts %}
     {% endblock scripts %}
     {% if ENABLE_ANALYTICS %}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ ANALYTICS_ID }}"></script>
-    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '{{ ANALYTICS_ID }}');</script>
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ ANALYTICS_ID }}"></script>
+      <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '{{ ANALYTICS_ID }}');</script>
     {% endif %}
   </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -17,7 +17,7 @@
               <div
                 class="fmj-search fmj-search--compact fmj-search--on-govuk-blue govuk-form-group govuk-!-padding-bottom-0 govuk-!-margin-bottom-2"
               >
-                <input id="search-input" class="search-input govuk-input" type="search" />
+                <input id="search-input" name="query" class="search-input govuk-input" type="search" />
                 <button type="submit">
                   <svg
                     aria-hidden="true"

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,16 +1,18 @@
 {% extends "base/base.html" %}
 {% load static %}
 
-{% block content %}
+{% block main %}
+  <main class="main-wrapper-with-masthead" id="main-content" role="main">
+    <div class="fmj-masthead">
+      <div class="govuk-width-container app-width-container">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl fmj-masthead__title">Find MOJ Data</h1>
+            <h2 class="govuk-heading-m fmj-masthead__title">Search metadata catalogue</h2>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
 
-  <a onclick="history.back()" class="govuk-back-link">Back</a>
-  <h1 class="govuk-heading-l">{{h1_value}}</h1>
-
-  <p class="govuk-body">
-    <a href="{% url 'home:glossary' %}" class="govuk-link">Glossary</a>
-  </p>
-  <p class="govuk-body">
-    <a href="{% url 'home:metadata_specification' %}" class="govuk-link">Metadata specification</a>
-  </p>
-
-{% endblock content %}
+{% endblock main %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -7,17 +7,17 @@
       <div class="govuk-width-container app-width-container">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl fmj-masthead__title">Find MOJ Data</h1>
+            <h1 class="govuk-heading-xl fmj-masthead__title">Find MOJ data</h1>
 
-            <form action="{% url 'home:search' %}" method="get" role="search" class="govuk-!-margin-bottom-4">
+            <form action="{% url 'home:search' %}" method="get" role="search" class="govuk-!-margin-bottom-0">
               <label
                 for="search-input"
                 class="govuk-label govuk-label--m"
               >Search metadata catalogue</label>
               <div
-                class="fmj-search fmj-search--compact fmj-search--on-govuk-blue govuk-form-group"
+                class="fmj-search fmj-search--compact fmj-search--on-govuk-blue govuk-form-group govuk-!-padding-bottom-0 govuk-!-margin-bottom-2"
               >
-                <input class="search-input govuk-input" type="search" />
+                <input id="search-input" class="search-input govuk-input" type="search" />
                 <button type="submit">
                   <svg
                     aria-hidden="true"
@@ -33,7 +33,6 @@
                     ></path>
                   </svg>
                   <label
-                    for="search-button"
                     class="govuk-label govuk-visually-hidden-focusable"
                   >Search</label
                     >
@@ -42,6 +41,31 @@
               </form>
             </div>
           </div>
+        </div>
+      </div>
+      <div class="govuk-main-wrapper govuk-main-wrapper--l">
+        <div class="govuk-width-container app-width-container">
+          {% if domains.top_level_domains %}
+            <h2 id="browse-by-domain" class="govuk-heading-l">Browse by domain</h2>
+            <ul id="domain-list" class="govuk-list govuk-list--bullet">
+              {% for domain in domains.top_level_domains  %}
+                <li><a href="{% url 'home:search' %}?domain={{domain.urn}}">{{domain.label}}</a></li>
+              {% endfor %}
+            </ul>
+
+            <details class="govuk-details">
+              <summary class="govuk-details__summary  govuk-!-margin-top-4">
+                <span class="govuk-details__summary-text">
+                  What are domains?
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                <p>Data in the catalogue is organised into data 'domains'. These are a grouping of data by subject area.</p>
+                <p>When data is related to more than one domain, we have assigned it to the one that appears most relevant.</p>
+                <p>Domains may be influenced by the organisational structure but they are intended to be narrower in scope than an entire agency.</p>
+              </div>
+            </details>
+          {% endif %}
         </div>
       </div>
     </main>

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,11 +8,42 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl fmj-masthead__title">Find MOJ Data</h1>
-            <h2 class="govuk-heading-m fmj-masthead__title">Search metadata catalogue</h2>
+
+            <form action="{% url 'home:search' %}" method="get" role="search" class="govuk-!-margin-bottom-4">
+              <label
+                for="search-input"
+                class="govuk-label govuk-label--m"
+              >Search metadata catalogue</label>
+              <div
+                class="fmj-search fmj-search--compact fmj-search--on-govuk-blue govuk-form-group"
+              >
+                <input class="search-input govuk-input" type="search" />
+                <button type="submit">
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 36 36"
+                    width="40"
+                    height="40"
+                  >
+                    <path
+                      d="M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z"
+                      fill="currentColor"
+                    ></path>
+                  </svg>
+                  <label
+                    for="search-button"
+                    class="govuk-label govuk-visually-hidden-focusable"
+                  >Search</label
+                    >
+                  </button>
+                </div>
+              </form>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </main>
+    </main>
 
 {% endblock main %}

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -67,6 +67,9 @@ class Page:
     def __init__(self, selenium):
         self.selenium = selenium
 
+    def primary_heading(self):
+        return self.selenium.find_element(By.TAG_NAME, "h1")
+
 
 class DatabaseDetailsPage(Page):
     def primary_heading(self):
@@ -103,10 +106,22 @@ class HomePage(Page):
     def glossary_nav_link(self) -> WebElement:
         return self.selenium.find_element(By.LINK_TEXT, "Glossary")
 
+    def search_bar(self) -> WebElement:
+        return self.selenium.find_element(By.NAME, "query")
+
+    def domain_link(self, domain) -> WebElement:
+        all_domains = self.selenium.find_elements(
+            By.CSS_SELECTOR, "ul#domain-list li a"
+        )
+        all_domain_names = [d.text for d in all_domains]
+        result = next((d for d in all_domains if domain == d.text), None)
+        if not result:
+            raise Exception(f"{domain!r} not found in {all_domain_names!r}")
+        return result
+
 
 class GlossaryPage(Page):
-    def primary_heading(self):
-        return self.selenium.find_element(By.TAG_NAME, "h1")
+    pass
 
 
 class SearchResultWrapper:

--- a/tests/selenium/test_interact_with_search_results.py
+++ b/tests/selenium/test_interact_with_search_results.py
@@ -1,0 +1,126 @@
+import pytest
+from data_platform_catalogue.search_types import ResultType
+
+from tests.conftest import (
+    generate_page,
+    mock_search_response,
+    search_result_from_database,
+)
+
+
+@pytest.mark.slow
+class TestInteractWithSearchResults:
+    """
+    Given I have a performed a search
+    When I click on a search result
+    Then I should be able to reach the details page for a database, table, or chart
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        live_server,
+        selenium,
+        search_page,
+        details_database_page,
+        table_details_page,
+        chromedriver_path,
+        axe_version,
+        page_titles,
+    ):
+        self.selenium = selenium
+        self.live_server_url = live_server.url
+        self.search_page = search_page
+        self.details_database_page = details_database_page
+        self.table_details_page = table_details_page
+        self.chromedriver_path = chromedriver_path
+        self.page_titles = page_titles
+        self.axe_version = axe_version
+
+    def test_table_search_to_details(self, mock_catalogue):
+        """
+        Users can search for a table and access a detail page
+        """
+        mock_search_response(
+            mock_catalogue=mock_catalogue,
+            page_results=generate_page(result_type=ResultType.TABLE),
+            total_results=100,
+        )
+        self.start_on_the_search_page()
+        self.enter_a_query_and_submit("court timeliness")
+        self.click_on_the_first_result()
+        self.verify_i_am_on_the_table_details_page()
+
+    def test_database_search_to_table_details(self, mock_catalogue, example_database):
+        """
+        Users can search and drill down into details
+        """
+        mock_search_response(
+            mock_catalogue=mock_catalogue,
+            page_results=[search_result_from_database(example_database)],
+            total_results=100,
+        )
+        self.start_on_the_search_page()
+        self.enter_a_query_and_submit("court timeliness")
+        item_name = self.click_on_the_first_result()
+        self.verify_i_am_on_the_database_details_page(item_name)
+        self.verify_database_details()
+        self.verify_database_tables_listed()
+        self.click_on_table()
+        self.verify_i_am_on_the_table_details_page()
+
+    def start_on_the_search_page(self):
+        self.selenium.get(f"{self.live_server_url}/search?new=True")
+        assert self.selenium.title in self.page_titles
+
+    def click_on_the_search_button(self):
+        self.search_page.search_button().click()
+
+    def click_on_the_first_result(self):
+        first_result = self.search_page.first_search_result()
+        assert first_result.text
+
+        first_link = first_result.link()
+        item_name = first_link.text
+        first_link.click()
+        return item_name
+
+    def verify_i_am_on_the_database_details_page(self, item_name):
+        assert self.selenium.title in self.page_titles
+
+        heading_text = self.details_database_page.primary_heading().text
+        assert heading_text == self.selenium.title.split("-")[0].strip()
+
+        subheading_text = self.details_database_page.secondary_heading().text
+        assert subheading_text and item_name.endswith(subheading_text)
+
+    def enter_a_query_and_submit(self, query):
+        search_bar = self.search_page.search_bar()
+        search_bar.send_keys(query)
+        self.click_on_the_search_button()
+
+    def verify_sort_selected(self, expected):
+        value = self.search_page.checked_sort_option().get_attribute("value") or ""
+        assert value == expected.lower()
+
+    def verify_database_tables_listed(self):
+        tables = self.details_database_page.database_tables()
+        assert tables.text
+
+    def verify_database_details(self):
+        database_details = self.details_database_page.database_details()
+        assert database_details.text
+
+    def click_on_table(self):
+        self.details_database_page.table_link().click()
+
+    def verify_i_am_on_the_table_details_page(self):
+        assert self.selenium.title in self.page_titles
+
+        heading_text = self.details_database_page.primary_heading().text
+        assert heading_text == self.selenium.title.split("-")[0].strip()
+
+        assert self.table_details_page.caption() == "Table"
+        assert self.table_details_page.column_descriptions() == [
+            "description with markdown"
+        ]

--- a/tests/selenium/test_primary_nav.py
+++ b/tests/selenium/test_primary_nav.py
@@ -1,0 +1,50 @@
+import pytest
+
+
+@pytest.mark.slow
+class TestPrimaryNav:
+    """
+    Given I am on the home page
+    Then I should be able to navigate using the primary nav bar
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        live_server,
+        selenium,
+        home_page,
+        glossary_page,
+        chromedriver_path,
+        axe_version,
+        page_titles,
+    ):
+        self.selenium = selenium
+        self.live_server_url = live_server.url
+        self.home_page = home_page
+        self.glossary_page = glossary_page
+        self.chromedriver_path = chromedriver_path
+        self.page_titles = page_titles
+        self.axe_version = axe_version
+
+    def test_glossary_link_from_homepage_works(self):
+        self.start_on_the_home_page()
+        self.click_on_the_glossary_link()
+        self.verify_i_am_on_the_glossary_page()
+
+    def start_on_the_home_page(self):
+        self.selenium.get(f"{self.live_server_url}")
+        assert self.selenium.title in self.page_titles
+        heading_text = self.home_page.primary_heading().text
+
+        assert heading_text == "Find MOJ data"
+        assert self.selenium.title.split("-")[0].strip() == "Home"
+
+    def click_on_the_glossary_link(self):
+        self.home_page.glossary_nav_link().click()
+
+    def verify_i_am_on_the_glossary_page(self):
+        assert self.selenium.title in self.page_titles
+        heading_text = self.glossary_page.primary_heading().text
+
+        assert heading_text == self.selenium.title.split("-")[0].strip()

--- a/tests/selenium/test_search_and_browse_from_homepage.py
+++ b/tests/selenium/test_search_and_browse_from_homepage.py
@@ -1,0 +1,93 @@
+import re
+
+import pytest
+from selenium.webdriver.common.keys import Keys
+
+from .helpers import check_for_accessibility_issues
+
+
+@pytest.mark.slow
+class TestSearchAndBrowseFromHomepage:
+    """
+    Given I am on the home page
+    When I search or browse
+    Then I should be taken to the search page
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        live_server,
+        selenium,
+        home_page,
+        search_page,
+        chromedriver_path,
+        axe_version,
+        page_titles,
+    ):
+        self.selenium = selenium
+        self.live_server_url = live_server.url
+        self.home_page = home_page
+        self.search_page = search_page
+        self.chromedriver_path = chromedriver_path
+        self.page_titles = page_titles
+        self.axe_version = axe_version
+
+    def test_search_with_query(self):
+        """
+        Types a search query and press enter
+        """
+        self.start_on_the_home_page()
+        self.enter_a_query_and_submit("nomis")
+        self.verify_i_am_on_the_search_page()
+        self.verify_the_search_bar_has_value("nomis")
+        self.verify_i_have_results()
+
+    def test_browse_to_domain(self):
+        self.start_on_the_home_page()
+        self.click_on_domain("Prisons")
+        self.verify_i_am_on_the_search_page()
+        self.verify_domain_selected("Prisons")
+
+    def test_automated_accessibility_home(self):
+        self.start_on_the_home_page()
+        check_for_accessibility_issues(
+            self.selenium.current_url,
+            chromedriver_path=self.chromedriver_path,
+            axe_version=self.axe_version,
+        )
+
+    def start_on_the_home_page(self):
+        self.selenium.get(f"{self.live_server_url}")
+        assert self.selenium.title in self.page_titles
+        heading_text = self.home_page.primary_heading().text
+
+        assert heading_text == "Find MOJ data"
+        assert self.selenium.title.split("-")[0].strip() == "Home"
+
+    def verify_i_am_on_the_search_page(self):
+        assert self.selenium.title in self.page_titles
+        heading_text = self.search_page.primary_heading().text
+
+        assert heading_text == self.selenium.title.split("-")[0].strip()
+
+    def verify_i_have_results(self):
+        result_count = self.search_page.result_count().text
+        assert re.match(r"[1-9]\d* results", result_count)
+
+    def enter_a_query_and_submit(self, query):
+        search_bar = self.home_page.search_bar()
+        search_bar.send_keys(query)
+        search_bar.send_keys(Keys.ENTER)
+
+    def verify_the_search_bar_has_value(self, query):
+        search_bar = self.search_page.search_bar()
+
+        assert search_bar.get_attribute("value") == query
+
+    def click_on_domain(self, domain):
+        self.home_page.domain_link(domain).click()
+
+    def verify_domain_selected(self, domain):
+        selected_domain = self.search_page.get_selected_domain().text
+        assert selected_domain == domain


### PR DESCRIPTION
Ticket: https://github.com/ministryofjustice/find-moj-data/issues/437
Figma: https://www.figma.com/design/zTOVhHRnWfxRJqH6Gr8cIc/Catalogue-sketches?node-id=703-3098&t=QhJPSs4WUanjVrT8-0

I've taken the masthead component from the [design system documentation page](https://design-system.service.gov.uk/), but increased the padding a little to match the design. This uses the design system's responsive spacing, so it will take up less space on narrow screens.

There is intentionally a small margin left between the MOJ primary nav component and the masthead, because otherwise the blue underlines from the nav items bump up against the blue masthead. The design system documentation page sneakily gets around this by not including the home page in the nav, but we've decided we do want to include a "Home" link.

The variant of the search bar is based on the [GOV.UK homepage search bar](https://components.publishing.service.gov.uk/component-guide/search/homepage)

The copy within "What is domain" is a placeholder I made up for now, as the one we have in the glossary is out of date.

In addition to adding this new variant of the search box, I've updated all variants so that the button goes lighter when you hover over it (matching the component from GOV.UK publishing components).

<img width="1710" alt="Screenshot 2024-06-25 at 15 18 03" src="https://github.com/ministryofjustice/find-moj-data/assets/87579/7dd9aee9-6db7-4f77-b205-885d51649abd">

<img width="500" alt="Screenshot 2024-06-25 at 15 18 38" src="https://github.com/ministryofjustice/find-moj-data/assets/87579/20094106-d05c-45b5-9fe9-2b33bfcad350">

