### PR TITLE
feat: add back button to cookie page

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -258,3 +258,6 @@ LOCALE_PATHS = [BASE_DIR / "locale"]
 
 origins_str = os.environ.get("CSRF_TRUSTED_ORIGINS", "")
 CSRF_TRUSTED_ORIGINS = origins_str.split(" ") if origins_str else []
+if DEBUG:
+    local_origins = ["http://127.0.0.1:8000", "http://localhost:8000"]
+    CSRF_TRUSTED_ORIGINS += local_origins

--- a/core/urls.py
+++ b/core/urls.py
@@ -17,7 +17,6 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
-from django.views.generic import TemplateView
 
 app_name = "core"
 
@@ -25,9 +24,6 @@ urlpatterns = [
     path("admin/", view=admin.site.urls),
     path("azure_auth/", include("azure_auth.urls", namespace="azure_auth")),
     path("feedback/", include("feedback.urls", namespace="feedback")),
-    path(
-        "cookies/", TemplateView.as_view(template_name="cookies.html"), name="cookies"
-    ),
     path("", include("home.urls", namespace="home")),
     path("", include("django_prometheus.urls")),
 ]

--- a/home/urls.py
+++ b/home/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
         name="details",
     ),
     path("pagination/<str:page>", views.search_view, name="pagination"),
+    path("cookies", views.cookies_view, name="cookies"),
 ]

--- a/home/views.py
+++ b/home/views.py
@@ -1,5 +1,8 @@
+from urllib.parse import urlparse
+
 from data_platform_catalogue.client.exceptions import EntityDoesNotExist
 from data_platform_catalogue.search_types import DomainOption
+from django.conf import settings
 from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import render
 from django.utils.translation import gettext as _
@@ -116,3 +119,22 @@ def metadata_specification_view(request):
     return render(
         request, "metadata_specification.html", metadata_specification.context
     )
+
+
+def cookies_view(request):
+    valid_domains = [
+        urlparse(origin).netloc for origin in settings.CSRF_TRUSTED_ORIGINS
+    ]
+    referer = request.META.get("HTTP_REFERER")
+
+    if referer:
+        referer_domain = urlparse(referer).netloc
+
+        # Validate this referer domain against declared valid domains
+        if referer_domain not in valid_domains:
+            referer = "/"  # Set to home page if invalid
+
+    context = {
+        "previous_page": referer or "/",  # Provide a default fallback if none found
+    }
+    return render(request, "cookies.html", context)

--- a/templates/base/footer.html
+++ b/templates/base/footer.html
@@ -6,7 +6,7 @@
         <h2 class="govuk-visually-hidden">{% translate "Support links" %}</h2>
         <ul class="govuk-footer__inline-list">
           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="{% url 'cookies' %}">
+            <a class="govuk-footer__link" href="{% url 'home:cookies' %}">
               {% translate "Cookies" %}
             </a>
           </li>

--- a/templates/cookies.html
+++ b/templates/cookies.html
@@ -15,11 +15,12 @@
       <p class="govuk-body">Cookies are used to:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>remember when you sign into the site</li>
-        <li>measure how you use the site so it can be updated and improved based on your needs</li>
+        <li>
+          measure how you use the site so it can be updated and improved based
+          on your needs
+        </li>
       </ul>
-      <p>
-        These cookies are not used to identify you personally.
-      </p>
+      <p>These cookies are not used to identify you personally.</p>
       <h2 class="govuk-heading-m">Essential cookies</h2>
 
       <table class="govuk-table">
@@ -38,7 +39,9 @@
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">csrftoken</th>
-            <td class="govuk-table__cell">Protects against unauthorised access</td>
+            <td class="govuk-table__cell">
+              Protects against unauthorised access
+            </td>
             <td class="govuk-table__cell">1 year</td>
           </tr>
         </tbody>
@@ -46,21 +49,22 @@
 
       <h2 class="govuk-heading-m">Analytical cookies</h2>
       <p class="govuk-body">
-        Analytics cookies collect information about how you use this site. This helps us make sure the site is meeting
-        the needs of users and helps us make improvements.
+        Analytics cookies collect information about how you use this site. This
+        helps us make sure the site is meeting the needs of users and helps us
+        make improvements.
       </p>
-      <p class="govuk-body">
-        We use Google Analytics to learn about:
-      </p>
+      <p class="govuk-body">We use Google Analytics to learn about:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>the pages you visit</li>
         <li>how long you spend on each page</li>
         <li>how you got to the site</li>
         <li>what you click on while you are using the site</li>
       </ul>
-      <p class="govuk-body">We do not collect or store your personal information (for example your name or address) so
-        this information can’t be used to identify who you are. We do not allow third parties to use or share our
-        analytics data.</p>
+      <p class="govuk-body">
+        We do not collect or store your personal information (for example your
+        name or address) so this information can’t be used to identify who you
+        are. We do not allow third parties to use or share our analytics data.
+      </p>
 
       <p class="govuk-body">
         The site may save the following analytics cookies:
@@ -80,16 +84,25 @@
             <td class="govuk-table__cell">2 years</td>
           </tr>
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">_ga_<code>&lt;container-id&gt;</code>
+            <th scope="row" class="govuk-table__header">
+              _ga_<code>&lt;container-id&gt;</code>
             </th>
             <td class="govuk-table__cell">Used to persist session state</td>
             <td class="govuk-table__cell">2 years</td>
           </tr>
         </tbody>
       </table>
-      <p class="govuk-body">You can use a browser addon to <a href="https://tools.google.com/dlpage/gaoptout">opt out
-          of Google Analytics cookies</a> on all websites.</p>
-      <p class="govuk-body">Find out more about <a href="https://www.aboutcookies.org/">how to manage cookies</a>.</p>
+      <p class="govuk-body">
+        You can use a browser addon to
+        <a href="https://tools.google.com/dlpage/gaoptout"
+          >opt out of Google Analytics cookies</a
+        >
+        on all websites.
+      </p>
+      <p class="govuk-body">
+        Find out more about
+        <a href="https://www.aboutcookies.org/">how to manage cookies</a>.
+      </p>
     </div>
   </div>
 </div>

--- a/templates/cookies.html
+++ b/templates/cookies.html
@@ -1,12 +1,13 @@
 {% extends "base/base.html" %}
 {% load static %}
 {% load i18n %}
-
 {% block content %}
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <a href="{{ previous_page }}" class="govuk-back-link">Back</a>
+      <div class="govuk-!-padding-bottom-2"></div>
       <h1 class="govuk-heading-l">{% translate 'Cookies' %}</h1>
       <p class="govuk-body">
         This site saves small files (known as ‘cookies’) onto your device.


### PR DESCRIPTION
The cookies page is viewable from any page in the application, but is likely not an endpoint for users, so they will want to be able to navigate back to their previous page.

The cookie view has been added to `home/views.py`, and the referer URL is validated to ensure the URL is one of the trusted domains (i.e. is within `settings.CSRF_TRUSTED_ORIGINS`).

localhost has been added to `settings.CSRF_TRUSTED_ORIGINS` when running with `settings.DEBUG == True`