### PR TITLE
fix: remove django admin

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -31,7 +31,6 @@ except gaierror:
 
 # Application definition
 INSTALLED_APPS = [
-    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/core/urls.py
+++ b/core/urls.py
@@ -15,13 +15,11 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from django.contrib import admin
 from django.urls import include, path
 
 app_name = "core"
 
 urlpatterns = [
-    path("admin/", view=admin.site.urls),
     path("azure_auth/", include("azure_auth.urls", namespace="azure_auth")),
     path("feedback/", include("feedback.urls", namespace="feedback")),
     path("", include("home.urls", namespace="home")),


### PR DESCRIPTION
We're not using it, so it should be disabled.