### PR TITLE
fix: add modsec rule for host header

### DIFF
--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -10,6 +10,8 @@ metadata:
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=data-catalogue"
       SecDefaultAction "phase:4,pass,log,tag:github_team=data-catalogue"
+      SecRule REQUEST_HEADERS:Host "!@endsWith .service.justice.gov.uk" \
+      "id:1001,phase:1,deny,log,status:403,msg:'Forbidden Host Header'"
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
PR adds a modsec rule to the ingress to only accept expected host headers

resolves #743
