### PR TITLE
Comment out ingress rule

### DIFF
--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -24,13 +24,13 @@ spec:
                 name: find-moj-data-service # this should match the metadata.name in service.yml
                 port:
                   number: 80
-    - host: ${EXTERNAL_DOMAIN_PREFIX}find-moj-data.service.justice.gov.uk
-      http:
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: find-moj-data-service # this should match the metadata.name in service.yml
-                port:
-                  number: 80
+    # - host: ${EXTERNAL_DOMAIN_PREFIX}find-moj-data.service.justice.gov.uk
+    #   http:
+    #     paths:
+    #       - path: /
+    #         pathType: ImplementationSpecific
+    #         backend:
+    #           service:
+    #             name: find-moj-data-service # this should match the metadata.name in service.yml
+    #             port:
+    #               number: 80


### PR DESCRIPTION
I want to delete the dev hosted zone in cloud platform. I need to remove the ingress rules related to it so that ExternalDNS will remove the custom records from the hosted zone and I can remove the hosted zone. I can reintroduce this after all the hosted zones are removed