### PR TITLE
fmd-648 - Hide Glossary from home page

### DIFF
--- a/templates/base/navigation.html
+++ b/templates/base/navigation.html
@@ -56,7 +56,6 @@
         <ul class="moj-primary-navigation__list">
           {% url 'home:home' as home_url %}
           {% url 'home:search' as search_url %}
-          {% url 'home:glossary' as glossary_url %}
           <li class="moj-primary-navigation__item">
             <a class="moj-primary-navigation__link" href="{% url 'home:home' %}" {% if request.path == home_url %}aria-current="page"{% endif %}>
               {% translate "Home" %}
@@ -67,12 +66,6 @@
               {% translate "Search" %}
             </a>
           </li>
-          <li class="moj-primary-navigation__item">
-            <a class="moj-primary-navigation__link" href="{% url 'home:glossary' %}" {% if request.path == glossary_url %}aria-current="page"{% endif %}>
-              {% translate "Glossary" %}
-            </a>
-          </li>
-
         </ul>
 
       </nav>

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -100,9 +100,6 @@ class HomePage(Page):
     def search_nav_link(self) -> WebElement:
         return self.selenium.find_element(By.LINK_TEXT, "Search")
 
-    def glossary_nav_link(self) -> WebElement:
-        return self.selenium.find_element(By.LINK_TEXT, "Glossary")
-
     def search_bar(self) -> WebElement:
         return self.selenium.find_element(By.NAME, "query")
 
@@ -117,10 +114,6 @@ class HomePage(Page):
         if not result:
             raise Exception(f"{domain!r} not found in {all_domain_names!r}")
         return result
-
-
-class GlossaryPage(Page):
-    pass
 
 
 class SearchResultWrapper:
@@ -259,11 +252,6 @@ def table_details_page(selenium) -> TableDetailsPage:
 
 
 @pytest.fixture
-def glossary_page(selenium) -> GlossaryPage:
-    return GlossaryPage(selenium)
-
-
-@pytest.fixture
 def page_titles():
-    pages = ["Home", "Search", "Glossary"]
+    pages = ["Home", "Search",]
     return [f"{page} - Find MOJ data - GOV.UK" for page in pages]

--- a/tests/integration/test_primary_nav.py
+++ b/tests/integration/test_primary_nav.py
@@ -14,7 +14,6 @@ class TestPrimaryNav:
         live_server,
         selenium,
         home_page,
-        glossary_page,
         chromedriver_path,
         axe_version,
         page_titles,
@@ -22,15 +21,9 @@ class TestPrimaryNav:
         self.selenium = selenium
         self.live_server_url = live_server.url
         self.home_page = home_page
-        self.glossary_page = glossary_page
         self.chromedriver_path = chromedriver_path
         self.page_titles = page_titles
         self.axe_version = axe_version
-
-    def test_glossary_link_from_homepage_works(self):
-        self.start_on_the_home_page()
-        self.click_on_the_glossary_link()
-        self.verify_i_am_on_the_glossary_page()
 
     def start_on_the_home_page(self):
         self.selenium.get(f"{self.live_server_url}")
@@ -40,11 +33,3 @@ class TestPrimaryNav:
         assert heading_text == "Find MoJ data"
         assert self.selenium.title.split("-")[0].strip() == "Home"
 
-    def click_on_the_glossary_link(self):
-        self.home_page.glossary_nav_link().click()
-
-    def verify_i_am_on_the_glossary_page(self):
-        assert self.selenium.title in self.page_titles
-        heading_text = self.glossary_page.primary_heading().text
-
-        assert heading_text == self.selenium.title.split("-")[0].strip()


### PR DESCRIPTION
Hide glossary from home page:

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/eeb89ede-bbb8-4314-a9ee-d7b37c7592ae">
