### PR TITLE
Homepage fixes

### DIFF
--- a/scss/base.scss
+++ b/scss/base.scss
@@ -1,6 +1,6 @@
 $govuk-assets-path: "/static/assets/";
 $moj-assets-path: "/static/assets/";
-$fmj-images-path: "/static/assets/images";
+$app-images-path: "/static/assets/images";
 
 // Removes need to put classes on all elements
 $govuk-global-styles: true;

--- a/scss/components/README.md
+++ b/scss/components/README.md
@@ -26,7 +26,7 @@ This variant should be used only for search-as-you-type behaviour that does not 
 See `enhanced-glossary.js`.
 
 ```html
-<div class="fmj-search govuk-form-group">
+<div class="app-search govuk-form-group">
   <label for="filter-input" class="govuk-label">Filter this page</label>
   <input
     id="filter-input"
@@ -42,7 +42,7 @@ This variant submits the form when the button is pressed or the user presses ent
 
 ```html
 <form action="" method="get" role="search" class="govuk-!-margin-bottom-4">
-  <div class="fmj-search fmj-search--compact govuk-form-group">
+  <div class="app-search app-search--compact govuk-form-group">
     <label
       for="search-input"
       class="govuk-label govuk-visually-hidden-focusable"
@@ -77,7 +77,7 @@ Use this variant on a blue background to change the button colour to black.
     >Search query</label
   >
   <div
-    class="fmj-search fmj-search--compact fmj-search--on-govuk-blue govuk-form-group">
+    class="app-search app-search--compact app-search--on-govuk-blue govuk-form-group">
     <input id="search-input" class="search-input govuk-input" type="search" />
     <button type="submit">
       <svg
@@ -111,12 +111,12 @@ The masthead is an extended header with search included.
 ### Usage
 
 ```html
-<div class="fmj-masthead">
+<div class="app-masthead">
   <div class="govuk-width-container app-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl fmj-masthead__title">Find MOJ Data</h1>
-        <h2 class="govuk-heading-m fmj-masthead__title">
+        <h1 class="govuk-heading-xl app-masthead__title">Find MOJ Data</h1>
+        <h2 class="govuk-heading-m app-masthead__title">
           Search metadata catalogue
         </h2>
       </div>

--- a/scss/components/_masthead.scss
+++ b/scss/components/_masthead.scss
@@ -1,6 +1,6 @@
 // Based on https://github.com/alphagov/govuk-design-system/blob/b3223714d8f2e9564b7e9d2ca703a3f902bf1ce8/src/stylesheets/components/_masthead.scss
 
-.fmj-masthead {
+.app-masthead {
   @include govuk-responsive-padding(8, "top");
   @include govuk-responsive-padding(8, "bottom");
   border-bottom: 1px solid govuk-colour("blue");
@@ -12,12 +12,12 @@
   }
 }
 
-.fmj-masthead__title {
+.app-masthead__title {
   color: govuk-colour("white");
   @include govuk-responsive-margin(6, "bottom");
 }
 
-.fmj-masthead__description {
+.app-masthead__description {
   @include govuk-font(24);
   margin-bottom: 0;
 }

--- a/scss/components/_search.scss
+++ b/scss/components/_search.scss
@@ -1,5 +1,5 @@
 // Base enhancements to search fields
-.fmj-search {
+.app-search {
   .govuk-input[type="search"] {
     &:focus {
       z-index: 1;
@@ -10,7 +10,7 @@
     // https://caniuse.com/mdn-css_selectors_-webkit-search-cancel-button
     &::-webkit-search-cancel-button {
       -webkit-appearance: none;
-      background-image: url(#{$fmj-images-path}/icon-close-cross-black.svg);
+      background-image: url(#{$app-images-path}/icon-close-cross-black.svg);
       background-position: center;
       background-repeat: no-repeat;
       cursor: pointer;
@@ -23,7 +23,7 @@
 }
 
 // Variant with search button adjacent to the input
-.fmj-search--compact {
+.app-search--compact {
   display: flex;
 
   .govuk-input[type="search"] {
@@ -61,7 +61,7 @@
 }
 
 // Variant for blue backgrounds
-.fmj-search--on-govuk-blue {
+.app-search--on-govuk-blue {
   .govuk-input[type="search"] {
     border-width: 0;
 

--- a/templates/base/navigation.html
+++ b/templates/base/navigation.html
@@ -11,16 +11,18 @@
 
       </svg>
 
-      <a class="moj-header__link moj-header__link--service-name" href="#">Find MOJ data
-      {% if ENV == "dev" or ENV is None %}&nbsp;
-      <strong class="govuk-tag govuk-tag--yellow">Development</strong>
-      {% endif %}
-      {% if ENV == "test" %}&nbsp;
-      <strong class="govuk-tag govuk-tag--green">{{ ENV|title }}</strong>
-      {% endif %}
-      {% if ENV == "preprod" %}&nbsp;
-        <strong class="govuk-tag govuk-tag--blue">{{ ENV|title }}</strong>
-      {% endif %}</a>
+      <span class="moj-header__link moj-header__link--service-name">
+        <a href="{% url 'home:home' %}">Find MOJ data</a>
+        {% if ENV == "dev" or ENV is None %}&nbsp;
+        <strong class="govuk-tag govuk-tag--yellow">Development</strong>
+        {% endif %}
+        {% if ENV == "test" %}&nbsp;
+        <strong class="govuk-tag govuk-tag--green">{{ ENV|title }}</strong>
+        {% endif %}
+        {% if ENV == "preprod" %}&nbsp;
+          <strong class="govuk-tag govuk-tag--blue">{{ ENV|title }}</strong>
+        {% endif %}
+      </span>
     </div>
     <div class="moj-header__content">
 

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -8,7 +8,7 @@
             <h1 class="govuk-heading-l">{{h1_value}}</h1>
         </div>
         <div class="govuk-grid-column-three-quarters">
-            <div role="search" class="fmj-search govuk-form-group govuk-!-margin-bottom-8 js-required">
+            <div role="search" class="app-search govuk-form-group govuk-!-margin-bottom-8 js-required">
                 <label for="filter-input" class="govuk-label govuk-visually-hidden-focusable">Filter this page (the content will be updated as you type)</label>
                 <input class="govuk-input" id="filter-input" type="search" placeholder="Filter this page">
             </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,11 +3,11 @@
 
 {% block main %}
   <main class="main-wrapper-with-masthead" id="main-content" role="main">
-    <div class="fmj-masthead">
+    <div class="app-masthead">
       <div class="govuk-width-container app-width-container">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl fmj-masthead__title">Find MOJ data</h1>
+            <h1 class="govuk-heading-xl app-masthead__title">Find MOJ data</h1>
 
             <form action="{% url 'home:search' %}" method="get" role="search" class="govuk-!-margin-bottom-0">
               <label
@@ -15,7 +15,7 @@
                 class="govuk-label govuk-label--m"
               >Search metadata catalogue</label>
               <div
-                class="fmj-search fmj-search--compact fmj-search--on-govuk-blue govuk-form-group govuk-!-padding-bottom-0 govuk-!-margin-bottom-2"
+                class="app-search app-search--compact app-search--on-govuk-blue govuk-form-group govuk-!-padding-bottom-0 govuk-!-margin-bottom-2"
               >
                 <input id="search-input" name="query" class="search-input govuk-input" type="search" />
                 <button type="submit">

--- a/templates/search.html
+++ b/templates/search.html
@@ -9,7 +9,7 @@
       <form action="{% url 'home:search' %}" method="get" role="search" class="search__form govuk-!-margin-bottom-4" id="searchform">
         <div class="govuk-form-group">
           <h1 class="govuk-heading-l">{{h1_value}}</h1>
-          <div class="fmj-search fmj-search--compact">
+          <div class="app-search app-search--compact">
             <label for="{{ form.query.id_for_label }}" class="govuk-label govuk-visually-hidden-focusable">Search MOJ Data</label>
             {{ form.query }}
             <button class="search-button" type="submit" id="search-button">


### PR DESCRIPTION
- Replace `fmj-` prefix with `app-` (this follows an unofficial convention followed by many other services, and makes it easier to lift and shift components)
- Add missing links to logo

I also had a look at increasing the left/right padding of the masthead component (so that the padding is equal on all sides), but this doesn't work because the text inside needs to horizontally align with the text in the main body of the page, which uses govuk-width-container for the right/left margins.