### PR TITLE
remove nltk data download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ COPY pyproject.toml poetry.lock ./
 COPY lib ./lib
 
 RUN poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR
-RUN poetry run python -m nltk.downloader punkt
 
 # The runtime image, used to just run the code provided its virtual environment
 FROM python:3.11-slim-buster as runtime


### PR DESCRIPTION
in response to https://github.com/nltk/nltk/issues/3266 - no longer download the data on image build.

Seems what we use from the nltk package (PorterStemmer) doesn't actually require the data anyway 