### PR TITLE
move axe to devDependencies and not install dev deps in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22-bullseye as node_builder
 WORKDIR /app
 COPY . .
 
-RUN npm install --production
+RUN npm install --omit=dev
 
 # The builder image, used to build the virtual environment
 FROM python:3.11-buster as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22-bullseye as node_builder
 WORKDIR /app
 COPY . .
 
-RUN npm install
+RUN npm install --production
 
 # The builder image, used to build the virtual environment
 FROM python:3.11-buster as builder

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "@babel/preset-env": "^7.24.7",
     "@ministryofjustice/frontend": "^2.1.3",
-    "axe": "^12.2.7",
     "babel-jest": "^29.7.0",
     "govuk-frontend": "^5.4.0",
     "jest-environment-jsdom": "^29.7.0",
@@ -14,6 +13,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.6",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "axe": "^12.2.7"
   }
 }


### PR DESCRIPTION
relates to https://nvd.nist.gov/vuln/detail/CVE-2024-29415 - a dependency of axe, since we only use axe for selenium tests it doesn't need to be installed in our image so this PR moves it to devDependencies in package.json and add the `npm install --production` to the dockerfile which does the install without dev dependencies.