### PR TITLE
fix: do not open global links in new tabs

### DIFF
--- a/templates/base/navigation.html
+++ b/templates/base/navigation.html
@@ -70,12 +70,12 @@
             </a>
           </li>
           <li class="moj-primary-navigation__item">
-            <a class="moj-primary-navigation__link" href="https://user-guide.find-moj-data.service.justice.gov.uk" rel="noreferrer noopener" target="_blank">
+            <a class="moj-primary-navigation__link" href="https://user-guide.find-moj-data.service.justice.gov.uk">
               {% translate "User guide" %}
             </a>
           </li>
           <li class="moj-primary-navigation__item">
-            <a class="moj-primary-navigation__link" href="https://user-guide.find-moj-data.service.justice.gov.uk/#contact-us" rel="noreferrer noopener" target="_blank">
+            <a class="moj-primary-navigation__link" href="https://user-guide.find-moj-data.service.justice.gov.uk#contact-us">
               {% translate "Contact us" %}
             </a>
           </li>

--- a/templates/base/navigation.html
+++ b/templates/base/navigation.html
@@ -75,7 +75,7 @@
             </a>
           </li>
           <li class="moj-primary-navigation__item">
-            <a class="moj-primary-navigation__link" href="https://user-guide.find-moj-data.service.justice.gov.uk#contact-us">
+            <a class="moj-primary-navigation__link" href="https://user-guide.find-moj-data.service.justice.gov.uk/#contact-us">
               {% translate "Contact us" %}
             </a>
           </li>


### PR DESCRIPTION
Users should be able to navigate backwards and forwards.

We will probably move this content onsite at some point, instead of having a separate manual.

https://github.com/ministryofjustice/find-moj-data/issues/623