### PR TITLE
fix(Makefile): escape $ when launching a subshell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,7 @@ unit:
 
 # Run integration tests. Requires chromedriver - version works with chromedriver 127.0.1 use - `npm install -g chromedriver@127.0.1`
 integration:
-	export CHROMEDRIVER_PATH=$(which chromedriver)
-	poetry run pytest tests/integration --axe-version 4.9.1 --chromedriver-path ${CHROMEDRIVER_PATH}
-
+	poetry run pytest tests/integration --axe-version 4.9.1 --chromedriver-path $$(which chromedriver)
 
 # Clean up (optional)
 clean:


### PR DESCRIPTION
The chromedriver variable wasn't set correctly due to Makefile quirks.

1. Each line of a makefile task runs in a separate shell, so exports need to be part of the same pipeline as the command that reads them, or be exported by Make itself via a top level `export` directive.

2. $(bla) is interpreted as a makefile variable, so we need to escape the $ for it to actually run a command.