### PR TITLE
ci: skip end to end test in deploy pipeline

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -115,8 +115,10 @@ jobs:
         if: steps.fast-tests.outcome == 'success'
         run: make integration
 
+      # This step should be skipped when triggered by workflow_call, since these tests
+      # rely on an external environment and are somewhat flaky.
       - name: Run end to end tests
-        if: steps.fast-tests.outcome == 'success'
+        if: steps.fast-tests.outcome == 'success' && github.event_name == 'pull_request'
         run: make end_to_end
         env:
           CATALOGUE_TOKEN: ${{secrets.DEV_CATALOGUE_TOKEN}}


### PR DESCRIPTION
reusable-tests is run in two contexts:

1. on a pull request
2. as part of other workflows post-merge: `deploy-staged` and `deploy-dev-from-branch`

The end to end testing step is working fine in scenario 1, but scenario 2 doesn't work because github cannot read the secret, when triggered with `workflow_call`.

I don't think it's a good idea for `deploy-staged` to depend on these (potentially flaky) selenium tests, so I've bypassed it in this case.