### PR TITLE
Update search form domain filters

### DIFF
--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -1,10 +1,11 @@
 from copy import deepcopy
 from urllib.parse import urlencode
 
-from data_platform_catalogue.search_types import ResultType
+from data_platform_catalogue.search_types import ListDomainOption, ResultType
 from django import forms
 
 from ..models.domain_model import Domain, DomainModel
+from ..service.list_domain_fetcher import ListDomainFetcher
 from ..service.search_facet_fetcher import SearchFacetFetcher
 from ..service.search_tag_fetcher import SearchTagFetcher
 
@@ -16,6 +17,17 @@ def get_domain_choices() -> list[Domain]:
     ]
     facets = SearchFacetFetcher().fetch()
     choices.extend(DomainModel(facets).top_level_domains)
+    return choices
+
+
+def get_list_domain_choices() -> list[Domain]:
+    """Make ListDomains API call to obtain domain choices"""
+    choices = [
+        Domain("", "All domains"),
+    ]
+    list_domain_options: list[ListDomainOption] = ListDomainFetcher().fetch()
+    domains: list[Domain] = [Domain(d.urn, d.name) for d in list_domain_options]
+    choices.extend(domains)
     return choices
 
 
@@ -86,7 +98,7 @@ class SearchForm(forms.Form):
         ),
     )
     domain = forms.ChoiceField(
-        choices=get_domain_choices,
+        choices=get_list_domain_choices,
         required=False,
         widget=forms.Select(
             attrs={

--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -1,20 +1,20 @@
 from copy import deepcopy
 from urllib.parse import urlencode
 
-from data_platform_catalogue.search_types import ListDomainOption, ResultType
+from data_platform_catalogue.search_types import DomainOption, ResultType
 from django import forms
 
 from ..models.domain_model import Domain
-from ..service.list_domain_fetcher import ListDomainFetcher
+from ..service.domain_fetcher import DomainFetcher
 from ..service.search_tag_fetcher import SearchTagFetcher
 
 
-def get_list_domain_choices() -> list[Domain]:
-    """Make ListDomains API call to obtain domain choices"""
+def get_domain_choices() -> list[Domain]:
+    """Make Domains API call to obtain domain choices"""
     choices = [
         Domain("", "All domains"),
     ]
-    list_domain_options: list[ListDomainOption] = ListDomainFetcher().fetch()
+    list_domain_options: list[DomainOption] = DomainFetcher().fetch()
     domains: list[Domain] = [Domain(d.urn, d.name) for d in list_domain_options]
     choices.extend(domains)
     return choices
@@ -59,7 +59,7 @@ class SearchForm(forms.Form):
         ),
     )
     domain = forms.ChoiceField(
-        choices=get_list_domain_choices,
+        choices=get_domain_choices,
         required=False,
         widget=forms.Select(
             attrs={

--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -4,20 +4,9 @@ from urllib.parse import urlencode
 from data_platform_catalogue.search_types import ListDomainOption, ResultType
 from django import forms
 
-from ..models.domain_model import Domain, DomainModel
+from ..models.domain_model import Domain
 from ..service.list_domain_fetcher import ListDomainFetcher
-from ..service.search_facet_fetcher import SearchFacetFetcher
 from ..service.search_tag_fetcher import SearchTagFetcher
-
-
-def get_domain_choices() -> list[Domain]:
-    """Make API call to obtain domain choices"""
-    choices = [
-        Domain("", "All domains"),
-    ]
-    facets = SearchFacetFetcher().fetch()
-    choices.extend(DomainModel(facets).top_level_domains)
-    return choices
 
 
 def get_list_domain_choices() -> list[Domain]:
@@ -28,13 +17,6 @@ def get_list_domain_choices() -> list[Domain]:
     list_domain_options: list[ListDomainOption] = ListDomainFetcher().fetch()
     domains: list[Domain] = [Domain(d.urn, d.name) for d in list_domain_options]
     choices.extend(domains)
-    return choices
-
-
-def get_subdomain_choices() -> list[Domain]:
-    choices = [Domain("", "All subdomains")]
-    facets = SearchFacetFetcher().fetch()
-    choices.extend(DomainModel(facets).all_subdomains())
     return choices
 
 
@@ -65,27 +47,6 @@ def get_tags():
     return tags
 
 
-class SelectWithOptionAttribute(forms.Select):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.domain_model = None
-
-    def create_option(
-        self, name, urn, label, selected, index, subindex=None, attrs=None
-    ):
-        option = super().create_option(
-            name, urn, label, selected, index, subindex, attrs
-        )
-
-        facets = SearchFacetFetcher().fetch()
-        self.domain_model = self.domain_model or DomainModel(facets)
-
-        if urn:
-            option["attrs"]["data-parent"] = self.domain_model.get_parent_urn(urn)
-
-        return option
-
-
 class SearchForm(forms.Form):
     """Django form to represent search page inputs"""
 
@@ -107,13 +68,6 @@ class SearchForm(forms.Form):
                 "aria-label": "Domain",
                 "onchange": "document.getElementById('searchform').submit();",
             }
-        ),
-    )
-    subdomain = forms.ChoiceField(
-        choices=get_subdomain_choices,
-        required=False,
-        widget=SelectWithOptionAttribute(
-            attrs={"form": "searchform", "class": "govuk-select"}
         ),
     )
     where_to_access = forms.MultipleChoiceField(
@@ -183,6 +137,4 @@ class SearchForm(forms.Form):
             value.remove(filter_value)
         elif isinstance(value, str) and filter_value == value:
             query_params.pop(filter_name)
-            if filter_name == "domain":
-                query_params.pop("subdomain")
         return f"?{urlencode(query_params, doseq=True)}"

--- a/home/models/domain_model.py
+++ b/home/models/domain_model.py
@@ -1,7 +1,7 @@
 import logging
 from typing import NamedTuple
 
-from data_platform_catalogue.search_types import ListDomainOption
+from data_platform_catalogue.search_types import DomainOption
 
 logger = logging.getLogger(__name__)
 
@@ -11,8 +11,8 @@ class Domain(NamedTuple):
     label: str
 
 
-class ListDomainModel:
-    def __init__(self, domains: list[ListDomainOption]):
+class DomainModel:
+    def __init__(self, domains: list[DomainOption]):
         self.labels = {}
 
         self.top_level_domains = [Domain(domain.urn, domain.name) for domain in domains]

--- a/home/models/domain_model.py
+++ b/home/models/domain_model.py
@@ -1,7 +1,7 @@
 import logging
 from typing import NamedTuple
 
-from data_platform_catalogue.search_types import ListDomainOption, SearchFacets
+from data_platform_catalogue.search_types import ListDomainOption
 
 logger = logging.getLogger(__name__)
 
@@ -20,46 +20,6 @@ class ListDomainModel:
 
         for urn, label in self.top_level_domains:
             self.labels[urn] = label
-
-    def get_label(self, urn):
-        return self.labels.get(urn, urn)
-
-
-class DomainModel:
-    """
-    Store information about domains and subdomains
-    """
-
-    def __init__(self, search_facets: SearchFacets):
-        self.labels = {}
-
-        self.top_level_domains = [
-            Domain(option.value, option.label)
-            for option in search_facets.options("domains")
-        ]
-        self.top_level_domains.sort(key=lambda d: d.label)
-
-        logger.info(f"{self.top_level_domains=}")
-
-        self.subdomains = {}
-
-        for urn, label in self.top_level_domains:
-            self.labels[urn] = label
-
-    def all_subdomains(self) -> list[Domain]:  # -> list[Any]
-        """
-        A flat list of all subdomains
-        """
-        subdomains = []
-        for domain_choices in self.subdomains.values():
-            subdomains.extend(domain_choices)
-        return subdomains
-
-    def get_parent_urn(self, child_subdomain_urn) -> str | None:
-        for domain, subdomains in self.subdomains.items():
-            for subdomain in subdomains:
-                if child_subdomain_urn == subdomain.urn:
-                    return domain
 
     def get_label(self, urn):
         return self.labels.get(urn, urn)

--- a/home/models/domain_model.py
+++ b/home/models/domain_model.py
@@ -1,7 +1,7 @@
 import logging
 from typing import NamedTuple
 
-from data_platform_catalogue.search_types import SearchFacets
+from data_platform_catalogue.search_types import ListDomainOption, SearchFacets
 
 logger = logging.getLogger(__name__)
 
@@ -9,6 +9,20 @@ logger = logging.getLogger(__name__)
 class Domain(NamedTuple):
     urn: str
     label: str
+
+
+class ListDomainModel:
+    def __init__(self, domains: list[ListDomainOption]):
+        self.labels = {}
+
+        self.top_level_domains = [Domain(domain.urn, domain.name) for domain in domains]
+        logger.info(f"{self.top_level_domains=}")
+
+        for urn, label in self.top_level_domains:
+            self.labels[urn] = label
+
+    def get_label(self, urn):
+        return self.labels.get(urn, urn)
 
 
 class DomainModel:

--- a/home/service/domain_fetcher.py
+++ b/home/service/domain_fetcher.py
@@ -1,12 +1,12 @@
-from data_platform_catalogue.search_types import ListDomainOption
+from data_platform_catalogue.search_types import DomainOption
 from django.core.cache import cache
 
 from .base import GenericService
 
 
-class ListDomainFetcher(GenericService):
+class DomainFetcher(GenericService):
     """
-    ListDomainFetcher implementation to fetch domains with the total number of
+    DomainFetcher implementation to fetch domains with the total number of
     associated entities from the backend.
     """
 
@@ -16,7 +16,7 @@ class ListDomainFetcher(GenericService):
         self.cache_timeout_seconds = 300
         self.filter_zero_entities = filter_zero_entities
 
-    def fetch(self) -> list[ListDomainOption]:
+    def fetch(self) -> list[DomainOption]:
         """
         Fetch a static list of options that is independent of the search query
         and any applied filters. Values are cached for 5 seconds to avoid

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -62,9 +62,6 @@ class SearchService(GenericService):
         sort = form_data.get("sort", "relevance")
         domain = form_data.get("domain", "")
         tags = form_data.get("tags", "")
-        # domains_and_subdomains = domains_with_their_subdomains(
-        #     domain, subdomain, self.domain_model
-        # )
         where_to_access = self._build_custom_property_filter(
             "dc_where_to_access_dataset=", form_data.get("where_to_access", [])
         )
@@ -148,7 +145,6 @@ class SearchService(GenericService):
         self,
     ) -> dict[str, str]:
         domain = self.form.cleaned_data.get("domain", "")
-        # subdomain = self.form.cleaned_data.get("subdomain", "")
 
         label = self.domain_model.get_label(domain)
 

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from typing import Any
 
 from data_platform_catalogue.search_types import (
-    ListDomainOption,
+    DomainOption,
     MultiSelectFilter,
     ResultType,
     SearchResponse,
@@ -14,16 +14,16 @@ from django.core.paginator import Paginator
 from nltk.stem import PorterStemmer
 
 from home.forms.search import SearchForm
-from home.models.domain_model import ListDomainModel
+from home.models.domain_model import DomainModel
 
 from .base import GenericService
-from .list_domain_fetcher import ListDomainFetcher
+from .domain_fetcher import DomainFetcher
 
 
 class SearchService(GenericService):
     def __init__(self, form: SearchForm, page: str, items_per_page: int = 20):
-        domains: list[ListDomainOption] = ListDomainFetcher().fetch()
-        self.domain_model = ListDomainModel(domains)
+        domains: list[DomainOption] = DomainFetcher().fetch()
+        self.domain_model = DomainModel(domains)
         self.stemmer = PorterStemmer()
         self.form = form
         if self.form.is_bound:

--- a/home/views.py
+++ b/home/views.py
@@ -1,5 +1,5 @@
 from data_platform_catalogue.client.exceptions import EntityDoesNotExist
-from data_platform_catalogue.search_types import ListDomainOption
+from data_platform_catalogue.search_types import DomainOption
 from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import render
 
@@ -9,8 +9,8 @@ from home.service.details import (
     DatabaseDetailsService,
     DatasetDetailsService,
 )
+from home.service.domain_fetcher import DomainFetcher
 from home.service.glossary import GlossaryService
-from home.service.list_domain_fetcher import ListDomainFetcher
 from home.service.metadata_specification import MetadataSpecificationService
 from home.service.search import SearchService
 
@@ -19,7 +19,7 @@ def home_view(request):
     """
     Displys only domains that have entities tagged for display in the catalog.
     """
-    domains: list[ListDomainOption] = ListDomainFetcher().fetch()
+    domains: list[DomainOption] = DomainFetcher().fetch()
     context = {"domains": domains, "h1_value": "Home"}
     return render(request, "home.html", context)
 

--- a/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
+++ b/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
@@ -3,30 +3,6 @@ import logging
 from importlib.resources import files
 from typing import Sequence
 
-from datahub.configuration.common import ConfigurationError
-from datahub.emitter import mce_builder
-from datahub.emitter.mcp import MetadataChangeProposalWrapper
-from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
-from datahub.ingestion.source.common.subtypes import (
-    DatasetContainerSubTypes,
-    DatasetSubTypes,
-)
-from datahub.metadata import schema_classes
-from datahub.metadata.com.linkedin.pegasus2avro.common import DataPlatformInstance
-from datahub.metadata.schema_classes import (
-    ChangeTypeClass,
-    ContainerClass,
-    ContainerPropertiesClass,
-    DatasetPropertiesClass,
-    DomainPropertiesClass,
-    DomainsClass,
-    OtherSchemaClass,
-    SchemaFieldClass,
-    SchemaFieldDataTypeClass,
-    SchemaMetadataClass,
-    SubTypesClass,
-)
-
 from data_platform_catalogue.client.exceptions import (
     AspectDoesNotExist,
     ConnectivityError,
@@ -57,12 +33,35 @@ from data_platform_catalogue.entities import (
     Table,
 )
 from data_platform_catalogue.search_types import (
-    ListDomainOption,
+    DomainOption,
     MultiSelectFilter,
     ResultType,
     SearchFacets,
     SearchResponse,
     SortOption,
+)
+from datahub.configuration.common import ConfigurationError
+from datahub.emitter import mce_builder
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+from datahub.ingestion.source.common.subtypes import (
+    DatasetContainerSubTypes,
+    DatasetSubTypes,
+)
+from datahub.metadata import schema_classes
+from datahub.metadata.com.linkedin.pegasus2avro.common import DataPlatformInstance
+from datahub.metadata.schema_classes import (
+    ChangeTypeClass,
+    ContainerClass,
+    ContainerPropertiesClass,
+    DatasetPropertiesClass,
+    DomainPropertiesClass,
+    DomainsClass,
+    OtherSchemaClass,
+    SchemaFieldClass,
+    SchemaFieldDataTypeClass,
+    SchemaMetadataClass,
+    SubTypesClass,
 )
 
 logger = logging.getLogger(__name__)
@@ -230,9 +229,9 @@ class DataHubCatalogueClient:
             MultiSelectFilter("tags", ["urn:li:tag:dc_display_in_catalogue"])
         ],
         count: int = 1000,
-    ) -> list[ListDomainOption]:
+    ) -> list[DomainOption]:
         """
-        Returns a list of ListDomainOption objects
+        Returns a list of DomainOption objects
         """
         return self.search_client.list_domains(
             query=query, filters=filters, count=count

--- a/lib/datahub-client/data_platform_catalogue/client/search.py
+++ b/lib/datahub-client/data_platform_catalogue/client/search.py
@@ -3,9 +3,6 @@ import logging
 from importlib.resources import files
 from typing import Any, Sequence
 
-from datahub.configuration.common import GraphError  # pylint: disable=E0611
-from datahub.ingestion.graph.client import DataHubGraph  # pylint: disable=E0611
-
 from data_platform_catalogue.client.exceptions import CatalogueError
 from data_platform_catalogue.client.graphql_helpers import (
     parse_created_and_modified,
@@ -19,8 +16,8 @@ from data_platform_catalogue.client.graphql_helpers import (
 )
 from data_platform_catalogue.entities import EntityRef
 from data_platform_catalogue.search_types import (
+    DomainOption,
     FacetOption,
-    ListDomainOption,
     MultiSelectFilter,
     ResultType,
     SearchFacets,
@@ -28,6 +25,8 @@ from data_platform_catalogue.search_types import (
     SearchResult,
     SortOption,
 )
+from datahub.configuration.common import GraphError  # pylint: disable=E0611
+from datahub.ingestion.graph.client import DataHubGraph  # pylint: disable=E0611
 
 logger = logging.getLogger(__name__)
 
@@ -193,7 +192,7 @@ class SearchClient:
             MultiSelectFilter("tags", ["urn:li:tag:dc_display_in_catalogue"])
         ],
         count: int = 1000,
-    ) -> list[ListDomainOption]:
+    ) -> list[DomainOption]:
         """
         Returns domains that can be used to filter the search results.
         """
@@ -255,8 +254,8 @@ class SearchClient:
 
     def _parse_list_domains(
         self, list_domains_result: list[dict[str, Any]]
-    ) -> list[ListDomainOption]:
-        list_domain_options: list[ListDomainOption] = []
+    ) -> list[DomainOption]:
+        list_domain_options: list[DomainOption] = []
 
         for domain in list_domains_result:
             urn = domain.get("urn", "")
@@ -265,7 +264,7 @@ class SearchClient:
             entities = domain.get("entities", {})
             total = entities.get("total", 0)
 
-            list_domain_options.append(ListDomainOption(urn, name, total))
+            list_domain_options.append(DomainOption(urn, name, total))
         return list_domain_options
 
     def _parse_result(

--- a/lib/datahub-client/data_platform_catalogue/search_types.py
+++ b/lib/datahub-client/data_platform_catalogue/search_types.py
@@ -55,7 +55,7 @@ class FacetOption:
 
 
 @dataclass
-class ListDomainOption:
+class DomainOption:
     """
     A representation of a domain and the number of associated entities
     represented by total.

--- a/lib/datahub-client/tests/test_integration_with_datahub_server.py
+++ b/lib/datahub-client/tests/test_integration_with_datahub_server.py
@@ -12,7 +12,6 @@ import time
 from datetime import datetime, timezone
 
 import pytest
-
 from data_platform_catalogue.client.datahub_client import DataHubCatalogueClient
 from data_platform_catalogue.entities import (
     AccessInformation,
@@ -32,7 +31,7 @@ from data_platform_catalogue.entities import (
     UsageRestrictions,
 )
 from data_platform_catalogue.search_types import (
-    ListDomainOption,
+    DomainOption,
     MultiSelectFilter,
     ResultType,
 )
@@ -48,7 +47,7 @@ def test_list_domains():
     response = client.list_domains()
     assert len(response) > 0
     domain = response[0]
-    assert isinstance(domain, ListDomainOption)
+    assert isinstance(domain, DomainOption)
     assert "urn:li:domain" in domain.urn
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ from django.test import Client
 from faker import Faker
 
 from home.forms.search import SearchForm
-from home.models.domain_model import DomainModel
+from home.models.domain_model import DomainModel, ListDomainModel
 from home.service.details import DatabaseDetailsService
 from home.service.list_domain_fetcher import ListDomainFetcher
 from home.service.search import SearchService
@@ -452,8 +452,8 @@ def search_tags():
 
 
 @pytest.fixture
-def valid_domain(search_facets):
-    return DomainModel(search_facets).top_level_domains[0]
+def valid_domain(list_domains):
+    return ListDomainModel(list_domains).top_level_domains[0]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ from django.test import Client
 from faker import Faker
 
 from home.forms.search import SearchForm
-from home.models.domain_model import DomainModel, ListDomainModel
+from home.models.domain_model import ListDomainModel
 from home.service.details import DatabaseDetailsService
 from home.service.list_domain_fetcher import ListDomainFetcher
 from home.service.search import SearchService
@@ -452,8 +452,11 @@ def search_tags():
 
 
 @pytest.fixture
-def valid_domain(list_domains):
-    return ListDomainModel(list_domains).top_level_domains[0]
+def valid_domain():
+    domains = ListDomainFetcher().fetch()
+    return ListDomainModel(
+        domains,
+    ).top_level_domains[0]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,8 +26,8 @@ from data_platform_catalogue.entities import (
     UsageRestrictions,
 )
 from data_platform_catalogue.search_types import (
+    DomainOption,
     FacetOption,
-    ListDomainOption,
     ResultType,
     SearchFacets,
     SearchResponse,
@@ -38,9 +38,9 @@ from django.test import Client
 from faker import Faker
 
 from home.forms.search import SearchForm
-from home.models.domain_model import ListDomainModel
+from home.models.domain_model import DomainModel
 from home.service.details import DatabaseDetailsService
-from home.service.list_domain_fetcher import ListDomainFetcher
+from home.service.domain_fetcher import DomainFetcher
 from home.service.search import SearchService
 from home.service.search_facet_fetcher import SearchFacetFetcher
 from home.service.search_tag_fetcher import SearchTagFetcher
@@ -294,22 +294,22 @@ def mock_catalogue(request, example_database):
     mock_list_domains_response(
         mock_catalogue,
         domains=[
-            ListDomainOption(
+            DomainOption(
                 urn="urn:li:domain:prisons",
                 name="Prisons",
                 total=fake.random_int(min=1, max=100),
             ),
-            ListDomainOption(
+            DomainOption(
                 urn="urn:li:domain:courts",
                 name="Courts",
                 total=fake.random_int(min=1, max=100),
             ),
-            ListDomainOption(
+            DomainOption(
                 urn="urn:li:domain:finance",
                 name="Finance",
                 total=fake.random_int(min=1, max=100),
             ),
-            ListDomainOption(
+            DomainOption(
                 urn="urn:li:domain:hq",
                 name="HQ",
                 total=0,
@@ -443,7 +443,7 @@ def search_facets():
 
 @pytest.fixture
 def list_domains(filter_zero_entities):
-    return ListDomainFetcher(filter_zero_entities).fetch()
+    return DomainFetcher(filter_zero_entities).fetch()
 
 
 @pytest.fixture
@@ -453,8 +453,8 @@ def search_tags():
 
 @pytest.fixture
 def valid_domain():
-    domains = ListDomainFetcher().fetch()
-    return ListDomainModel(
+    domains = DomainFetcher().fetch()
+    return DomainModel(
         domains,
     ).top_level_domains[0]
 

--- a/tests/home/service/test_search.py
+++ b/tests/home/service/test_search.py
@@ -6,7 +6,7 @@ from urllib.parse import quote
 import pytest
 
 from home.forms.search import SearchForm
-from home.service.search import SearchService, domains_with_their_subdomains
+from home.service.search import SearchService
 
 dev_env = True if os.environ.get("ENV") == "dev" else False
 run_for_dev = pytest.mark.skipif(
@@ -48,7 +48,6 @@ class TestSearchService:
             "analytical_platform": (
                 "?query=test&"
                 f"domain={quote(valid_domain.urn)}&"
-                "subdomain=&"
                 "entity_types=TABLE&"
                 "sort=ascending&"
                 "clear_filter=False&"
@@ -61,7 +60,6 @@ class TestSearchService:
             "Table": (
                 "?query=test&"
                 f"domain={quote(valid_domain.urn)}&"
-                "subdomain=&"
                 "where_to_access=analytical_platform&"
                 "sort=ascending&"
                 "clear_filter=False&"
@@ -74,7 +72,6 @@ class TestSearchService:
             "tag-1": (
                 "?query=test&"
                 f"domain={quote(valid_domain.urn)}&"
-                "subdomain=&"
                 "where_to_access=analytical_platform&"
                 "entity_types=TABLE&"
                 "sort=ascending&"
@@ -157,28 +154,3 @@ class TestSearchService:
             search_service.results.page_results
             != search_service.highlighted_results.page_results
         )
-
-
-@run_for_dev
-@pytest.mark.parametrize(
-    "domain, subdomain, expected_subdomains",
-    [
-        ("does-not-exist", "", []),
-        (
-            "urn:li:domain:HMPPS",
-            "",
-            [
-                "urn:li:domain:HMPPS",
-                "urn:li:domain:2feb789b-44d3-4412-b998-1f26819fabf9",
-                "urn:li:domain:abe153c1-416b-4abb-be7f-6accf2abb10a",
-            ],
-        ),
-        (
-            "urn:li:domain:HMPPS",
-            "urn:li:domain:2feb789b-44d3-4412-b998-1f26819fabf9",
-            ["urn:li:domain:2feb789b-44d3-4412-b998-1f26819fabf9"],
-        ),
-    ],
-)
-def test_domain_expansion(domain, subdomain, expected_subdomains):
-    assert domains_with_their_subdomains(domain, subdomain) == expected_subdomains


### PR DESCRIPTION
This PR utilises the implementation from [here](https://github.com/ministryofjustice/find-moj-data/pull/589) to pull domains from the back end along with the count of entities tagged for display in the catalogue. 

It is key to note that this implementation bypasses the existing `facets` code, and given that we are not currently using `subdomains` and we have standalone fetchers for both tags and glossary we could consider removing the facets code altogether.

- Implements a new `get_list_domain_choices` function to return a list of `Domain` objects used for the domain filter options.