### PR TITLE
fix: swap `image_tag` for `"latest"` as env can't be passed to `with` action block.

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -20,10 +20,8 @@ jobs:
 
       - name: Build and export
         uses: docker/build-push-action@v6
-        env:
-          IMAGE_TAG: ${{ github.sha }}
         with:
-          tags: fmd-image:${IMAGE_TAG}
+          tags: fmd-image:latest
           outputs: type=docker,dest=/tmp/fmd-image.tar
 
       - name: Upload artifact

--- a/.github/workflows/reusable-push-and-deploy.yml
+++ b/.github/workflows/reusable-push-and-deploy.yml
@@ -77,9 +77,8 @@ jobs:
         id: retag-image
         env:
           IMAGE_PATH: ${{ steps.image-path.outputs.image_path }}
-          IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker tag fmd-image:${IMAGE_TAG} ${image_path}
+          docker tag fmd-image:latest ${image_path}
 
       - name: Push Docker image to ECR
         id: push-docker-image-to-ecr


### PR DESCRIPTION
For context, the issue arises when trying to use environment variables within the `with` block of an action (see [SO link](https://stackoverflow.com/questions/76211635/how-to-use-env-variables-in-the-with-block-of-github-action-workflows)). 

The tag for the image during the `build-and-export` job does not need to be meaningful, as it will be replaced in the `push-and-deploy` workflow.