### PR TITLE
Missing metadata placeholders

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Find MoJ data\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-07 14:56+0100\n"
+"POT-Creation-Date: 2024-08-08 16:39+0100\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -43,7 +43,7 @@ msgid "Chart"
 msgstr "Chart"
 
 # Page title
-#: home/service/glossary.py:61 templates/base/navigation.html:72
+#: home/service/glossary.py:61
 msgid "Glossary"
 msgstr "Glossary"
 
@@ -53,13 +53,13 @@ msgid "Metadata specification"
 msgstr "Metadata specification"
 
 # Page title
-#: home/service/search.py:170 templates/base/navigation.html:67
+#: home/service/search.py:170 templates/base/navigation.html:66
 #: templates/details_base.html:14
 msgid "Search"
 msgstr "Search"
 
 # Page title
-#: home/views.py:25 templates/base/navigation.html:62
+#: home/views.py:25 templates/base/navigation.html:61
 msgid "Home"
 msgstr "Home"
 
@@ -187,6 +187,10 @@ msgstr "First created:"
 #: templates/details_base.html:61
 msgid "Last updated:"
 msgstr "Last updated:"
+
+#: templates/details_base.html:72
+msgid "Not provided"
+msgstr "Not provided."
 
 # Metadata field
 #: templates/details_base.html:73 templates/partial/search_result.html:40
@@ -479,7 +483,7 @@ msgid "Database:"
 msgstr "Database:"
 
 # Search result metadata
-#: templates/partial/search_result.html:64
+#: templates/partial/search_result.html:65
 msgid "Matched fields:"
 msgstr "Matched fields:"
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Find MoJ data\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-08 16:39+0100\n"
+"POT-Creation-Date: 2024-08-08 16:54+0100\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -188,14 +188,14 @@ msgstr "First created:"
 msgid "Last updated:"
 msgstr "Last updated:"
 
-#: templates/details_base.html:72
-msgid "Not provided"
-msgstr "Not provided."
-
 # Metadata field
-#: templates/details_base.html:73 templates/partial/search_result.html:40
+#: templates/details_base.html:72 templates/partial/search_result.html:40
 msgid "Domain:"
 msgstr "Domain:"
+
+#: templates/details_base.html:73 templates/partial/search_result.html:41
+msgid "Not provided"
+msgstr "Not provided."
 
 # Contact info heading
 #: templates/details_chart.html:8
@@ -376,12 +376,12 @@ msgid "Processing the data might require permission from IAO or Data owner."
 msgstr "Processing the data might require permission from the Data owner."
 
 # Heading
-#: templates/partial/contact_info.html:21
+#: templates/partial/contact_info.html:20
 msgid "Contact channels for questions"
 msgstr "Contact channels for questions"
 
 # Heading
-#: templates/partial/contact_info.html:29
+#: templates/partial/contact_info.html:32
 msgid "IAO or Data Owner"
 msgstr "Data owner"
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Find MoJ data\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-08 16:54+0100\n"
+"POT-Creation-Date: 2024-08-12 13:45+0100\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -193,7 +193,8 @@ msgstr "Last updated:"
 msgid "Domain:"
 msgstr "Domain:"
 
-#: templates/details_base.html:73 templates/partial/search_result.html:41
+#: templates/details_base.html:73 templates/partial/contact_info.html:36
+#: templates/partial/search_result.html:41
 msgid "Not provided"
 msgstr "Not provided."
 
@@ -366,22 +367,25 @@ msgid "Access requirements"
 msgstr "Request access"
 
 # Request access link
-#: templates/partial/contact_info.html:8
+#: templates/partial/contact_info.html:7
 msgid "Click link for access information (opens in new tab)"
 msgstr "Click link for access information (opens in new tab)"
 
-# Default text for contact info
-#: templates/partial/contact_info.html:13
-msgid "Processing the data might require permission from IAO or Data owner."
-msgstr "Processing the data might require permission from the Data owner."
+#: templates/partial/contact_info.html:12
+msgid "Please use contact channels to request access."
+msgstr "Please use contact channels to request access."
+
+#: templates/partial/contact_info.html:14
+msgid "Please contact the data owner for access information."
+msgstr "Please contact the data owner for access information."
 
 # Heading
-#: templates/partial/contact_info.html:20
+#: templates/partial/contact_info.html:22
 msgid "Contact channels for questions"
 msgstr "Contact channels for questions"
 
 # Heading
-#: templates/partial/contact_info.html:32
+#: templates/partial/contact_info.html:34
 msgid "IAO or Data Owner"
 msgstr "Data owner"
 

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -68,12 +68,10 @@
                 {{entity.custom_properties.data_summary.refresh_period}}
               </li>
             {% endif %}
-            {% if entity.domain %}
-              <li>
-                <span class="govuk-!-font-weight-bold">{% translate "Domain:" %}</span>
-                {{entity.domain.display_name}}
-              </li>
-            {% endif %}
+            <li>
+              <span class="govuk-!-font-weight-bold">{% translate "Domain:" %}</span>
+              {{entity.domain.display_name | default:_('Not provided') }}
+            </li>
             {% switch 'display-result-tags' %}
               {% if entity.tags_to_display %}
                 <li>

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -2,32 +2,33 @@
 
 <div class="govuk-body">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Access requirements" %}</h2>
-  <p class="govuk-body">
-    {% if access_requirements %}
-      {% if is_access_url %}
-        <a id="request-access" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{% translate "Click link for access information (opens in new tab)" %}</a><br>
-      {% else %}
-        <p id="request-access">{{ access_requirements }} </p>
-      {% endif %}
+  {% if access_requirements %}
+    {% if is_access_url %}
+      <p class="govuk-body"><a id="request-access" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{% translate "Click link for access information (opens in new tab)" %}</a></p>
     {% else %}
-      <p id="request-access"> {% translate "Processing the data might require permission from IAO or Data owner." %} </p>
-
+      <p id="request-access">{{ access_requirements }} </p>
     {% endif %}
-  </p>
+  {% else %}
+    <p id="request-access"> {% translate "Processing the data might require permission from IAO or Data owner." %} </p>
+  {% endif %}
 </div>
 <!-- placeholder until we have more contact channels than just slack -->
 {% if slack_channel.dc_slack_channel_url %}
   <div class="govuk-body">
     <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Contact channels for questions" %}</h2>
     <p class="govuk-body">
+      {% if slack_channel %}
         <!-- This should become a list of populated contact channels -->
-      Slack channel: <a href="{{ slack_channel.dc_slack_channel_url }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ slack_channel.dc_slack_channel_name }} (opens in new tab)</a>
+        Slack channel: <a href="{{ slack_channel.dc_slack_channel_url }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ slack_channel.dc_slack_channel_name }} (opens in new tab)</a>
+      {% else %}
+        {% translate 'Not provided'}
+      {% endif %}
     </p>
   </div>
 {% endif %}
 <div class="govuk-body">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "IAO or Data Owner" %}</h2>
   <p class="govuk-body">
-    {{ data_owner_email|urlize }}
+    {{ data_owner_email|urlize|default:_('Not provided') }}
   </p>
 </div>

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -8,8 +8,12 @@
     {% else %}
       <p id="request-access">{{ access_requirements }} </p>
     {% endif %}
+  {% elif slack_channel.dc_slack_channel_url %}
+    <p id="request-access">{% translate "Please use contact channels to request access." %}</p>
+  {% elif data_owner_email %}
+    <p id="request-access">{% translate "Please contact the data owner for access information." %}</p>
   {% else %}
-    <p id="request-access"> {% translate "Processing the data might require permission from IAO or Data owner." %} </p>
+    <p id="request-access"> {% translate "Not provided" %} </p>
   {% endif %}
 </div>
 <!-- placeholder until we have more contact channels than just slack -->

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -38,7 +38,7 @@
         <ul class="govuk-list govuk-body" id="metadata-property-list">
           <li>
             <span class="govuk-!-font-weight-bold">{% translate "Domain:" %}</span>
-            <span>{{result.metadata.domain_name}}</span>
+            <span>{{result.metadata.domain_name | default:_('Not provided')}}</span>
           </li>
           {% if result.result_type.name == "TABLE" %}
             <li>

--- a/tests/integration/test_details_contact_contents.py
+++ b/tests/integration/test_details_contact_contents.py
@@ -1,5 +1,10 @@
 import pytest
-from data_platform_catalogue.entities import AccessInformation, CustomEntityProperties
+from data_platform_catalogue.entities import (
+    AccessInformation,
+    CustomEntityProperties,
+    FurtherInformation,
+    OwnerRef,
+)
 
 from tests.conftest import (
     generate_database_metadata,
@@ -41,15 +46,14 @@ class TestDetailsPageContactDetails:
                 "To access these data you need to seek permission from the data owner by email",
                 "p",
             ),
-            (
-                "",
-                "Processing the data might require permission from the Data owner.",
-                "p",
-            ),
         ],
     )
     def test_access_requirements_content(
-        self, mock_catalogue, access_reqs, expected_text, expected_tag
+        self,
+        mock_catalogue,
+        access_reqs,
+        expected_text,
+        expected_tag,
     ):
         """
         test that what is displayed in the request action section of contacts is what we expect
@@ -61,9 +65,12 @@ class TestDetailsPageContactDetails:
         """
         test_database = generate_database_metadata(
             custom_properties=CustomEntityProperties(
-                access_information=AccessInformation(dc_access_requirements=access_reqs)
+                access_information=AccessInformation(
+                    dc_access_requirements=access_reqs
+                ),
             )
         )
+
         mock_get_database_details_response(mock_catalogue, test_database)
 
         self.start_on_the_details_page()
@@ -72,6 +79,75 @@ class TestDetailsPageContactDetails:
 
         assert request_access_metadata.text == expected_text
         assert request_access_metadata.tag_name == expected_tag
+
+    @pytest.mark.parametrize(
+        "access_reqs, slack_channel, owner, expected_text",
+        [
+            (
+                "Some contact info",
+                "#contact us",
+                "meta.data@justice.gov.uk",
+                "Some contact info",
+            ),
+            (
+                "",
+                "#contact_us",
+                "meta.data@justice.gov.uk",
+                "Please use contact channels to request access.",
+            ),
+            (
+                "",
+                "",
+                "meta.data@justice.gov.uk",
+                "Please contact the data owner for access information.",
+            ),
+            (
+                "",
+                "",
+                "",
+                "Not provided.",
+            ),
+        ],
+    )
+    def test_access_requirements_fallbacks(
+        self, mock_catalogue, access_reqs, slack_channel, owner, expected_text
+    ):
+        """
+        If no access requirements are given, users should use the contact info,
+        if provided. If not, then they should contact the data owner.
+        If none of the information is provided, then the catalogue entry is
+        non-functional - we should prevent this happening at ingestion time
+        or before.
+        """
+        test_database = generate_database_metadata(
+            custom_properties=CustomEntityProperties(
+                access_information=AccessInformation(
+                    dc_access_requirements=access_reqs
+                ),
+            )
+        )
+
+        if owner:
+            test_database.governance.data_owner = OwnerRef(
+                display_name=owner, email=owner, urn="urn:bla"
+            )
+        else:
+            test_database.governance.data_owner.display_name = ""
+            test_database.governance.data_owner.email = ""
+
+        if slack_channel:
+            test_database.custom_properties.further_information = FurtherInformation(
+                dc_slack_channel_name=slack_channel,
+                dc_slack_channel_url="http://bla.com",
+            )
+
+        mock_get_database_details_response(mock_catalogue, test_database)
+
+        self.start_on_the_details_page()
+
+        request_access_metadata = self.details_database_page.request_access()
+
+        assert request_access_metadata.text == expected_text
 
     def start_on_the_details_page(self):
         self.selenium.get(


### PR DESCRIPTION
Add some placeholder text if required metadata is missing for any reason.

Part of https://github.com/ministryofjustice/find-moj-data/issues/601

This text is provisional for now. I added two extra fallbacks for missing access info:
1. If contact info exists, direct users to that
2. otherwise, if there is a data owner, they could ask the data owner

This info *should* be mandatory in order for the asset to be displayed in the catalogue. But at the moment we have some gaps.

![Screenshot 2024-08-08 at 17 02 57](https://github.com/user-attachments/assets/8499d16f-9928-4f75-8942-942177cf5bc6)
![Screenshot 2024-08-08 at 17 03 30](https://github.com/user-attachments/assets/2e48bb65-d3e4-4769-9b0e-08bdcfe33532)
![Screenshot 2024-08-08 at 17 03 40](https://github.com/user-attachments/assets/2af74f72-56b3-42fe-b4ea-d7e6e3ed4dd0)
