### PR TITLE
Linked contact href in footer to data catalogue slack

### DIFF
--- a/templates/base/footer.html
+++ b/templates/base/footer.html
@@ -15,7 +15,7 @@
             </a>
           </li>
           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="#">
+            <a class="govuk-footer__link" href="https://moj.enterprise.slack.com/archives/C06NPM2200N">
               Contact
             </a>
           </li>


### PR DESCRIPTION
* This is in line with the contact us link in the error pages