### PR TITLE
fmd-194 - Make search result same structure as result detail

### DIFF
--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -28,38 +28,32 @@
             {{ result.description|truncate_snippet:300|markdown:3 }}
           </div>
         {% endif %}
-        <dl class="govuk-summary-list govuk-summary-list--no-border">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Refresh period:</dt>
-            <dd class="govuk-summary-list__value">
-              TBC
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Domain:</dt>
-            <dd class="govuk-summary-list__value">
-              {{result.metadata.domain_name}}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Tags:</dt>
-            <dd class="govuk-summary-list__value">
-              {% if result.tags_to_display %}
-                {% for tag in result.tags_to_display %}
-                  <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
-                {% endfor %}
-              {% endif %}
-            </dd>
-          </div>
+        <ul class="govuk-list govuk-body" id="metadata-property-list">
+          <li>
+            <span class="govuk-!-font-weight-bold">Refresh period:</span>
+            <span>TBC</span>
+          </li>
+          <li>
+            <span class="govuk-!-font-weight-bold">Domain name:</span>
+            <span>{{result.metadata.domain_name}}</span>
+          </li>
+        <li>
+            <span class="govuk-!-font-weight-bold">Tags:</span>
+            <span>
+                {% if result.tags_to_display %}
+                    {% for tag in result.tags_to_display %}
+                        <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
+                {% endif %}
+            </span>
+        </li>
           {% if result.matches %}
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">Matched fields:</dt>
-              <dd class="govuk-summary-list__value">
-                {{ result.matches|lookup:readable_match_reasons|join:", " }}
-              </dd>
-            </div>
+            <li>
+              <span class="govuk-!-font-weight-bold">Matched fields:</span>
+              <span>{{ result.matches|lookup:readable_match_reasons|join:", " }}</span>
+            </li>
           {% endif %}
-        </dl>
+        </ul>
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
       </div>
     </div>


### PR DESCRIPTION
Changing Search page results to be consistent with Chart details page.

**previous**: 
<img width="704" alt="image" src="https://github.com/ministryofjustice/find-moj-data/assets/166705689/56a3a19b-a6f2-4179-883f-9f7a64b58b93">


**current**:
<img width="1036" alt="image" src="https://github.com/ministryofjustice/find-moj-data/assets/166705689/616ca496-579b-46ec-84ff-84a74ec12c2c">

