### PR TITLE
fmd-551: hide all tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,7 +158,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 .DS_Store
 
 #static files dirs

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please refer to Prerequisites for dependencies and installation instructions
 1. Run `poetry run python manage.py collectstatic --noinput` to collect static files
 1. Run `poetry run python manage.py migrate` this will create a local sqlite3 database and migrate any tables
 1. Run `poetry run python manage.py waffle_switch search-sort-radio-buttons off --create` to setup the waffle switch tables
+1. Run `poetry run python manage.py waffle_switch display-result-tags off --create` to setup the waffle switch for tags
 1. Run `poetry run python manage.py runserver`
 
 ```sh
@@ -199,3 +200,4 @@ Our switches are created via the cli; the commands can be seen in the Dockerfile
 Current swicthes and default settings:
 
 - `search-sort-radio-buttons` off - switches on/off radio selection buttons for sort order of search results.
+- `display-result-tags` off - switches on/off the display of tags in search and results pages

--- a/scripts/app-entrypoint.sh
+++ b/scripts/app-entrypoint.sh
@@ -12,5 +12,7 @@ fi
 
 python manage.py migrate
 python manage.py waffle_switch search-sort-radio-buttons off --create # create switch with default setting
+python manage.py waffle_switch display-result-tags off --create # create display tags switch with default off
+
 
 gunicorn --bind 0.0.0.0:8000 core.wsgi:application --workers 2 --threads 4

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -3,6 +3,8 @@
 {% load markdown %}
 {% load humanize %}
 {% load future %}
+{% load waffle_tags %}
+
 
 {% block breadcrumbs %}
   <div class="govuk-breadcrumbs">

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -67,14 +67,16 @@
                 {{entity.domain.display_name}}
               </li>
             {% endif %}
-            {% if entity.tags_to_display %}
-              <li>
-                <span class="govuk-!-font-weight-bold">Tags:</span>
-                {% for tag in entity.tags_to_display %}
-                  <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
-                {% endfor %}
-              </li>
-            {% endif %}
+            {% switch 'display-result-tags' %}
+              {% if entity.tags_to_display %}
+                <li>
+                  <span class="govuk-!-font-weight-bold">Tags:</span>
+                  {% for tag in entity.tags_to_display %}
+                    <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag%}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                  {% endfor %}
+                </li>
+              {% endif %}
+            {% endswitch %}
           </ul>
           {% include "partial/esda_info.html" with is_esda=is_esda %}
         {% endblock metadata_list %}

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -45,16 +45,19 @@
               <span>{{result.parent_entity.display_name}}</span>
             </li>
           {% endif %}
-          <li>
-            <span class="govuk-!-font-weight-bold">Tags:</span>
-            <span>
-              {% if result.tags_to_display %}
-                {% for tag in result.tags_to_display %}
-                  <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
-                {% endfor %}
-              {% endif %}
-            </span>
-          </li>
+          {% switch 'display-result-tags' %}
+            <li>
+              <span class="govuk-!-font-weight-bold">Tags:</span>
+              <span>
+                {% if result.tags_to_display %}
+                  {% for tag in result.tags_to_display %}
+                    <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% query_string clear_label=None clear_filter=None new=None tags=tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                  {% endfor %}
+                {% endif %}
+              </span>
+            </li>
+          {% endswitch %}
+        
           {% if result.matches %}
             <li>
               <span class="govuk-!-font-weight-bold">Matched fields:</span>

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -1,6 +1,8 @@
 {% load markdown %}
 {% load humanize %}
 {% load future %}
+{% load waffle_tags %}
+
 <div id="search-results">
   {% for result in highlighted_results %}
     <div class="govuk-grid-row">


### PR DESCRIPTION
Creates switch that manages display or hiding of result tags.

Creates a waffle switch `display-result-tags` with default set to off.

behaviour with switch set to off:

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/f937a6e3-208b-4f48-9cf1-9b9c92801f01">
