### PR TITLE
Add custom domain for prod

### DIFF
--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -10,8 +10,21 @@ spec:
   tls:
     - hosts:
         - ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
+        - find-moj-data.service.justice.gov.uk
+      secretName: find-moj-data-cert # pragma: allowlist secret
   rules:
     - host: ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: find-moj-data-service # this should match the metadata.name in service.yml
+                port:
+                  number: 80
+
+    - host: find-moj-data.service.justice.gov.uk
       http:
         paths:
           - path: /

--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -10,6 +10,7 @@ spec:
   tls:
     - hosts:
         - ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
+    - hosts
         - find-moj-data.service.justice.gov.uk
       secretName: find-moj-data-cert # pragma: allowlist secret
   rules:

--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -23,7 +23,6 @@ spec:
                 name: find-moj-data-service # this should match the metadata.name in service.yml
                 port:
                   number: 80
-
     - host: find-moj-data.service.justice.gov.uk
       http:
         paths:

--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -10,7 +10,7 @@ spec:
   tls:
     - hosts:
         - ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
-    - hosts
+    - hosts:
         - find-moj-data.service.justice.gov.uk
       secretName: find-moj-data-cert # pragma: allowlist secret
   rules:


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/find-moj-data/issues/546

I'm following this guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/custom-domain-cert.html

This should hopefully allow us to access the app via find-moj-data.service.justice.gov.uk.

I'm going straight to prod only because we are pre-launch, and this is the one we definitely want on justice.service.gov.uk

Once it works for one environment, I'll repeat for the others.