### PR TITLE
Configured pod securityContext

### DIFF
--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -98,8 +98,8 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
           volumeMounts:
-          - mountPath: /tmp
-            name: tmp
-        volumes:
+            - mountPath: /tmp
+              name: tmp
+      volumes:
         - name: tmp
           emptyDir: {}

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -19,10 +19,6 @@ spec:
       labels:
         app: find-moj-data
     spec:
-      securityContext:
-        readOnlyRootFilesystem: true
-        allowPrivilegeEscalation: false
-        runAsNonRoot: true
       containers:
         - name: find-moj-data
           image: ${IMAGE_PATH}
@@ -97,3 +93,7 @@ spec:
                 secretKeyRef:
                   name: rds-postgresql-instance-output
                   key: rds_instance_address
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -97,6 +97,8 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - mountPath: /tmp
               name: tmp

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -19,6 +19,10 @@ spec:
       labels:
         app: find-moj-data
     spec:
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
       containers:
         - name: find-moj-data
           image: ${IMAGE_PATH}

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -94,6 +94,6 @@ spec:
                   name: rds-postgresql-instance-output
                   key: rds_instance_address
           securityContext:
-            # readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             runAsNonRoot: true

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -94,6 +94,6 @@ spec:
                   name: rds-postgresql-instance-output
                   key: rds_instance_address
           securityContext:
-            readOnlyRootFilesystem: true
+            # readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             runAsNonRoot: true

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -98,20 +98,8 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
           volumeMounts:
-            - mountPath: /tmp
-              name: tmp-dir
-            - mountPath: /var/tmp
-              name: var-tmp-dir
-            - mountPath: /usr/tmp
-              name: usr-tmp-dir
-            - mountPath: /app
-              name: app-dir
+          - mountPath: /tmp
+            name: tmp
         volumes:
-          - name: tmp-dir
-            emptyDir: {}
-          - name: var-tmp-dir
-            emptyDir: {}
-          - name: usr-tmp-dir
-            emptyDir: {}
-          - name: app-dir
-            emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -97,3 +97,21 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
+            - mountPath: /var/tmp
+              name: var-tmp-dir
+            - mountPath: /usr/tmp
+              name: usr-tmp-dir
+            - mountPath: /app
+              name: app-dir
+        volumes:
+          - name: tmp-dir
+            emptyDir: {}
+          - name: var-tmp-dir
+            emptyDir: {}
+          - name: usr-tmp-dir
+            emptyDir: {}
+          - name: app-dir
+            emptyDir: {}


### PR DESCRIPTION
* These settings are in line with the security remediation guidance

-           readOnlyRootFilesystem: true
-           allowPrivilegeEscalation: false
-           runAsNonRoot: true
-           seccompProfile:
              type: RuntimeDefault