### PR TITLE
feat(k8s): add a horizontal pod autoscaler

### DIFF
--- a/.github/workflows/reusable-push-and-deploy.yml
+++ b/.github/workflows/reusable-push-and-deploy.yml
@@ -118,6 +118,7 @@ jobs:
 
         run: |
           cat deployments/templates/deployment.yml | envsubst > deployments/deployment.yml
+          cat deployments/templates/hpa.yml | envsubst > deployments/hpa.yml
           cat deployments/templates/ingress.yml | envsubst > deployments/ingress.yml
           cat deployments/templates/service.yml | envsubst > deployments/service.yml
           cat deployments/templates/secrets.yml | envsubst > deployments/secrets.yml

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -21,6 +21,13 @@ spec:
       containers:
         - name: find-moj-data
           image: ${IMAGE_PATH}
+          resources:
+            requests:
+              cpu: 20m
+              memory: 300Mi
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
           ports:
             - name: http
               containerPort: 8000

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: find-moj-data
 spec:
-  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/deployments/templates/hpa.yml
+++ b/deployments/templates/hpa.yml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: find-moj-data
+  namespace: ${NAMESPACE}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: find-moj-data-deployment
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 95


### PR DESCRIPTION
This adds a horizontal pod autoscaler that scales up when the average CPU utilization is at 95% of the requested CPU.

I've deployed to dev, and it seems to work, but the limitranges might need tweaking. Currently the pods are exceeding the requested CPU even with 5 of them, but I'm not sure why.

View the status using `kubectl describe hpa -n data-platform-find-moj-data-dev find-moj-data`

We should remove the replicas key from the deployment, otherwise any time we deploy it will overwrite the HPA (source:
https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling)

Behaviour:

- every 15 seconds - The HPA controller checks the value of the metric used every 15 seconds per pod.
- every 3 minutes - The HPA scales up pods if the metric threshold has been continually exceeded for 3 mins.
- every 5 minutes - The HPA scales down pods if the metric threshold has not been exceeded for 5 mins.

Further info:

- https://user-guide.cloud-platform.service.justice.gov.uk/documentation/concepts/deploying.html#horizontal-pod-autoscaling-hpa
- https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale