### PR TITLE
Set the secure flag on all django cookies

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -261,3 +261,7 @@ CSRF_TRUSTED_ORIGINS = origins_str.split(" ") if origins_str else []
 if DEBUG:
     local_origins = ["http://127.0.0.1:8000", "http://localhost:8000"]
     CSRF_TRUSTED_ORIGINS += local_origins
+
+CSRF_COOKIE_SECURE = True
+LANGUAGE_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
This prevents cookies being sent when HTTPS is not used