### PR TITLE
fix: add a few more dev dependencies to the dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,12 @@ updates:
         applies-to: version-updates
         patterns:
           - "black"
-          - "flake8"
-          - "pytest*"
           - "faker"
+          - "flake8"
           - "isort"
+          - "pre-commit"
+          - "pytest*"
+          - "selenium"
       django-dependencies:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
I added this group this morning to allow dependabot to group related dependency updates together. But I forgot a couple of dev dependencies.