### PR TITLE
add actual owner from datahub to chart details template

### DIFF
--- a/templates/details_chart.html
+++ b/templates/details_chart.html
@@ -62,7 +62,7 @@
             </div>
         </div>
         <div class="govuk-grid-column-one-third">
-            {% include "partial/contact_info.html" with data_owner="chart owner" data_owner_email="chart owner email" slack_channel=chart.custom_properties.further_information %}
+            {% include "partial/contact_info.html" with data_owner=chart.governance.data_owner.display_name data_owner_email=chart.governance.data_owner.email slack_channel=chart.custom_properties.further_information %}
         </div>
     </div>
     <div class="govuk-grid-row">


### PR DESCRIPTION
simple one to populate the owner info from datahub for charts rather than hardcoded values in the template

resolves #438 