### PR TITLE
fix: unite reusable push and deploy jobs for single stage during workflow, mask `image_path`, fix `docker tag` statement env reference

### DIFF
--- a/.github/workflows/reusable-push-and-deploy.yml
+++ b/.github/workflows/reusable-push-and-deploy.yml
@@ -74,12 +74,17 @@ jobs:
           name: fmd-image
           path: /tmp
 
+      - name: Load image
+        id: load-image
+        run: |
+          docker load --input /tmp/fmd-image.tar
+          docker image ls -a
+
       - name: Re-tag docker image
         id: retag-image
         env:
           IMAGE_PATH: ${{ steps.image-path.outputs.image_path }}
         run: |
-          echo $(docker ps -a)
           docker tag "fmd-image" "${IMAGE_PATH}"
 
       - name: Push Docker image to ECR

--- a/.github/workflows/reusable-push-and-deploy.yml
+++ b/.github/workflows/reusable-push-and-deploy.yml
@@ -44,8 +44,6 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    outputs:
-      image_path: ${{ steps.image-path.outputs.image_path }}
     steps:
       - uses: actions/checkout@v4
 
@@ -64,9 +62,9 @@ jobs:
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          echo "::add-mask::${{ steps.login-to-ecr.outputs.registry }}"
+          ::add-mask::${{ steps.login-to-ecr.outputs.registry }}
           IMAGE_PATH="${{ steps.login-to-ecr.outputs.registry }}/${REPOSITORY}:${IMAGE_TAG}"
-          echo "::add-mask::$IMAGE_PATH"
+          ::add-mask::$IMAGE_PATH
           echo "image_path=$IMAGE_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Download artifact
@@ -80,7 +78,8 @@ jobs:
         env:
           IMAGE_PATH: ${{ steps.image-path.outputs.image_path }}
         run: |
-          docker tag "fmd-image:latest" "${IMAGE_PATH}"
+          echo $(docker ps -a)
+          docker tag "fmd-image" "${IMAGE_PATH}"
 
       - name: Push Docker image to ECR
         id: push-docker-image-to-ecr

--- a/.github/workflows/reusable-push-and-deploy.yml
+++ b/.github/workflows/reusable-push-and-deploy.yml
@@ -59,12 +59,12 @@ jobs:
       - name: Generate, mask, output image path
         id: image-path
         env:
+          REGISTRY: ${{ steps.login-to-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
           echo "adding masks"
-          echo "::add-mask::${{ steps.login-to-ecr.outputs.registry }}"
-          IMAGE_PATH="${{ steps.login-to-ecr.outputs.registry }}/${REPOSITORY}:${IMAGE_TAG}"
+          IMAGE_PATH="${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
           echo "::add-mask::$IMAGE_PATH"
           echo "image_path=$IMAGE_PATH" >> "$GITHUB_OUTPUT"
 
@@ -78,7 +78,6 @@ jobs:
         id: load-image
         run: |
           docker load --input /tmp/fmd-image.tar
-          docker image ls -a
 
       - name: Re-tag docker image
         id: retag-image

--- a/.github/workflows/reusable-push-and-deploy.yml
+++ b/.github/workflows/reusable-push-and-deploy.yml
@@ -62,9 +62,10 @@ jobs:
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          ::add-mask::${{ steps.login-to-ecr.outputs.registry }}
+          echo "adding masks"
+          echo "::add-mask::${{ steps.login-to-ecr.outputs.registry }}"
           IMAGE_PATH="${{ steps.login-to-ecr.outputs.registry }}/${REPOSITORY}:${IMAGE_TAG}"
-          ::add-mask::$IMAGE_PATH
+          echo "::add-mask::$IMAGE_PATH"
           echo "image_path=$IMAGE_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Download artifact

--- a/.github/workflows/reusable-push-and-deploy.yml
+++ b/.github/workflows/reusable-push-and-deploy.yml
@@ -61,13 +61,13 @@ jobs:
       - name: Generate, mask, output image path
         id: image-path
         env:
-          REGISTRY: ${{ steps.login-to-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          image-path="${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
-          echo "::add-mask::$image-path"
-          echo "image_path=$image-path" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::${{ steps.login-to-ecr.outputs.registry }}"
+          IMAGE_PATH="${{ steps.login-to-ecr.outputs.registry }}/${REPOSITORY}:${IMAGE_TAG}"
+          echo "::add-mask::$IMAGE_PATH"
+          echo "image_path=$IMAGE_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/reusable-push-and-deploy.yml
+++ b/.github/workflows/reusable-push-and-deploy.yml
@@ -37,8 +37,8 @@ on:
         required: true
 
 jobs:
-  push:
-    name: Push Docker image to CP namespace ECR
+  push-and-deploy:
+    name: Push image to CP namespace ECR and apply deployment in CP
     environment: ${{ inputs.env }}
     runs-on: ubuntu-latest
     permissions:
@@ -58,14 +58,16 @@ jobs:
         id: login-to-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Output image path
+      - name: Generate, mask, output image path
         id: image-path
         env:
           REGISTRY: ${{ steps.login-to-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          echo "image_path=${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          image-path="${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
+          echo "::add-mask::$image-path"
+          echo "image_path=$image-path" >> "$GITHUB_OUTPUT"
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -78,26 +80,16 @@ jobs:
         env:
           IMAGE_PATH: ${{ steps.image-path.outputs.image_path }}
         run: |
-          docker tag fmd-image:latest ${image_path}
+          docker tag "fmd-image:latest" "${IMAGE_PATH}"
 
       - name: Push Docker image to ECR
         id: push-docker-image-to-ecr
         env:
           IMAGE_PATH: ${{ steps.image-path.outputs.image_path }}
-        run: docker push ${IMAGE_PATH}
+        run: docker push "${IMAGE_PATH}"
 
-  deploy:
-    name: Deploy Helm chart into Cloud Platform
-    needs: push
-    environment: ${{ inputs.env }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare Helm deployment
-        id: prepare-helm-deployment
+      - name: Prepare deployment yaml
+        id: prepare-deployment
         env:
           ENV: ${{ inputs.env }}
           CATALOGUE_URL: ${{ vars.CATALOGUE_URL }}
@@ -108,7 +100,7 @@ jobs:
           SENTRY_DSN_WORKAROUND: ${{ vars.SENTRY_DSN_WORKAROUND }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
           CATALOGUE_TOKEN: ${{ secrets.CATALOGUE_TOKEN }}
-          IMAGE_PATH: ${{ needs.build-and-push.outputs.image_path }}
+          IMAGE_PATH: ${{ steps.image-path.outputs.image_path }}
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
           ENABLE_ANALYTICS: ${{ vars.ENABLE_ANALYTICS }}
           ANALYTICS_ID: ${{ vars.ANALYTICS_ID }}
@@ -140,8 +132,8 @@ jobs:
           kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
           kubectl config use-context ${KUBE_CLUSTER}
 
-      - name: Apply Helm deployment
-        id: apply-helm-deployment
+      - name: Apply deployment
+        id: apply-deployment
         env:
           KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
         run: kubectl -n ${KUBE_NAMESPACE} apply -f deployments/


### PR DESCRIPTION
One of the goals of #590 is to unite workflows so there is only 1 approval required per environment. For that to work, `push` and `deploy` workflow jobs need to be united, as both would require approval for protected environments. This PR fixes that oversight.

This PR also adds a mask to the sensitive `image_path` env var, and attempts to fix a bug with `docker tag` step that isn't interpolating the provided env var.