### PR TITLE
Browse by Domain Improvements

### DIFF
--- a/home/models/domain_model.py
+++ b/home/models/domain_model.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 class Domain(NamedTuple):
     urn: str
     label: str
+    assets: int
 
 
 class DomainModel:
@@ -20,7 +21,7 @@ class DomainModel:
         self.labels = {}
 
         self.top_level_domains = [
-            Domain(option.value, option.label)
+            Domain(option.value, option.label, option.count)
             for option in search_facets.options("domains")
         ]
         self.top_level_domains.sort(key=lambda d: d.label)
@@ -29,7 +30,7 @@ class DomainModel:
 
         self.subdomains = {}
 
-        for urn, label in self.top_level_domains:
+        for urn, label, assets in self.top_level_domains:
             self.labels[urn] = label
 
     def all_subdomains(self) -> list[Domain]:  # -> list[Any]

--- a/home/models/domain_model.py
+++ b/home/models/domain_model.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 class Domain(NamedTuple):
     urn: str
     label: str
-    assets: int
 
 
 class DomainModel:
@@ -21,7 +20,7 @@ class DomainModel:
         self.labels = {}
 
         self.top_level_domains = [
-            Domain(option.value, option.label, option.count)
+            Domain(option.value, option.label)
             for option in search_facets.options("domains")
         ]
         self.top_level_domains.sort(key=lambda d: d.label)
@@ -30,7 +29,7 @@ class DomainModel:
 
         self.subdomains = {}
 
-        for urn, label, assets in self.top_level_domains:
+        for urn, label in self.top_level_domains:
             self.labels[urn] = label
 
     def all_subdomains(self) -> list[Domain]:  # -> list[Any]

--- a/home/service/list_domain_fetcher.py
+++ b/home/service/list_domain_fetcher.py
@@ -25,6 +25,7 @@ class ListDomainFetcher(GenericService):
         result = cache.get(self.cache_key)
         if not result:
             result = self.client.list_domains()
+            result = sorted(result, key=lambda d: d.urn)
             cache.set(self.cache_key, result, timeout=self.cache_timeout_seconds)
 
         if self.filter_zero_entities:

--- a/home/service/list_domain_fetcher.py
+++ b/home/service/list_domain_fetcher.py
@@ -1,0 +1,32 @@
+from data_platform_catalogue.search_types import ListDomainOption
+from django.core.cache import cache
+
+from .base import GenericService
+
+
+class ListDomainFetcher(GenericService):
+    """
+    ListDomainFetcher implementation to fetch domains with the total number of
+    associated entities from the backend.
+    """
+
+    def __init__(self, filter_zero_entities: bool = True):
+        self.client = self._get_catalogue_client()
+        self.cache_key = "list_domains"
+        self.cache_timeout_seconds = 300
+        self.filter_zero_entities = filter_zero_entities
+
+    def fetch(self) -> list[ListDomainOption]:
+        """
+        Fetch a static list of options that is independent of the search query
+        and any applied filters. Values are cached for 5 seconds to avoid
+        unnecessary queries.
+        """
+        result = cache.get(self.cache_key)
+        if not result:
+            result = self.client.list_domains()
+            cache.set(self.cache_key, result, timeout=self.cache_timeout_seconds)
+
+        if self.filter_zero_entities:
+            result = [domain for domain in result if domain.total > 0]
+        return result

--- a/home/views.py
+++ b/home/views.py
@@ -1,23 +1,26 @@
 from data_platform_catalogue.client.exceptions import EntityDoesNotExist
+from data_platform_catalogue.search_types import ListDomainOption
 from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import render
 
 from home.forms.search import SearchForm
-from home.models.domain_model import DomainModel
 from home.service.details import (
     ChartDetailsService,
     DatabaseDetailsService,
     DatasetDetailsService,
 )
 from home.service.glossary import GlossaryService
+from home.service.list_domain_fetcher import ListDomainFetcher
 from home.service.metadata_specification import MetadataSpecificationService
 from home.service.search import SearchService
-from home.service.search_facet_fetcher import SearchFacetFetcher
 
 
 def home_view(request):
-    facets = SearchFacetFetcher().fetch()
-    context = {"domains": DomainModel(facets), "h1_value": "Home"}
+    """
+    Displys only domains that have entities tagged for display in the catalog.
+    """
+    domains: list[ListDomainOption] = ListDomainFetcher().fetch()
+    context = {"domains": domains, "h1_value": "Home"}
     return render(request, "home.html", context)
 
 

--- a/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
+++ b/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
@@ -57,6 +57,7 @@ from data_platform_catalogue.entities import (
     Table,
 )
 from data_platform_catalogue.search_types import (
+    ListDomainOption,
     MultiSelectFilter,
     ResultType,
     SearchFacets,
@@ -220,6 +221,21 @@ class DataHubCatalogueClient:
         """
         return self.search_client.search_facets(
             query=query, result_types=result_types, filters=filters
+        )
+
+    def list_domains(
+        self,
+        query: str = "*",
+        filters: Sequence[MultiSelectFilter] = [
+            MultiSelectFilter("tags", ["urn:li:tag:dc_display_in_catalogue"])
+        ],
+        count: int = 1000,
+    ) -> list[ListDomainOption]:
+        """
+        Returns a list of ListDomainOption objects
+        """
+        return self.search_client.list_domains(
+            query=query, filters=filters, count=count
         )
 
     def get_glossary_terms(self, count: int = 1000) -> SearchResponse:

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/listDomains.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/listDomains.graphql
@@ -1,0 +1,21 @@
+query getDomains(
+    $count: Int!
+  	$filters:[FacetFilterInput!]
+    $query: String!
+) {
+listDomains(
+    input: {start: 0, count: $count}
+) {
+  domains{
+    urn
+    properties{
+      name
+    }
+    entities(
+      input:{query:$query,start:0,count: 0, filters:$filters}
+    ){
+      total
+    }
+  }
+}
+}

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/listDomains.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/listDomains.graphql
@@ -1,6 +1,6 @@
 query getDomains(
     $count: Int!
-  	$filters:[FacetFilterInput!]
+    $filters:[FacetFilterInput!]
     $query: String!
 ) {
 listDomains(

--- a/lib/datahub-client/data_platform_catalogue/search_types.py
+++ b/lib/datahub-client/data_platform_catalogue/search_types.py
@@ -55,6 +55,18 @@ class FacetOption:
 
 
 @dataclass
+class ListDomainOption:
+    """
+    A representation of a domain and the number of associated entities
+    represented by total.
+    """
+
+    urn: str
+    name: str
+    total: int
+
+
+@dataclass
 class SearchResult:
     urn: str
     result_type: ResultType

--- a/lib/datahub-client/tests/test_integration_with_datahub_server.py
+++ b/lib/datahub-client/tests/test_integration_with_datahub_server.py
@@ -31,7 +31,11 @@ from data_platform_catalogue.entities import (
     TagRef,
     UsageRestrictions,
 )
-from data_platform_catalogue.search_types import MultiSelectFilter, ResultType
+from data_platform_catalogue.search_types import (
+    ListDomainOption,
+    MultiSelectFilter,
+    ResultType,
+)
 
 jwt_token = os.environ.get("CATALOGUE_TOKEN")
 api_url = os.environ.get("CATALOGUE_URL", "")
@@ -43,6 +47,9 @@ def test_list_domains():
     client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
     response = client.list_domains()
     assert len(response) > 0
+    domain = response[0]
+    assert isinstance(domain, ListDomainOption)
+    assert "urn:li:domain" in domain.urn
 
 
 @runs_on_development_server

--- a/lib/datahub-client/tests/test_integration_with_datahub_server.py
+++ b/lib/datahub-client/tests/test_integration_with_datahub_server.py
@@ -12,6 +12,7 @@ import time
 from datetime import datetime, timezone
 
 import pytest
+
 from data_platform_catalogue.client.datahub_client import DataHubCatalogueClient
 from data_platform_catalogue.entities import (
     AccessInformation,
@@ -35,6 +36,13 @@ from data_platform_catalogue.search_types import MultiSelectFilter, ResultType
 jwt_token = os.environ.get("CATALOGUE_TOKEN")
 api_url = os.environ.get("CATALOGUE_URL", "")
 runs_on_development_server = pytest.mark.skipif("not jwt_token or not api_url")
+
+
+@runs_on_development_server
+def test_list_domains():
+    client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
+    response = client.list_domains()
+    assert len(response) > 0
 
 
 @runs_on_development_server

--- a/templates/home.html
+++ b/templates/home.html
@@ -45,11 +45,11 @@
       </div>
       <div class="govuk-main-wrapper govuk-main-wrapper--l">
         <div class="govuk-width-container app-width-container">
-          {% if domains.top_level_domains %}
+          {% if domains %}
             <h2 id="browse-by-domain" class="govuk-heading-l">Browse by domain</h2>
             <ul id="domain-list" class="govuk-list govuk-list--bullet">
-              {% for domain in domains.top_level_domains  %}
-                <li><a href="{% url 'home:search' %}?domain={{domain.urn}}">{{domain.label}} ({{domain.assets}})</a></li>
+              {% for domain in domains  %}
+                <li><a href="{% url 'home:search' %}?domain={{domain.urn}}">{{domain.name}} ({{domain.total}})</a></li>
               {% endfor %}
             </ul>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -49,7 +49,7 @@
             <h2 id="browse-by-domain" class="govuk-heading-l">Browse by domain</h2>
             <ul id="domain-list" class="govuk-list govuk-list--bullet">
               {% for domain in domains.top_level_domains  %}
-                <li><a href="{% url 'home:search' %}?domain={{domain.urn}}">{{domain.label}}</a></li>
+                <li><a href="{% url 'home:search' %}?domain={{domain.urn}}">{{domain.label}} ({{domain.assets}})</a></li>
               {% endfor %}
             </ul>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ from data_platform_catalogue.entities import (
 )
 from data_platform_catalogue.search_types import (
     FacetOption,
+    ListDomainOption,
     ResultType,
     SearchFacets,
     SearchResponse,
@@ -39,6 +40,7 @@ from faker import Faker
 from home.forms.search import SearchForm
 from home.models.domain_model import DomainModel
 from home.service.details import DatabaseDetailsService
+from home.service.list_domain_fetcher import ListDomainFetcher
 from home.service.search import SearchService
 from home.service.search_facet_fetcher import SearchFacetFetcher
 from home.service.search_tag_fetcher import SearchTagFetcher
@@ -289,6 +291,26 @@ def mock_catalogue(request, example_database):
     mock_search_response(
         mock_catalogue, page_results=generate_page(), total_results=100
     )
+    mock_list_domains_response(
+        mock_catalogue,
+        domains=[
+            ListDomainOption(
+                urn="urn:li:domain:prisons",
+                name="Prisons",
+                total=fake.random_int(min=0, max=100),
+            ),
+            ListDomainOption(
+                urn="urn:li:domain:courts",
+                name="Courts",
+                total=fake.random_int(min=0, max=100),
+            ),
+            ListDomainOption(
+                urn="urn:li:domain:finance",
+                name="Finance",
+                total=fake.random_int(min=0, max=100),
+            ),
+        ],
+    )
     mock_search_facets_response(
         mock_catalogue,
         domains=[
@@ -344,6 +366,10 @@ def mock_search_response(mock_catalogue, total_results=0, page_results=()):
         total_results=total_results, page_results=page_results
     )
     mock_catalogue.search.return_value = search_response
+
+
+def mock_list_domains_response(mock_catalogue, domains):
+    mock_catalogue.list_domains.return_value = domains
 
 
 def mock_search_facets_response(mock_catalogue, domains):
@@ -408,6 +434,11 @@ def mock_get_glossary_terms_response(mock_catalogue):
 @pytest.fixture
 def search_facets():
     return SearchFacetFetcher().fetch()
+
+
+@pytest.fixture
+def list_domains():
+    return ListDomainFetcher().fetch()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,17 +297,22 @@ def mock_catalogue(request, example_database):
             ListDomainOption(
                 urn="urn:li:domain:prisons",
                 name="Prisons",
-                total=fake.random_int(min=0, max=100),
+                total=fake.random_int(min=1, max=100),
             ),
             ListDomainOption(
                 urn="urn:li:domain:courts",
                 name="Courts",
-                total=fake.random_int(min=0, max=100),
+                total=fake.random_int(min=1, max=100),
             ),
             ListDomainOption(
                 urn="urn:li:domain:finance",
                 name="Finance",
-                total=fake.random_int(min=0, max=100),
+                total=fake.random_int(min=1, max=100),
+            ),
+            ListDomainOption(
+                urn="urn:li:domain:hq",
+                name="HQ",
+                total=0,
             ),
         ],
     )
@@ -437,8 +442,8 @@ def search_facets():
 
 
 @pytest.fixture
-def list_domains():
-    return ListDomainFetcher().fetch()
+def list_domains(filter_zero_entities):
+    return ListDomainFetcher(filter_zero_entities).fetch()
 
 
 @pytest.fixture

--- a/tests/home/service/test_list_domains.py
+++ b/tests/home/service/test_list_domains.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+class TestListDomains:
+    @pytest.mark.parametrize("filter_zero_entities", [False])
+    def test_list_all_domains(self, mock_catalogue, list_domains):
+        domains = list_domains
+        assert len(domains) == 4
+
+    @pytest.mark.parametrize("filter_zero_entities", [True])
+    def test_list_domains_exclude_zero_entities(self, mock_catalogue, list_domains):
+        domains = list_domains
+        assert len(domains) == 3
+        assert all(domain.total > 0 for domain in domains)

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -108,7 +108,9 @@ class HomePage(Page):
             By.CSS_SELECTOR, "ul#domain-list li a"
         )
         all_domain_names = [d.text for d in all_domains]
-        result = next((d for d in all_domains if domain == d.text), None)
+        result = next(
+            (d for d in all_domains if domain == d.text.split("(")[0].strip()), None
+        )
         if not result:
             raise Exception(f"{domain!r} not found in {all_domain_names!r}")
         return result


### PR DESCRIPTION
- Implements a new `ListDomainFetcher` class to obtain a list of domains and the number of associated entities tagged for display in the catalogue
- Only domains with entities tagged for display in the catalogue greater than zero are displayed in browse by domain on the home page
- Implements `listDomains.graphql` to list domains with query and entity filters applied
- Implements `list_domains` methods on the datahub client and search classes
- Implements a `ListDomainOption` type
- Displays the number of tagged assets associated with the given domain in the home page