### PR TITLE
ci: completely remove e2e test from ci

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -115,15 +115,6 @@ jobs:
         if: steps.fast-tests.outcome == 'success'
         run: make integration
 
-      # This step should be skipped when triggered by workflow_call, since these tests
-      # rely on an external environment and are somewhat flaky.
-      - name: Run end to end tests
-        if: steps.fast-tests.outcome == 'success' && github.event_name == 'pull_request'
-        run: make end_to_end
-        env:
-          CATALOGUE_TOKEN: ${{secrets.DEV_CATALOGUE_TOKEN}}
-          CATALOGUE_URL: ${{vars.DEV_CATALOGUE_URL}}
-
   javascript-only-tests:
     name: Javascript tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
including a test that depends on our datahub dev environment (and therefore needs a secret token) breaks in a bunch of subtle ways:

- workflow_call triggered jobs can't access the secret, unless we explicitly pass it through from the parent workflows
- dependabot can't access the secret, unless we copy the secret to dependabot secrets
- pull requests from outside the org can't access the secret either (a security measure to prevent exfiltrating secrets)

the benefit of this test is already quite minimal so this has convinced me we don't need it in our CI pipeline.