### PR TITLE
Opt into new type scale

### DIFF
--- a/scss/base.scss
+++ b/scss/base.scss
@@ -5,6 +5,8 @@ $app-images-path: "/static/assets/images";
 // Removes need to put classes on all elements
 $govuk-global-styles: true;
 
+$govuk-new-typography-scale: true;
+
 @import "node_modules/govuk-frontend/dist/govuk/all";
 @import "node_modules/@ministryofjustice/frontend/moj/all";
 @import "./components/search";


### PR DESCRIPTION
GOV.UK design system will be removing the old type scale in version 6.

The new one removes some smaller font sizes that are hard to read, e.g. in the page footer.

See https://design-system.service.gov.uk/get-started/new-type-scale/