### PR TITLE
feat(deployments): Add external domain to ingress (take 2)

### DIFF
--- a/.github/workflows/reusable-build-and-deploy.yml
+++ b/.github/workflows/reusable-build-and-deploy.yml
@@ -110,6 +110,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_REDIRECT_URI: ${{ vars.AZURE_REDIRECT_URI }}
           AZURE_AUTHORITY: ${{ vars.AZURE_AUTHORITY }}
+          EXTERNAL_DOMAIN_PREFIX: ${{ vars.EXTERNAL_DOMAIN_PREFIX }}
 
         run: |
           cat deployments/templates/deployment.yml | envsubst > deployments/deployment.yml

--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -10,8 +10,21 @@ spec:
   tls:
     - hosts:
         - ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
+    - hosts:
+        - ${EXTERNAL_DOMAIN_PREFIX}find-moj-data.service.justice.gov.uk
+      secretName: find-moj-data-cert # pragma: allowlist secret
   rules:
     - host: ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: find-moj-data-service # this should match the metadata.name in service.yml
+                port:
+                  number: 80
+    - host: ${EXTERNAL_DOMAIN_PREFIX}find-moj-data.service.justice.gov.uk
       http:
         paths:
           - path: /


### PR DESCRIPTION
(fixes the code rolled back in https://github.com/ministryofjustice/find-moj-data/pull/592)

This amends the ingress to enable ingress via a service.justice.gov.uk domain.

- Add an entry to `tls` to set up HTTPS, using a certificate secret that is managed in the cloud-platform-environments repo (this is managed via cert-manager)

- Add an extra rule so that the backend is mapped for all paths on *.find-moj-data.service.justice.gov.uk URLs (not just the cloud platform one)

- Make sure the hostname is the right one for the environment. This is controlled by a new github actions variable that is environment-specific.

For further info, see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/route53-zone.html#creating-a-route-53-hosted-zone