### PR TITLE
fix: use correct labels for "Selected filters" panel

### DIFF
--- a/home/forms/search.py
+++ b/home/forms/search.py
@@ -66,7 +66,7 @@ class SearchForm(forms.Form):
             attrs={
                 "form": "searchform",
                 "class": "govuk-select",
-                "aria-label": "Domain",
+                "aria-label": _("Domain"),
                 "onchange": "document.getElementById('searchform').submit();",
             }
         ),

--- a/home/service/search.py
+++ b/home/service/search.py
@@ -109,7 +109,7 @@ class SearchService(GenericService):
             tags = self.form.cleaned_data.get("tags", [])
             remove_filter_hrefs = {}
             if domain:
-                remove_filter_hrefs["domain"] = self._generate_domain_clear_href()
+                remove_filter_hrefs[_("Domain")] = self._generate_domain_clear_href()
             if entity_types:
                 entity_types_clear_href = {}
                 for entity_type in entity_types:
@@ -118,7 +118,7 @@ class SearchService(GenericService):
                             filter_name="entity_types", filter_value=entity_type
                         )
                     )
-                remove_filter_hrefs["Entity Types"] = entity_types_clear_href
+                remove_filter_hrefs[_("Entity Types")] = entity_types_clear_href
 
             if where_to_access:
                 where_to_access_clear_href = {}
@@ -128,7 +128,7 @@ class SearchService(GenericService):
                             filter_name="where_to_access", filter_value=access
                         )
                     )
-                remove_filter_hrefs["Where To Access"] = where_to_access_clear_href
+                remove_filter_hrefs[_("Where To Access")] = where_to_access_clear_href
 
             if tags:
                 tags_clear_href = {}
@@ -136,7 +136,7 @@ class SearchService(GenericService):
                     tags_clear_href[tag] = self.form.encode_without_filter(
                         filter_name="tags", filter_value=tag
                     )
-                remove_filter_hrefs["Tags"] = tags_clear_href
+                remove_filter_hrefs[_("Tags")] = tags_clear_href
         else:
             remove_filter_hrefs = None
 

--- a/lib/datahub-client/tests/client/datahub/test_datahub_client.py
+++ b/lib/datahub-client/tests/client/datahub/test_datahub_client.py
@@ -7,7 +7,10 @@ from data_platform_catalogue.client.datahub_client import (
     DataHubCatalogueClient,
     InvalidDomain,
 )
-from data_platform_catalogue.client.exceptions import ReferencedEntityMissing, EntityDoesNotExist
+from data_platform_catalogue.client.exceptions import (
+    EntityDoesNotExist,
+    ReferencedEntityMissing,
+)
 from data_platform_catalogue.entities import (
     AccessInformation,
     Chart,
@@ -703,7 +706,8 @@ class TestCatalogueClientWithDatahub:
         base_mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
 
         with patch(
-                "data_platform_catalogue.client.datahub_client.DataHubCatalogueClient.check_entity_exists_by_urn") as mock_exists:
+            "data_platform_catalogue.client.datahub_client.DataHubCatalogueClient.check_entity_exists_by_urn"
+        ) as mock_exists:
             mock_exists.return_value = False  # Entity does not exist
             with pytest.raises(EntityDoesNotExist):
                 datahub_client.get_table_details(urn)
@@ -714,13 +718,14 @@ class TestCatalogueClientWithDatahub:
             "dataset": {
                 "platform": {"name": "datahub"},
                 "name": "Dataset",
-                "properties": {}
+                "properties": {},
             }
         }
         base_mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
 
         with patch(
-                "data_platform_catalogue.client.datahub_client.DataHubCatalogueClient.check_entity_exists_by_urn") as mock_exists:
+            "data_platform_catalogue.client.datahub_client.DataHubCatalogueClient.check_entity_exists_by_urn"
+        ) as mock_exists:
             mock_exists.return_value = True
             dataset = datahub_client.get_table_details(urn)
 

--- a/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
+++ b/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
@@ -402,7 +402,10 @@ def test_parse_relations_multiple_relationships():
                     "entity": {
                         "urn": "urn:li:dataProduct:test1",
                         "type": "DATA_PRODUCT",
-                        "properties": {"name": "test1", "description": "first test entity"},
+                        "properties": {
+                            "name": "test1",
+                            "description": "first test entity",
+                        },
                         "tags": {
                             "tags": [
                                 {"tag": {"urn": "urn:li:tag:dc_display_in_catalogue"}}
@@ -414,14 +417,17 @@ def test_parse_relations_multiple_relationships():
                     "entity": {
                         "urn": "urn:li:dataProduct:test2",
                         "type": "DATA_PRODUCT",
-                        "properties": {"name": "test2", "description": "second test entity"},
+                        "properties": {
+                            "name": "test2",
+                            "description": "second test entity",
+                        },
                         "tags": {
                             "tags": [
                                 {"tag": {"urn": "urn:li:tag:dc_display_in_catalogue2"}}
                             ]
                         },
                     }
-                }
+                },
             ],
         }
     }

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Find MoJ data\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-20 16:38+0100\n"
+"POT-Creation-Date: 2024-08-21 10:00+0100\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -78,6 +78,12 @@ msgstr "All subject areas"
 msgid "Analytical Platform"
 msgstr "Analytical Platform"
 
+# Filter
+#: home/forms/search.py:69 home/service/search.py:112
+#: home/service/search.py:222 templates/partial/filter.html:20
+msgid "Domain"
+msgstr "Subject area"
+
 # Entity type displayed with as a tag component
 #: home/service/details.py:65 templates/partial/search_result.html:21
 msgid "Database"
@@ -98,6 +104,19 @@ msgstr "Glossary"
 msgid "Metadata specification"
 msgstr "Metadata specification"
 
+# Filter
+#: home/service/search.py:121 templates/partial/filter.html:34
+msgid "Entity Types"
+msgstr "Entity types"
+
+#: home/service/search.py:131
+msgid "Where To Access"
+msgstr "Where to access"
+
+#: home/service/search.py:139
+msgid "Tags"
+msgstr "Tags"
+
 # Page title
 #: home/service/search.py:171 templates/base/navigation.html:69
 #: templates/details_base.html:14
@@ -111,11 +130,6 @@ msgstr "ID"
 #: home/service/search.py:221
 msgid "URN"
 msgstr "URN"
-
-# Filter
-#: home/service/search.py:222 templates/partial/filter.html:20
-msgid "Domain"
-msgstr "Subject area"
 
 #: home/service/search.py:223
 msgid "Title"
@@ -481,11 +495,6 @@ msgstr "Filter"
 msgid "Subdomain"
 msgstr "Subdomain"
 
-# Filter
-#: templates/partial/filter.html:34
-msgid "Entity Types"
-msgstr "Entity types"
-
 # Result page 0 results text
 #: templates/partial/no_results.html:2
 msgid "No results found"
@@ -621,59 +630,3 @@ msgstr "first name"
 #: users/models.py:12
 msgid "last name"
 msgstr "last name"
-
-# User model field
-#, fuzzy
-#~| msgid "email address"
-#~ msgid "Enter a valid email address."
-#~ msgstr "email address"
-
-# Heading
-#, fuzzy
-#~| msgid "Description"
-#~ msgid "Duration"
-#~ msgstr "Description"
-
-# User model field
-#, fuzzy
-#~| msgid "email address"
-#~ msgid "Email address"
-#~ msgstr "email address"
-
-# User model field
-#, fuzzy
-#~| msgid "email address"
-#~ msgid "IPv4 address"
-#~ msgstr "email address"
-
-# User model field
-#, fuzzy
-#~| msgid "email address"
-#~ msgid "IP address"
-#~ msgstr "email address"
-
-# Page title
-#, fuzzy
-#~| msgid "Search"
-#~ msgid "March"
-#~ msgstr "Search"
-
-# Footer link
-#, fuzzy
-#~| msgid "Contact"
-#~ msgid "oct"
-#~ msgstr "Contact"
-
-# Page title
-#, fuzzy
-#~| msgid "Search"
-#~ msgctxt "abbrev. month"
-#~ msgid "March"
-#~ msgstr "Search"
-
-# Page title
-#, fuzzy
-#~| msgid "Search"
-#~ msgctxt "alt. month"
-#~ msgid "March"
-#~ msgstr "Search"

--- a/tests/home/service/test_search.py
+++ b/tests/home/service/test_search.py
@@ -32,7 +32,7 @@ class TestSearchService:
         assert search_context["h1_value"] == "Search"
 
     def test_get_context_remove_filter_hrefs(self, search_context, valid_domain):
-        assert search_context["remove_filter_hrefs"]["domain"] == {
+        assert search_context["remove_filter_hrefs"]["Subject area"] == {
             valid_domain.label: (
                 "?query=test&"
                 "where_to_access=analytical_platform&"
@@ -44,7 +44,7 @@ class TestSearchService:
             )
         }
 
-        assert search_context["remove_filter_hrefs"]["Where To Access"] == {
+        assert search_context["remove_filter_hrefs"]["Where to access"] == {
             "analytical_platform": (
                 "?query=test&"
                 f"domain={quote(valid_domain.urn)}&"
@@ -56,7 +56,7 @@ class TestSearchService:
             )
         }
 
-        assert search_context["remove_filter_hrefs"]["Entity Types"] == {
+        assert search_context["remove_filter_hrefs"]["Entity types"] == {
             "Table": (
                 "?query=test&"
                 f"domain={quote(valid_domain.urn)}&"

--- a/tests/integration/test_details_contact_contents.py
+++ b/tests/integration/test_details_contact_contents.py
@@ -1,7 +1,6 @@
 import pytest
 from data_platform_catalogue.entities import (
     AccessInformation,
-    CustomEntityProperties,
     Database,
     FurtherInformation,
     OwnerRef,


### PR DESCRIPTION
We recently introduced a translation file just for english, so that all the messages are in one file. We have also changed some of the copy to make it more understandable to our users, e.g. Domain is now referred to as Subject area.

However, these labels weren't going through the translation system, so they didn't get affected by this change.