### PR TITLE
Fmd 471 display table name only

### DIFF
--- a/lib/datahub-client/data_platform_catalogue/client/graphql/search.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/search.graphql
@@ -128,6 +128,13 @@ query Search(
           platform {
             name
           }
+          container {
+            urn
+            properties {
+              name
+              qualifiedName
+            }
+          }
           subTypes {
             typeNames
           }

--- a/lib/datahub-client/data_platform_catalogue/client/search.py
+++ b/lib/datahub-client/data_platform_catalogue/client/search.py
@@ -17,6 +17,7 @@ from data_platform_catalogue.client.graphql_helpers import (
     parse_properties,
     parse_tags,
 )
+from data_platform_catalogue.entities import EntityRef
 from data_platform_catalogue.search_types import (
     FacetOption,
     MultiSelectFilter,
@@ -232,24 +233,15 @@ class SearchClient:
         last_modified = parse_last_modified(entity)
         name, display_name, qualified_name = parse_names(entity, properties)
         container = entity.get("container")
+        if container:
+            container_name, container_display_name, container_qualified_name = (
+                parse_names(container, container.get("properties"))
+            )
         domain = parse_domain(entity)
 
         metadata = {
             "owner": owner.display_name,
             "owner_email": owner.email,
-            "parent_container_display_name": (
-                container.get("properties").get("name")
-                if container is not None
-                else None
-            ),
-            "parent_container_fqn": (
-                container.get("properties").get("qualifiedName")
-                if container is not None
-                else None
-            ),
-            "parent_container_urn": (
-                container.get("urn") if container is not None else None
-            ),
             "total_parents": entity.get("relationships", {}).get("total", 0),
             "domain_name": domain.display_name,
             "domain_id": domain.urn,
@@ -270,6 +262,11 @@ class SearchClient:
             name=name,
             display_name=display_name,
             fully_qualified_name=qualified_name,
+            parent_entity=(
+                EntityRef(urn=container.get("urn"), display_name=container_display_name)
+                if container
+                else None
+            ),
             description=properties.get("description", ""),
             metadata=metadata,
             tags=tags,

--- a/lib/datahub-client/data_platform_catalogue/client/search.py
+++ b/lib/datahub-client/data_platform_catalogue/client/search.py
@@ -231,12 +231,25 @@ class SearchClient:
         terms = parse_glossary_terms(entity)
         last_modified = parse_last_modified(entity)
         name, display_name, qualified_name = parse_names(entity, properties)
-
+        container = entity.get("container")
         domain = parse_domain(entity)
 
         metadata = {
             "owner": owner.display_name,
             "owner_email": owner.email,
+            "parent_container_display_name": (
+                container.get("properties").get("name")
+                if container is not None
+                else None
+            ),
+            "parent_container_fqn": (
+                container.get("properties").get("qualifiedName")
+                if container is not None
+                else None
+            ),
+            "parent_cotainer_urn": (
+                container.get("urn") if container is not None else None
+            ),
             "total_parents": entity.get("relationships", {}).get("total", 0),
             "domain_name": domain.display_name,
             "domain_id": domain.urn,

--- a/lib/datahub-client/data_platform_catalogue/client/search.py
+++ b/lib/datahub-client/data_platform_catalogue/client/search.py
@@ -247,7 +247,7 @@ class SearchClient:
                 if container is not None
                 else None
             ),
-            "parent_cotainer_urn": (
+            "parent_container_urn": (
                 container.get("urn") if container is not None else None
             ),
             "total_parents": entity.get("relationships", {}).get("total", 0),

--- a/lib/datahub-client/data_platform_catalogue/search_types.py
+++ b/lib/datahub-client/data_platform_catalogue/search_types.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Any
 
-from data_platform_catalogue.entities import GlossaryTermRef, TagRef
+from data_platform_catalogue.entities import EntityRef, GlossaryTermRef, TagRef
 
 
 class ResultType(Enum):
@@ -68,6 +68,7 @@ class SearchResult:
     glossary_terms: list[GlossaryTermRef] = field(default_factory=list)
     last_modified: datetime | None = None
     created: datetime | None = None
+    parent_entity: EntityRef | None = None
     tags_to_display: list[str] = field(init=False)
 
     def __post_init__(self):

--- a/lib/datahub-client/tests/client/datahub/test_search.py
+++ b/lib/datahub-client/tests/client/datahub/test_search.py
@@ -7,6 +7,7 @@ from data_platform_catalogue.client.search import SearchClient
 from data_platform_catalogue.entities import (
     AccessInformation,
     DataSummary,
+    EntityRef,
     FurtherInformation,
     TagRef,
     UsageRestrictions,
@@ -130,9 +131,6 @@ def test_one_search_result(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
-                    "parent_container_display_name": "abc",
-                    "parent_container_fqn": None,
-                    "parent_container_urn": "urn:li:container:abc",
                     "total_parents": 0,
                     "domain_name": "HMPPS",
                     "domain_id": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
@@ -150,6 +148,7 @@ def test_one_search_result(mock_graph, searcher):
                 tags=[],
                 last_modified=None,
                 created=None,
+                parent_entity=EntityRef(urn="urn:li:container:abc", display_name="abc"),
             )
         ],
         facets=SearchFacets(facets={}),
@@ -220,9 +219,6 @@ def test_dataset_result(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
-                    "parent_container_display_name": None,
-                    "parent_container_fqn": None,
-                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "HMPPS",
                     "domain_id": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
@@ -314,9 +310,6 @@ def test_full_page(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
-                    "parent_container_display_name": None,
-                    "parent_container_fqn": None,
-                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -348,9 +341,6 @@ def test_full_page(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
-                    "parent_container_display_name": None,
-                    "parent_container_fqn": None,
-                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -380,9 +370,6 @@ def test_full_page(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
-                    "parent_container_display_name": None,
-                    "parent_container_fqn": None,
-                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -462,9 +449,6 @@ def test_query_match(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
-                    "parent_container_display_name": None,
-                    "parent_container_fqn": None,
-                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -540,9 +524,6 @@ def test_result_with_owner(mock_graph, searcher):
                 metadata={
                     "owner": "Shannon Lovett",
                     "owner_email": "shannon@longtail.com",
-                    "parent_container_display_name": None,
-                    "parent_container_fqn": None,
-                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -913,9 +894,6 @@ def test_search_for_charts(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
-                    "parent_container_display_name": None,
-                    "parent_container_fqn": None,
-                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -1088,9 +1066,6 @@ def test_tag_to_display(tags, result):
         metadata={
             "owner": "",
             "owner_email": "",
-            "parent_container_display_name": None,
-            "parent_container_fqn": None,
-            "parent_container_urn": None,
             "total_parents": 0,
             "parents": [],
             "domain_name": "",

--- a/lib/datahub-client/tests/client/datahub/test_search.py
+++ b/lib/datahub-client/tests/client/datahub/test_search.py
@@ -79,6 +79,13 @@ def test_one_search_result(mock_graph, searcher):
                         "type": "DATASET",
                         "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",  # noqa E501
                         "platform": {"name": "bigquery"},
+                        "container": {
+                            "urn": "urn:li:container:abc",
+                            "properties": {
+                                "name": "abc",
+                                "qualifiedName": None,
+                            },
+                        },
                         "ownership": None,
                         "name": "calm-pagoda-323403.jaffle_shop.customers",
                         "properties": {
@@ -123,6 +130,9 @@ def test_one_search_result(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
+                    "parent_container_display_name": "abc",
+                    "parent_container_fqn": None,
+                    "parent_container_urn": "urn:li:container:abc",
                     "total_parents": 0,
                     "domain_name": "HMPPS",
                     "domain_id": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
@@ -161,6 +171,7 @@ def test_dataset_result(mock_graph, searcher):
                         "type": "DATASET",
                         "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",  # noqa E501
                         "platform": {"name": "bigquery"},
+                        "container": None,
                         "ownership": None,
                         "name": "calm-pagoda-323403.jaffle_shop.customers",
                         "properties": {
@@ -209,6 +220,9 @@ def test_dataset_result(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
+                    "parent_container_display_name": None,
+                    "parent_container_fqn": None,
+                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "HMPPS",
                     "domain_id": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
@@ -300,6 +314,9 @@ def test_full_page(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
+                    "parent_container_display_name": None,
+                    "parent_container_fqn": None,
+                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -331,6 +348,9 @@ def test_full_page(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
+                    "parent_container_display_name": None,
+                    "parent_container_fqn": None,
+                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -360,6 +380,9 @@ def test_full_page(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
+                    "parent_container_display_name": None,
+                    "parent_container_fqn": None,
+                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -439,6 +462,9 @@ def test_query_match(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
+                    "parent_container_display_name": None,
+                    "parent_container_fqn": None,
+                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -514,6 +540,9 @@ def test_result_with_owner(mock_graph, searcher):
                 metadata={
                     "owner": "Shannon Lovett",
                     "owner_email": "shannon@longtail.com",
+                    "parent_container_display_name": None,
+                    "parent_container_fqn": None,
+                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -884,6 +913,9 @@ def test_search_for_charts(mock_graph, searcher):
                 metadata={
                     "owner": "",
                     "owner_email": "",
+                    "parent_container_display_name": None,
+                    "parent_container_fqn": None,
+                    "parent_container_urn": None,
                     "total_parents": 0,
                     "domain_name": "",
                     "domain_id": "",
@@ -1056,6 +1088,9 @@ def test_tag_to_display(tags, result):
         metadata={
             "owner": "",
             "owner_email": "",
+            "parent_container_display_name": None,
+            "parent_container_fqn": None,
+            "parent_container_urn": None,
             "total_parents": 0,
             "parents": [],
             "domain_name": "",

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -7,7 +7,11 @@
       <div class="govuk-grid-column-full">
         <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
           {% with result_type=result.result_type.name|lower %}
-            <a href="{% url 'home:details' result_type=result_type urn=result.urn %}" class="govuk-link">{{result.fully_qualified_name}}</a>
+            {% if result.display_name %}
+              <a href="{% url 'home:details' result_type=result_type urn=result.urn %}" class="govuk-link">{{result.display_name}}</a>
+            {% else %}
+              <a href="{% url 'home:details' result_type=result_type urn=result.urn %}" class="govuk-link">{{result.fully_qualified_name}}</a>
+            {% endif %}
           {% endwith %}
           {% if result.result_type.name == "TABLE" %}
             <strong class="govuk-tag govuk-!-margin-left-2">
@@ -34,19 +38,29 @@
             <span>TBC</span>
           </li>
           <li>
-            <span class="govuk-!-font-weight-bold">Domain name:</span>
+            <span class="govuk-!-font-weight-bold">Domain:</span>
             <span>{{result.metadata.domain_name}}</span>
           </li>
-        <li>
+          {% if result.result_type.name == "TABLE" %}
+            <li>
+              <span class="govuk-!-font-weight-bold">Database:</span>
+              {% if result.metadata.parent_container_display_name %}
+                <span>{{result.metadata.parent_container_display_name}}</span>
+              {% else %}
+                <span>{{result.metadata.parent_container_fqn}}</span>
+              {% endif %}
+            </li>
+          {% endif %}
+          <li>
             <span class="govuk-!-font-weight-bold">Tags:</span>
             <span>
-                {% if result.tags_to_display %}
-                    {% for tag in result.tags_to_display %}
-                        <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
-                    {% endfor %}
-                {% endif %}
+              {% if result.tags_to_display %}
+                {% for tag in result.tags_to_display %}
+                  <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+              {% endif %}
             </span>
-        </li>
+          </li>
           {% if result.matches %}
             <li>
               <span class="govuk-!-font-weight-bold">Matched fields:</span>

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -7,11 +7,7 @@
       <div class="govuk-grid-column-full">
         <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
           {% with result_type=result.result_type.name|lower %}
-            {% if result.display_name %}
-              <a href="{% url 'home:details' result_type=result_type urn=result.urn %}" class="govuk-link">{{result.display_name}}</a>
-            {% else %}
-              <a href="{% url 'home:details' result_type=result_type urn=result.urn %}" class="govuk-link">{{result.fully_qualified_name}}</a>
-            {% endif %}
+            <a href="{% url 'home:details' result_type=result_type urn=result.urn %}" class="govuk-link">{{result.name}}</a>
           {% endwith %}
           {% if result.result_type.name == "TABLE" %}
             <strong class="govuk-tag govuk-!-margin-left-2">
@@ -44,11 +40,7 @@
           {% if result.result_type.name == "TABLE" %}
             <li>
               <span class="govuk-!-font-weight-bold">Database:</span>
-              {% if result.metadata.parent_container_display_name %}
-                <span>{{result.metadata.parent_container_display_name}}</span>
-              {% else %}
-                <span>{{result.metadata.parent_container_fqn}}</span>
-              {% endif %}
+              <span>{{result.parent_entity.display_name}}</span>
             </li>
           {% endif %}
           <li>


### PR DESCRIPTION
PR addresses the long fully qualified names that were being displayed in search results for tables.
It now displays a display name for each table (which is just the table name) and the database the table is part of in the metadata below (if it has a database)

resolves https://github.com/ministryofjustice/find-moj-data/issues/471