### PR TITLE
Revert "Add custom domain for prod"

### DIFF
--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -10,21 +10,8 @@ spec:
   tls:
     - hosts:
         - ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
-    - hosts:
-        - find-moj-data.service.justice.gov.uk
-      secretName: find-moj-data-cert # pragma: allowlist secret
   rules:
     - host: ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: find-moj-data-service # this should match the metadata.name in service.yml
-                port:
-                  number: 80
-    - host: find-moj-data.service.justice.gov.uk
       http:
         paths:
           - path: /


### PR DESCRIPTION
Reverts ministryofjustice/find-moj-data#591

```
Name: "find-moj-data-ingress", Namespace: "***"
for: "deployments/ingress.yml": error when patching "deployments/ingress.yml": admission webhook "validation.gatekeeper.sh" denied the request: [k8singressclash] ingress host (find-moj-data.service.justice.gov.uk) conflicts with ingress data-platform-find-moj-data-test/find-moj-data-ingress
```