### PR TITLE
return tags in dataset parent relationships

### DIFF
--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getDatasetDetails.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getDatasetDetails.graphql
@@ -72,6 +72,14 @@ query getDatasetDetails($urn: String!) {
             properties {
               name
             }
+            tags {
+              tags {
+                tag{urn}
+              }
+            }
+            subTypes {
+              typeNames
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes a small bug which was resulting in databases not being displayed in thew table detail breadcrumbs