### PR TITLE
Better defaults for contact info panel

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -383,7 +383,7 @@ msgstr "Contact the data owner to request access."
 # Heading
 #: templates/partial/contact_info.html:22
 msgid "Contact channels for questions"
-msgstr "Contact channels for questions"
+msgstr "Ask a question"
 
 # Heading
 #: templates/partial/contact_info.html:28
@@ -593,14 +593,3 @@ msgstr "first name"
 #: users/models.py:12
 msgid "last name"
 msgstr "last name"
-
-# Column heading
-#~ msgid "Schema details"
-#~ msgstr "Schema details"
-
-# Heading
-#~ msgid "Table details"
-#~ msgstr "Table details"
-
-#~ msgid "Please use contact channels to request access."
-#~ msgstr "Please use contact channels to request access."

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -392,7 +392,7 @@ msgstr "Please use contact channels to request access."
 
 #: templates/partial/contact_info.html:14
 msgid "Please contact the data owner for access information."
-msgstr "Please contact the data owner for access information."
+msgstr "Contact the data owner to request access."
 
 # Heading
 #: templates/partial/contact_info.html:22

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Find MoJ data\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-15 11:07+0100\n"
+"POT-Creation-Date: 2024-08-19 10:23+0100\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -101,7 +101,7 @@ msgid "Search"
 msgstr "Search"
 
 # Page title
-#: home/views.py:25 templates/base/navigation.html:64
+#: home/views.py:27 templates/base/navigation.html:64
 msgid "Home"
 msgstr "Home"
 
@@ -239,8 +239,8 @@ msgstr "Last updated:"
 msgid "Domain:"
 msgstr "Subject area:"
 
-#: templates/details_base.html:73 templates/partial/contact_info.html:16
-#: templates/partial/contact_info.html:36
+#: templates/details_base.html:73 templates/partial/contact_info.html:15
+#: templates/partial/contact_info.html:30
 #: templates/partial/search_result.html:41
 msgid "Not provided"
 msgstr "Not provided."
@@ -282,7 +282,7 @@ msgid "Justice Data (opens in new tab)"
 msgstr "Justice Data (opens in new tab)"
 
 # Heading
-#: templates/details_database.html:10 templates/details_database.html:37
+#: templates/details_database.html:10 templates/details_database.html:35
 msgid "Database content"
 msgstr "Database content"
 
@@ -291,18 +291,8 @@ msgstr "Database content"
 msgid "Table name"
 msgstr "Table name"
 
-# Column heading
-#: templates/details_database.html:15
-msgid "Schema details"
-msgstr "Schema details"
-
-# Heading
-#: templates/details_database.html:30
-msgid "Table details"
-msgstr "Table details"
-
 # Text for databases without any tables
-#: templates/details_database.html:38
+#: templates/details_database.html:36
 msgid "This database is missing table information."
 msgstr "This database is missing table information."
 
@@ -382,15 +372,11 @@ msgid "Access requirements"
 msgstr "Request access"
 
 # Request access link
-#: templates/partial/contact_info.html:7
+#: templates/partial/contact_info.html:8
 msgid "Click link for access information (opens in new tab)"
 msgstr "Click link for access information (opens in new tab)"
 
-#: templates/partial/contact_info.html:12
-msgid "Please use contact channels to request access."
-msgstr "Please use contact channels to request access."
-
-#: templates/partial/contact_info.html:14
+#: templates/partial/contact_info.html:13
 msgid "Please contact the data owner for access information."
 msgstr "Contact the data owner to request access."
 
@@ -400,9 +386,25 @@ msgid "Contact channels for questions"
 msgstr "Contact channels for questions"
 
 # Heading
-#: templates/partial/contact_info.html:34
+#: templates/partial/contact_info.html:28
+msgid "Contact the data owner with questions."
+msgstr "Contact the data owner with questions."
+
+# Heading
+#: templates/partial/contact_info.html:36
 msgid "IAO or Data Owner"
 msgstr "Data owner"
+
+# Contact us link on error pages
+#: templates/partial/contact_info.html:41
+msgid ""
+"Not provided - <a href=\"https://moj.enterprise.slack.com/archives/"
+"C06NPM2200N\" class=\"govuk-link\">contact the Data Catalogue team</a> about this "
+"data."
+msgstr ""
+"Not provided - <a href=\"https://moj.enterprise.slack.com/archives/"
+"C06NPM2200N\" class=\"govuk-link\">contact the Data Catalogue team</a> about this "
+"data."
 
 # Contact us link on error pages
 #: templates/partial/contact_team.html:4
@@ -591,3 +593,14 @@ msgstr "first name"
 #: users/models.py:12
 msgid "last name"
 msgstr "last name"
+
+# Column heading
+#~ msgid "Schema details"
+#~ msgstr "Schema details"
+
+# Heading
+#~ msgid "Table details"
+#~ msgstr "Table details"
+
+#~ msgid "Please use contact channels to request access."
+#~ msgstr "Please use contact channels to request access."

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -2,35 +2,43 @@
 
 <div class="govuk-body">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Access requirements" %}</h2>
-  {% if access_requirements %}
-    {% if is_access_url %}
-      <p class="govuk-body"><a id="request-access" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{% translate "Click link for access information (opens in new tab)" %}</a></p>
+  <p id="request_access" class="govuk-body">
+    {% if access_requirements %}
+      {% if is_access_url %}
+        <a href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{% translate "Click link for access information (opens in new tab)" %}</a>
+      {% else %}
+        {{ access_requirements }}
+      {% endif %}
+    {% elif data_owner_email %}
+      {% translate "Please contact the data owner for access information." %}
     {% else %}
-      <p id="request-access">{{ access_requirements }} </p>
+      {% translate "Not provided" %}
     {% endif %}
-  {% elif data_owner_email %}
-    <p id="request-access">{% translate "Please contact the data owner for access information." %}</p>
-  {% else %}
-    <p id="request-access"> {% translate "Not provided" %} </p>
-  {% endif %}
+  </p>
 </div>
 <!-- placeholder until we have more contact channels than just slack -->
-{% if slack_channel.dc_slack_channel_url %}
-  <div class="govuk-body">
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Contact channels for questions" %}</h2>
-    <p class="govuk-body">
-      {% if slack_channel %}
-        <!-- This should become a list of populated contact channels -->
-        Slack channel: <a href="{{ slack_channel.dc_slack_channel_url }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ slack_channel.dc_slack_channel_name }} (opens in new tab)</a>
-      {% else %}
-        {% translate 'Not provided'}
-      {% endif %}
-    </p>
-  </div>
-{% endif %}
+
+<div class="govuk-body">
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Contact channels for questions" %}</h2>
+  <p id="contact_channels" class="govuk-body">
+    {% if slack_channel.dc_slack_channel_url %}
+      <!-- This should become a list of populated contact channels -->
+      Slack channel: <a href="{{ slack_channel.dc_slack_channel_url }}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ slack_channel.dc_slack_channel_name }} (opens in new tab)</a>
+    {% elif data_owner_email %}
+      {% translate "Contact the data owner with questions." %}
+    {% else %}
+      {% translate 'Not provided' %}
+    {% endif %}
+  </p>
+</div>
+
 <div class="govuk-body">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "IAO or Data Owner" %}</h2>
-  <p class="govuk-body">
-    {{ data_owner_email|urlize|default:_('Not provided') }}
+  <p id="data_owner" class="govuk-body">
+    {% if data_owner_email %}
+      {{ data_owner_email|urlize }}
+    {% else %}
+      {% blocktranslate %}Not provided - <a href="https://moj.enterprise.slack.com/archives/C06NPM2200N" class="govuk-link">contact the Data Catalogue team</a> about this data.{% endblocktranslate %}
+    {% endif %}
   </p>
 </div>

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -8,8 +8,6 @@
     {% else %}
       <p id="request-access">{{ access_requirements }} </p>
     {% endif %}
-  {% elif slack_channel.dc_slack_channel_url %}
-    <p id="request-access">{% translate "Please use contact channels to request access." %}</p>
   {% elif data_owner_email %}
     <p id="request-access">{% translate "Please contact the data owner for access information." %}</p>
   {% else %}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -71,7 +71,18 @@ class Page:
         return self.selenium.find_element(By.TAG_NAME, "h1")
 
 
-class DatabaseDetailsPage(Page):
+class DetailsPage(Page):
+    def request_access(self):
+        return self.selenium.find_element(By.ID, "request_access")
+
+    def contact_channels(self):
+        return self.selenium.find_element(By.ID, "contact_channels")
+
+    def data_owner(self):
+        return self.selenium.find_element(By.ID, "data_owner")
+
+
+class DatabaseDetailsPage(DetailsPage):
     def primary_heading(self):
         return self.selenium.find_element(By.TAG_NAME, "h1")
 
@@ -86,11 +97,8 @@ class DatabaseDetailsPage(Page):
             By.CSS_SELECTOR, ".govuk-table tr td:first-child a"
         )
 
-    def request_access(self):
-        return self.selenium.find_element(By.ID, "request-access")
 
-
-class TableDetailsPage(Page):
+class TableDetailsPage(DetailsPage):
     def column_descriptions(self):
         return [
             c.text

--- a/tests/integration/test_details_contact_contents.py
+++ b/tests/integration/test_details_contact_contents.py
@@ -93,13 +93,13 @@ class TestDetailsPageContactDetails:
                 "",
                 "#contact_us",
                 "meta.data@justice.gov.uk",
-                "Please use contact channels to request access.",
+                "Contact the data owner to request access.",
             ),
             (
                 "",
                 "",
                 "meta.data@justice.gov.uk",
-                "Please contact the data owner for access information.",
+                "Contact the data owner to request access.",
             ),
             (
                 "",

--- a/tests/integration/test_details_contact_contents.py
+++ b/tests/integration/test_details_contact_contents.py
@@ -2,6 +2,7 @@ import pytest
 from data_platform_catalogue.entities import (
     AccessInformation,
     CustomEntityProperties,
+    Database,
     FurtherInformation,
     OwnerRef,
 )
@@ -33,27 +34,36 @@ class TestDetailsPageContactDetails:
         self.live_server_url = live_server.url
         self.details_database_page = details_database_page
 
+    @pytest.fixture
+    def database(self) -> Database:
+        result = generate_database_metadata()
+
+        # Blank out owner
+        result.governance.data_owner.email = ""
+        result.governance.data_owner.display_name = ""
+
+        return result
+
+    def start_on_the_details_page(self):
+        self.selenium.get(
+            f"{self.live_server_url}/details/database/urn:li:container:test"
+        )
+
     @pytest.mark.parametrize(
-        "access_reqs, expected_text, expected_tag",
+        "access_reqs, expected_text",
         [
             (
                 "https://place-to-get-your-access.com",
                 "Click link for access information (opens in new tab)",
-                "a",
             ),
             (
                 "To access these data you need to seek permission from the data owner by email",
                 "To access these data you need to seek permission from the data owner by email",
-                "p",
             ),
         ],
     )
     def test_access_requirements_content(
-        self,
-        mock_catalogue,
-        access_reqs,
-        expected_text,
-        expected_tag,
+        self, database, mock_catalogue, access_reqs, expected_text
     ):
         """
         test that what is displayed in the request action section of contacts is what we expect
@@ -63,22 +73,15 @@ class TestDetailsPageContactDetails:
         shown as given
         3 - where no access_requirements custom property exists default to the standrd line
         """
-        test_database = generate_database_metadata(
-            custom_properties=CustomEntityProperties(
-                access_information=AccessInformation(
-                    dc_access_requirements=access_reqs
-                ),
-            )
+        database.custom_properties.access_information = AccessInformation(
+            dc_access_requirements=access_reqs
         )
-
-        mock_get_database_details_response(mock_catalogue, test_database)
+        mock_get_database_details_response(mock_catalogue, database)
 
         self.start_on_the_details_page()
-
         request_access_metadata = self.details_database_page.request_access()
 
         assert request_access_metadata.text == expected_text
-        assert request_access_metadata.tag_name == expected_tag
 
     @pytest.mark.parametrize(
         "access_reqs, slack_channel, owner, expected_text",
@@ -110,46 +113,108 @@ class TestDetailsPageContactDetails:
         ],
     )
     def test_access_requirements_fallbacks(
-        self, mock_catalogue, access_reqs, slack_channel, owner, expected_text
+        self,
+        database,
+        mock_catalogue,
+        access_reqs,
+        slack_channel,
+        owner,
+        expected_text,
     ):
-        """
-        If no access requirements are given, users should use the contact info,
-        if provided. If not, then they should contact the data owner.
-        If none of the information is provided, then the catalogue entry is
-        non-functional - we should prevent this happening at ingestion time
-        or before.
-        """
-        test_database = generate_database_metadata(
-            custom_properties=CustomEntityProperties(
-                access_information=AccessInformation(
-                    dc_access_requirements=access_reqs
-                ),
+        if access_reqs:
+            database.custom_properties.access_information = AccessInformation(
+                dc_access_requirements=access_reqs
             )
-        )
-
         if owner:
-            test_database.governance.data_owner = OwnerRef(
+            database.governance.data_owner = OwnerRef(
                 display_name=owner, email=owner, urn="urn:bla"
             )
-        else:
-            test_database.governance.data_owner.display_name = ""
-            test_database.governance.data_owner.email = ""
-
         if slack_channel:
-            test_database.custom_properties.further_information = FurtherInformation(
+            database.custom_properties.further_information = FurtherInformation(
                 dc_slack_channel_name=slack_channel,
                 dc_slack_channel_url="http://bla.com",
             )
 
-        mock_get_database_details_response(mock_catalogue, test_database)
+        mock_get_database_details_response(mock_catalogue, database)
 
         self.start_on_the_details_page()
-
         request_access_metadata = self.details_database_page.request_access()
 
         assert request_access_metadata.text == expected_text
 
-    def start_on_the_details_page(self):
-        self.selenium.get(
-            f"{self.live_server_url}/details/database/urn:li:container:test"
-        )
+    @pytest.mark.parametrize(
+        "slack_channel, owner, expected_text",
+        [
+            (
+                "#contact-us",
+                "meta.data@justice.gov.uk",
+                "Slack channel: #contact-us (opens in new tab)",
+            ),
+            (
+                "",
+                "meta.data@justice.gov.uk",
+                "Contact the data owner with questions.",
+            ),
+            (
+                "",
+                "",
+                "Not provided.",
+            ),
+        ],
+    )
+    def test_contact_channels_fallbacks(
+        self,
+        database,
+        mock_catalogue,
+        slack_channel,
+        owner,
+        expected_text,
+    ):
+        if owner:
+            database.governance.data_owner = OwnerRef(
+                display_name=owner, email=owner, urn="urn:bla"
+            )
+        if slack_channel:
+            database.custom_properties.further_information = FurtherInformation(
+                dc_slack_channel_name=slack_channel,
+                dc_slack_channel_url="http://bla.com",
+            )
+
+        mock_get_database_details_response(mock_catalogue, database)
+
+        self.start_on_the_details_page()
+        request_access_metadata = self.details_database_page.contact_channels()
+
+        assert request_access_metadata.text == expected_text
+
+    @pytest.mark.parametrize(
+        "owner, expected_text",
+        [
+            (
+                "meta.data@justice.gov.uk",
+                "meta.data@justice.gov.uk",
+            ),
+            (
+                "",
+                "Not provided - contact the Data Catalogue team about this data.",
+            ),
+        ],
+    )
+    def test_data_owner_fallbacks(
+        self,
+        database,
+        mock_catalogue,
+        owner,
+        expected_text,
+    ):
+        if owner:
+            database.governance.data_owner = OwnerRef(
+                display_name=owner, email=owner, urn="urn:bla"
+            )
+
+        mock_get_database_details_response(mock_catalogue, database)
+
+        self.start_on_the_details_page()
+        request_access_metadata = self.details_database_page.data_owner()
+
+        assert request_access_metadata.text == expected_text


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/find-moj-data/issues/601

In order to present a consistent contact info panel, we should always show each of the three metadata fields, falling back to a "Not provided" value if missing.

If access information or contact information is missing, direct the user to the data owner. When this happens we would also like the data owner to add in the missing metadata.

If the data owner is missing, then direct the user to us. We do not intend to show any metadata without a data owner, so this should be treated as a bug in the service.

## Examples
### All metadata missing
<img width="341" alt="Screenshot 2024-08-19 at 13 33 00" src="https://github.com/user-attachments/assets/aa98a4e5-87d2-4805-bdb9-9ff9a34e792a">


## Access information missing
<img width="356" alt="Screenshot 2024-08-19 at 13 32 31" src="https://github.com/user-attachments/assets/f7518746-7397-42cb-b4c1-54f2fffa50e3">


## Contact channels missing
<img width="307" alt="Screenshot 2024-08-19 at 13 32 12" src="https://github.com/user-attachments/assets/8c94fc57-9e22-4199-9cba-cd8daf5881a1">

