### PR TITLE
Remove ingress rules for the old domain

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           status: ${{ github.event.workflow_run.conclusion }}
           notification_title: "Deployment Successful"
-          message_format: ":rocket: <https://data-platform-find-moj-data-preprod.apps.live.cloud-platform.service.justice.gov.uk/|New Preproduction Deployment>"
+          message_format: ":rocket: <https://preprod.find-moj-data.service.justice.gov.uk/|New Preproduction Deployment>"
           footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_DATA_CATALOGUE }}
@@ -74,7 +74,7 @@ jobs:
         with:
           status: ${{ github.event.workflow_run.conclusion }}
           notification_title: "Deployment Successful"
-          message_format: ":rocket: <https://data-platform-find-moj-data-prod.apps.live.cloud-platform.service.justice.gov.uk/|New Production Deployment>"
+          message_format: ":rocket: <https://find-moj-data.service.justice.gov.uk/|New Production Deployment>"
           footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_ASK_DATA_CATALOGUE }}

--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -14,21 +14,9 @@ spec:
   ingressClassName: modsec
   tls:
     - hosts:
-        - ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
-    - hosts:
         - ${EXTERNAL_DOMAIN_PREFIX}find-moj-data.service.justice.gov.uk
       secretName: find-moj-data-cert # pragma: allowlist secret
   rules:
-    - host: ${NAMESPACE}.apps.live.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: find-moj-data-service # this should match the metadata.name in service.yml
-                port:
-                  number: 80
     - host: ${EXTERNAL_DOMAIN_PREFIX}find-moj-data.service.justice.gov.uk
       http:
         paths:


### PR DESCRIPTION
The service is now on find-moj-data.service.justice.gov.uk, so everything should be using that.

The old domain is not functional anymore because the app is configured to use the new URL as the Oauth redirect_uri, meaning EntraID will redirect to the *new* origin but the app will expect cookies that were set on the *old* origin.