### PR TITLE
add _make_user_email_from_urn() to graphql helpers

### DIFF
--- a/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
@@ -309,6 +309,6 @@ def _make_user_email_from_urn(urn) -> str:
     but for now this will fix the issue of owners being flagged in datahub but not
     showing in find-moj-data
     """
-    email_parts = urn.replace("urn:li:corpuser:", "").split(".")
-    email = f"{email_parts[0]}.{email_parts[1]}@justice.gov.uk"
+  username = urn.replace("urn:li:corpuser:", "")
+  email = f"{username}@justice.gov.uk"
     return email

--- a/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
@@ -37,7 +37,10 @@ def parse_owner(entity: dict[str, Any]) -> OwnerRef:
         )
         owner_details = OwnerRef(
             display_name=display_name or "",
-            email=properties.get("email", ""),
+            email=properties.get(
+                "email",
+                _make_user_email_from_urn(owners[0].get("urn")),
+            ),
             urn=owners[0].get("urn", ""),
         )
     else:
@@ -293,3 +296,19 @@ def parse_relations(
 
     relations_return = {relationship_type: related_entities}
     return relations_return
+
+
+def _make_user_email_from_urn(urn) -> str:
+    """
+    Creates a user email using a user entity urn. This should only be called
+    when an urn exists for a user that has not signed into datahub via sso,
+    so has not been created as an entity and has no associated email address.
+
+    We will look to revist our approach to ownership user creation, see
+    github issue https://github.com/ministryofjustice/find-moj-data/issues/578,
+    but for now this will fix the issue of owners being flagged in datahub but not
+    showing in find-moj-data
+    """
+    email_parts = urn.replace("urn:li:corpuser:", "").split(".")
+    email = f"{email_parts[0]}.{email_parts[1]}@justice.gov.uk"
+    return email

--- a/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
@@ -309,6 +309,6 @@ def _make_user_email_from_urn(urn) -> str:
     but for now this will fix the issue of owners being flagged in datahub but not
     showing in find-moj-data
     """
-  username = urn.replace("urn:li:corpuser:", "")
-  email = f"{username}@justice.gov.uk"
+    username = urn.replace("urn:li:corpuser:", "")
+    email = f"{username}@justice.gov.uk"
     return email

--- a/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
+++ b/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timezone
 
 import pytest
+
 from data_platform_catalogue.client.graphql_helpers import (
+    _make_user_email_from_urn,
     parse_columns,
     parse_created_and_modified,
     parse_glossary_terms,
@@ -375,3 +377,25 @@ def test_parse_glossary_terms():
     )
 
     assert result == [term]
+
+
+@pytest.mark.parametrize(
+    "urn, expected_email",
+    [
+        (
+            "urn:li:corpuser:jon.smith",
+            "jon.smith@justice.gov.uk",
+        ),
+        (
+            "urn:li:corpuser:jon.smith54",
+            "jon.smith54@justice.gov.uk",
+        ),
+        (
+            "urn:li:corpuser:jon.smith.sullivan",
+            "jon.smith.sullivan@justice.gov.uk",
+        ),
+    ],
+)
+def test_make_user_email_from_urn(urn, expected_email):
+    email = _make_user_email_from_urn(urn)
+    assert email == expected_email


### PR DESCRIPTION
This PR is a fix for the owner not displaying bug. It has highlighted some deeper issues with our appraoch to ownership and usercreation.

But for a quick fix this will be ok for now so we have owners displaying in find-moj-data.

I have written up in some more dteail the issue in a new spike ticket added to our backlog, see #578 

resolves #556 