### PR TITLE
Fmd 584 contact redesign

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Install project
         run: poetry install --no-interaction --no-root
 
+      - name: compile messages
+        run: make compile_messages
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -74,7 +74,7 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: compile messages
-        run: make compile_messages
+        run: poetry run python manage.py compilemessages
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -73,10 +73,8 @@ jobs:
       - name: Install project
         run: poetry install --no-interaction --no-root
 
-      - name: Install compile messages reqs
-        run: |
-          apt-get update
-          sudo apt-get install gettext
+      - name: Install compile messages prereqs
+        run: sudo apt-get install gettext
 
       - name: Compile messages
         run: make compile_messages

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -73,8 +73,13 @@ jobs:
       - name: Install project
         run: poetry install --no-interaction --no-root
 
-      - name: compile messages
-        run: poetry run python manage.py compilemessages
+      - name: Install compile messages reqs
+        run: |
+          apt-get update
+          sudo apt-get install gettext
+
+      - name: Compile messages
+        run: make compile_messages
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/home/service/details.py
+++ b/home/service/details.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 from .base import GenericService
 
 
-def _parse_parent(relationships) -> EntityRef | None:
+def _parse_parent(relationships: dict) -> EntityRef | None:
     """
     returns the EntityRef of the first parent if one exists
     """

--- a/home/service/details.py
+++ b/home/service/details.py
@@ -69,7 +69,7 @@ class DatabaseDetailsService(GenericService):
             ),
             "h1_value": self.database_metadata.name,
             "is_esda": self.is_esda,
-            "is_access_requirements_url": is_access_requirements_a_url(
+            "is_access_requirements_a_url": is_access_requirements_a_url(
                 self.database_metadata.custom_properties.access_information.access_requirements
             ),
         }
@@ -107,7 +107,7 @@ class DatasetDetailsService(GenericService):
             "h1_value": self.table_metadata.name,
             "has_lineage": self.has_lineage(),
             "lineage_url": f"{split_datahub_url.scheme}://{split_datahub_url.netloc}/dataset/{self.table_metadata.urn}/Lineage?is_lineage_mode=true&",  # noqa: E501
-            "is_access_requirements_url": is_access_requirements_a_url(
+            "is_access_requirements_a_url": is_access_requirements_a_url(
                 self.table_metadata.custom_properties.access_information.access_requirements
             ),
         }
@@ -140,7 +140,7 @@ class ChartDetailsService(GenericService):
             "parent_entity": self.parent_entity,
             "parent_type": ResultType.DASHBOARD.name.lower(),
             "h1_value": self.chart_metadata.name,
-            "is_access_requirements_url": is_access_requirements_a_url(
+            "is_access_requirements_a_url": is_access_requirements_a_url(
                 self.chart_metadata.custom_properties.access_information.access_requirements
             ),
         }
@@ -163,7 +163,7 @@ class DashboardDetailsService(GenericService):
                 self.children,
                 key=lambda d: d.entity_ref.display_name,
             ),
-            "is_access_requirements_url": is_access_requirements_a_url(
+            "is_access_requirements_a_url": is_access_requirements_a_url(
                 self.dashboard_metadata.custom_properties.access_information.access_requirements
             ),
         }

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -353,9 +353,9 @@ msgstr ""
 "intended to be narrower in scope than an entire agency."
 
 # Heading
-#: templates/partial/contact_info.html:4
+#: templates/partial/contact_info.html:29
 msgid "IAO or Data Owner"
-msgstr "IAO or Data Owner"
+msgstr "Data owner"
 
 # Heading
 #: templates/partial/contact_info.html:10
@@ -363,19 +363,24 @@ msgid "Contact email for access requests"
 msgstr "Contact email for access requests"
 
 # Heading
-#: templates/partial/contact_info.html:18
-msgid "Contact channels for access requests"
-msgstr "Contact channels for access requests"
+#: templates/partial/contact_info.html:21
+msgid "Contact channels for questions"
+msgstr "Contact channels for questions"
 
 # Heading
-#: templates/partial/contact_info.html:26
+#: templates/partial/contact_info.html:4
 msgid "Access requirements"
-msgstr "Access requirements"
+msgstr "Request access"
+
+# Request access link
+#: templates/partial/contact_info.html:8
+msgid "Click link for access information (opens in new tab)"
+msgstr "Click link for access information (opens in new tab)"
 
 # Default text for contact info
-#: templates/partial/contact_info.html:31
+#: templates/partial/contact_info.html:13
 msgid "Processing the data might require permission from IAO or Data owner."
-msgstr "Processing the data might require permission from IAO or Data owner."
+msgstr "Processing the data might require permission from the Data owner."
 
 # Contact us link on error pages
 #: templates/partial/contact_team.html:4

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -90,7 +90,7 @@
       </div>
     </div>
     <div class="govuk-grid-column-one-third">
-      {% include "partial/contact_info.html" with data_owner=entity.governance.data_owner.display_name data_owner_email=entity.governance.data_owner.email slack_channel=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.access_requirements is_access_url=is_access_requirements_url%}
+      {% include "partial/contact_info.html" with data_owner=entity.governance.data_owner.display_name data_owner_email=entity.governance.data_owner.email slack_channel=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.access_requirements is_access_url=is_access_requirements_a_url%}
     </div>
   </div>
 

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -90,7 +90,7 @@
       </div>
     </div>
     <div class="govuk-grid-column-one-third">
-      {% include "partial/contact_info.html" with data_owner=entity.governance.data_owner.display_name data_owner_email=entity.governance.data_owner.email slack_channel=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.access_requirements%}
+      {% include "partial/contact_info.html" with data_owner=entity.governance.data_owner.display_name data_owner_email=entity.governance.data_owner.email slack_channel=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.access_requirements is_access_url=is_access_requirements_url%}
     </div>
   </div>
 

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -1,34 +1,33 @@
 {% load i18n %}
 
 <div class="govuk-body">
-  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "IAO or Data Owner" %}</h2>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Request access</h2>
   <p class="govuk-body">
-    {{ data_owner }}
-  </p>
-</div>
-<div class="govuk-body">
-  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Contact email for access requests" %}</h2>
-  <p class="govuk-body">
-    {{ data_owner_email|urlize }}
+    {% if access_requirements %}
+      {% if is_access_url %}
+        <a id="request-access" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Click link for access information (opens in new tab)</a><br>
+      {% else %}
+        <p id="request-access">{{ access_requirements }} </p>
+      {% endif %}
+    {% else %}
+      <p id="request-access"> Processing the data might require permission from the Data owner. </p>
+
+    {% endif %}
   </p>
 </div>
 <!-- placeholder until we have more contact channels than just slack -->
 {% if slack_channel.dc_slack_channel_url %}
   <div class="govuk-body">
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Contact channels for access requests" %}</h2>
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Contact channels for questions</h2>
     <p class="govuk-body">
         <!-- This should become a list of populated contact channels -->
-      Slack channel: <a href="{{ slack_channel.dc_slack_channel_url }}" target="_blank">{{ slack_channel.dc_slack_channel_name }} (opens in new tab)</a>
+      Slack channel: <a href="{{ slack_channel.dc_slack_channel_url }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ slack_channel.dc_slack_channel_name }} (opens in new tab)</a>
     </p>
   </div>
 {% endif %}
 <div class="govuk-body">
-  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Access requirements" %}</h2>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Data owner</h2>
   <p class="govuk-body">
-    {% if access_requirements %}
-      {{ access_requirements }}
-    {% else %}
-    {% translate "Processing the data might require permission from IAO or Data owner." %}
-    {% endif %}
+    {{ data_owner_email|urlize }}
   </p>
 </div>

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -1,16 +1,16 @@
 {% load i18n %}
 
 <div class="govuk-body">
-  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Request access</h2>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Access requirements" %}</h2>
   <p class="govuk-body">
     {% if access_requirements %}
       {% if is_access_url %}
-        <a id="request-access" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Click link for access information (opens in new tab)</a><br>
+        <a id="request-access" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{% translate "Click link for access information (opens in new tab)" %}</a><br>
       {% else %}
         <p id="request-access">{{ access_requirements }} </p>
       {% endif %}
     {% else %}
-      <p id="request-access"> Processing the data might require permission from the Data owner. </p>
+      <p id="request-access"> {% translate "Processing the data might require permission from IAO or Data owner." %} </p>
 
     {% endif %}
   </p>
@@ -18,7 +18,7 @@
 <!-- placeholder until we have more contact channels than just slack -->
 {% if slack_channel.dc_slack_channel_url %}
   <div class="govuk-body">
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Contact channels for questions</h2>
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Contact channels for questions" %}</h2>
     <p class="govuk-body">
         <!-- This should become a list of populated contact channels -->
       Slack channel: <a href="{{ slack_channel.dc_slack_channel_url }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ slack_channel.dc_slack_channel_name }} (opens in new tab)</a>
@@ -26,7 +26,7 @@
   </div>
 {% endif %}
 <div class="govuk-body">
-  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Data owner</h2>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "IAO or Data Owner" %}</h2>
   <p class="govuk-body">
     {{ data_owner_email|urlize }}
   </p>

--- a/tests/home/service/test_details.py
+++ b/tests/home/service/test_details.py
@@ -1,3 +1,4 @@
+import pytest
 from data_platform_catalogue.entities import (
     AccessInformation,
     Chart,
@@ -18,12 +19,71 @@ from home.service.details import (
     DashboardDetailsService,
     DatabaseDetailsService,
     DatasetDetailsService,
+    _parse_parent,
+    is_access_requirements_a_url,
 )
 from tests.conftest import (
     generate_dashboard_metadata,
     generate_database_metadata,
     generate_table_metadata,
 )
+
+
+@pytest.mark.parametrize(
+    "input, expected_output",
+    [
+        (
+            {
+                RelationshipType.PARENT: [
+                    EntitySummary(
+                        entity_ref=EntityRef(urn="urn:li:db", display_name="db"),
+                        description="test",
+                        entity_type="database",
+                        tags=[],
+                    )
+                ]
+            },
+            EntityRef(urn="urn:li:db", display_name="db"),
+        ),
+        ({}, None),
+        (
+            {
+                RelationshipType.DATA_LINEAGE: [
+                    EntitySummary(
+                        entity_ref=EntityRef(urn="urn:li:db", display_name="db"),
+                        description="test",
+                        entity_type="database",
+                        tags=[],
+                    )
+                ]
+            },
+            None,
+        ),
+    ],
+)
+def test_parse_parent(input, expected_output):
+    result = _parse_parent(input)
+    assert result == expected_output
+
+
+@pytest.mark.parametrize(
+    "input, expected_output",
+    [
+        ("122", False),
+        ("https://test.gov.uk", True),
+        ("https://test.gov.uk/data/#readme", True),
+        ("http://test.co.uk", True),
+        ("ftp.example.com/how-to-access.txt", False),
+        ("Just some instructions", False),
+        ("", False),
+        (123, False),
+        (None, False),
+        (["https://test.gov.uk"], False),
+    ],
+)
+def test_is_access_requirements_a_url(input, expected_output):
+    result = is_access_requirements_a_url(input)
+    assert result == expected_output
 
 
 class TestDatasetDetailsService:
@@ -156,6 +216,7 @@ class TestChartDetailsService:
             "parent_entity": None,
             "parent_type": "dashboard",
             "h1_value": "test",
+            "is_access_requirements_url": False,
         }
 
         assert context == expected

--- a/tests/home/service/test_details.py
+++ b/tests/home/service/test_details.py
@@ -216,7 +216,7 @@ class TestChartDetailsService:
             "parent_entity": None,
             "parent_type": "dashboard",
             "h1_value": "test",
-            "is_access_requirements_url": False,
+            "is_access_requirements_a_url": False,
         }
 
         assert context == expected

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -84,6 +84,9 @@ class DatabaseDetailsPage(Page):
     def table_link(self):
         return self.selenium.find_element(By.LINK_TEXT, "Table details")
 
+    def request_access(self):
+        return self.selenium.find_element(By.ID, "request-access")
+
 
 class TableDetailsPage(Page):
     def column_descriptions(self):

--- a/tests/selenium/test_details_contact_contents.py
+++ b/tests/selenium/test_details_contact_contents.py
@@ -1,0 +1,79 @@
+import pytest
+from data_platform_catalogue.entities import AccessInformation, CustomEntityProperties
+
+from tests.conftest import (
+    generate_database_metadata,
+    mock_get_database_details_response,
+)
+
+
+@pytest.mark.slow
+class TestDetailsPageContactDetails:
+    """
+    Given I am in a details page
+    When I view the content of the contact information
+    Then I should be presented with corrently formated information. A link
+    if the request access section is a url, the given free text or if nothing
+    given the default text for request access.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        live_server,
+        selenium,
+        details_database_page,
+    ):
+        self.selenium = selenium
+        self.live_server_url = live_server.url
+        self.details_database_page = details_database_page
+
+    @pytest.mark.parametrize(
+        "access_reqs, expected_text, expected_tag",
+        [
+            (
+                "https://place-to-get-your-access.com",
+                "Click link for access information (opens in new tab)",
+                "a",
+            ),
+            (
+                "To access these data you need to seek permission from the data owner by email",
+                "To access these data you need to seek permission from the data owner by email",
+                "p",
+            ),
+            (
+                "",
+                "Processing the data might require permission from the Data owner.",
+                "p",
+            ),
+        ],
+    )
+    def test_access_requirements_content(
+        self, mock_catalogue, access_reqs, expected_text, expected_tag
+    ):
+        """
+        test that what is displayed in the request action section of contacts is what we expect
+        e.g.
+        1 - a sole link given is rendered as a hyperlink with standard link text
+        2 - some other specific free text held in the access_requirements custom property is
+        shown as given
+        3 - where no access_requirements custom property exists default to the standrd line
+        """
+        test_database = generate_database_metadata(
+            custom_properties=CustomEntityProperties(
+                access_information=AccessInformation(access_requirements=access_reqs)
+            )
+        )
+        mock_get_database_details_response(mock_catalogue, test_database)
+
+        self.start_on_the_details_page()
+
+        request_access_metadata = self.details_database_page.request_access()
+
+        assert request_access_metadata.text == expected_text
+        assert request_access_metadata.tag_name == expected_tag
+
+    def start_on_the_details_page(self):
+        self.selenium.get(
+            f"{self.live_server_url}/details/database/urn:li:container:test"
+        )

--- a/tests/selenium/test_primary_nav.py
+++ b/tests/selenium/test_primary_nav.py
@@ -37,7 +37,7 @@ class TestPrimaryNav:
         assert self.selenium.title in self.page_titles
         heading_text = self.home_page.primary_heading().text
 
-        assert heading_text == "Find MOJ data"
+        assert heading_text == "Find MoJ data"
         assert self.selenium.title.split("-")[0].strip() == "Home"
 
     def click_on_the_glossary_link(self):

--- a/tests/selenium/test_search_and_browse_from_homepage.py
+++ b/tests/selenium/test_search_and_browse_from_homepage.py
@@ -62,7 +62,7 @@ class TestSearchAndBrowseFromHomepage:
         assert self.selenium.title in self.page_titles
         heading_text = self.home_page.primary_heading().text
 
-        assert heading_text == "Find MOJ data"
+        assert heading_text == "Find MoJ data"
         assert self.selenium.title.split("-")[0].strip() == "Home"
 
     def verify_i_am_on_the_search_page(self):


### PR DESCRIPTION
PR updates the contacts partial template to the agreed improved contact design.

- The contact partial template now applies some logic within the template to render the appropriate link/text dependent on the value in the `access_requirements` custom property:
  1. a sole link given is rendered as a hyperlink with standard link text
  2. some other specific free text held in the access_requirements custom property is
  shown as given
  3. where no access_requirements custom property exists default to the standard line
- Amends some values in the new copy file and adds in new request access hyperlink text
- Adds a new function `is_access_requirements_a_url()` to details service to indicate whether the `access_requirements` custom property value is a url.
- Adds a new selenium test to make sure trhe logic is correctly rendered on the details page.
- And a unit test for the `is_access_requirements_a_url` function (and another unit test for `_parse_parent()` that wasn't added before - my bad)
- Also updated the tests workflow to compile messages as where these have changed they were not picked up by selenium tests

Kind of related as will populate the request access for all cadet models with a default but sensible link - i've done this PR but it has not been picked up https://github.com/moj-analytical-services/create-a-derived-table/pull/1883

Maybe Jake HP will have a look when he is back on 07/08 though

If you want to look at it either by deploying or running the branch locally - in the dev env i have added a test_pk table where i have put the link i've got in the above PR for the cadet request access default link