### PR TITLE
Standardise MoJ header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ ENV VIRTUAL_ENV=/app/.venv \
 # copy project and dependencies
 COPY . .
 COPY --from=builder /app/static ./static
+COPY --from=builder /app/locale ./locale
 COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 RUN chmod +x ./scripts/app-entrypoint.sh

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Find MoJ data\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-07 11:51+0100\n"
+"POT-Creation-Date: 2024-08-07 14:56+0100\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -43,7 +43,7 @@ msgid "Chart"
 msgstr "Chart"
 
 # Page title
-#: home/service/glossary.py:61 templates/base/navigation.html:70
+#: home/service/glossary.py:61 templates/base/navigation.html:72
 msgid "Glossary"
 msgstr "Glossary"
 
@@ -53,13 +53,13 @@ msgid "Metadata specification"
 msgstr "Metadata specification"
 
 # Page title
-#: home/service/search.py:170 templates/base/navigation.html:65
+#: home/service/search.py:170 templates/base/navigation.html:67
 #: templates/details_base.html:14
 msgid "Search"
 msgstr "Search"
 
 # Page title
-#: home/views.py:25 templates/base/navigation.html:60
+#: home/views.py:25 templates/base/navigation.html:62
 msgid "Home"
 msgstr "Home"
 
@@ -153,13 +153,17 @@ msgstr ""
 "<a class=\"govuk-footer__link govuk-footer__copyright-logo\" "
 "href=\"%(href)s\">© Crown copyright</a>"
 
+#: templates/base/navigation.html:15
+msgid "Ministry of Justice"
+msgstr "Ministry of Justice"
+
 # Service name - note the capitalisation
-#: templates/base/navigation.html:16 templates/home.html:11
+#: templates/base/navigation.html:18 templates/home.html:11
 msgid "Find MOJ data"
 msgstr "Find MoJ data"
 
 # Header link
-#: templates/base/navigation.html:34
+#: templates/base/navigation.html:36
 msgid "Sign out"
 msgstr "Sign out"
 

--- a/templates/base/navigation.html
+++ b/templates/base/navigation.html
@@ -12,6 +12,8 @@
 
       </svg>
 
+      <a class="moj-header__link moj-header__link--organisation-name" href="#">{% translate "Ministry of Justice" %}</a>
+
       <span class="moj-header__link moj-header__link--service-name">
         <a href="{% url 'home:home' %}">{% translate "Find MOJ data" %}</a>
         {% if ENV == "dev" or ENV is None %}&nbsp;


### PR DESCRIPTION
Add organisation name back in to match
https://design-patterns.service.justice.gov.uk/components/header/

Before:
<img width="1703" alt="Screenshot 2024-08-07 at 15 00 22" src="https://github.com/user-attachments/assets/df398265-c668-4a9f-b0a1-271deb82d0b1">

After:
<img width="1693" alt="Screenshot 2024-08-07 at 15 02 53" src="https://github.com/user-attachments/assets/28aac70d-09c4-47ff-a790-03ffaa34d6fc">
