### PR TITLE
Block search engines and remove redundant <main> element from error pages

### DIFF
--- a/templates/400.html
+++ b/templates/400.html
@@ -3,14 +3,10 @@
 
 {% block content %}
 
-  <div class="govuk-width-container">
-    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">{{h1_value}}</h1>
-        </div>
-      </div>
-    </main>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">{{h1_value}}</h1>
   </div>
+</div>
 
 {% endblock content %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -4,20 +4,16 @@
 
 {% block content %}
 
-  <div class="govuk-width-container">
-    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">{{h1_value}}</h1>
-          <p class="govuk-body">
-            {% translate "If you typed the web address, check it is correct." %}
-          </p>
-          <p class="govuk-body">
-            {% translate "If you pasted the web address, check you copied the entire address." %}
-          </p>
-        </div>
-      </div>
-    </main>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">{{h1_value}}</h1>
+    <p class="govuk-body">
+      {% translate "If you typed the web address, check it is correct." %}
+    </p>
+    <p class="govuk-body">
+      {% translate "If you pasted the web address, check you copied the entire address." %}
+    </p>
   </div>
+</div>
 
 {% endblock content %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -4,18 +4,14 @@
 
 {% block content %}
 
-  <div class="govuk-width-container">
-    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">{{h1_value}}</h1>
-          <p class="govuk-body">
-            {% translate "There is a problem with the server." %}
-          </p>
-          {% include "partial/contact_team.html" %}
-        </div>
-      </div>
-    </main>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">{{h1_value}}</h1>
+    <p class="govuk-body">
+      {% translate "There is a problem with the server." %}
+    </p>
+    {% include "partial/contact_team.html" %}
   </div>
+</div>
 
 {% endblock content %}

--- a/templates/500_datahub_unavailable.html
+++ b/templates/500_datahub_unavailable.html
@@ -3,19 +3,14 @@
 {% load static %}
 
 {% block content %}
-
-  <div class="govuk-width-container">
-    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">{{h1_value}}</h1>
-          <p class="govuk-body">
-            {% translate "The DataHub catalogue is currently unavailable. Please try again in a few minutes." %}
-          </p>
-          {% include "partial/contact_team.html" %}
-        </div>
-      </div>
-    </main>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">{{h1_value}}</h1>
+    <p class="govuk-body">
+      {% translate "The DataHub catalogue is currently unavailable. Please try again in a few minutes." %}
+    </p>
+    {% include "partial/contact_team.html" %}
   </div>
+</div>
 
 {% endblock content %}

--- a/templates/base/head.html
+++ b/templates/base/head.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load page_title %}
+
 <head>
   <meta charset="utf-8">
   <title>{{h1_value|render_title}}</title>
@@ -12,4 +13,5 @@
   <link rel="manifest" href="{% static 'assets/manifest.json' %}">
   <link rel="stylesheet" type="text/css" href="{% static 'assets/css/base.css' %}">
   <meta property="og:image" content="{% static 'assets/images/govuk-opengraph-image.png' %}">
+  <meta name="robots" content="noindex, nofollow" />
 </head>


### PR DESCRIPTION
- This is an internal service so we don't want it in google (https://github.com/ministryofjustice/find-moj-data/issues/760)
- The main element and govuk-width-container div were being duplicated between the base layout and the error pages