### PR TITLE
Fmd 449 remove to level domain

### DIFF
--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -82,7 +82,13 @@ class SearchForm(forms.Form):
     domain = forms.ChoiceField(
         choices=get_domain_choices,
         required=False,
-        widget=forms.Select(attrs={"form": "searchform", "class": "govuk-select"}),
+        widget=forms.Select(
+            attrs={
+                "form": "searchform",
+                "class": "govuk-select",
+                "aria-label": "Domain",
+            }
+        ),
     )
     subdomain = forms.ChoiceField(
         choices=get_subdomain_choices,

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -54,3 +54,7 @@ code {
   @extend .govuk-main-wrapper;
   padding-top: govuk-spacing(3);
 }
+
+.moj-filter .govuk-select {
+  min-width: 5.5em;
+}

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -55,6 +55,8 @@ code {
   padding-top: govuk-spacing(3);
 }
 
+// we've reduced the minimum here as the default value was higher
+// than the minumum of the moj filter component
 .moj-filter .govuk-select {
   min-width: 5.5em;
 }

--- a/templates/partial/filter.html
+++ b/templates/partial/filter.html
@@ -22,7 +22,6 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Domain</legend>
             <div class="govuk-form-group">
-              <label class="govuk-label" for="{{form.domain.id_for_label}}">Top-level domain</label>
               {{form.domain}}
             </div>
             {% if form.subdomain.choices %}


### PR DESCRIPTION
removes top level domain from filter side panel and fixes select box overspill by decreasing min width in base css.

#449 