### PR TITLE
fix: use STORAGES instead of STATICFILES_STORAGE

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -127,7 +127,12 @@ USE_TZ = True
 STATIC_URL = "/static/"
 # https://whitenoise.readthedocs.io/en/latest/django.html#make-sure-staticfiles-is-configured-correctly
 STATIC_ROOT = BASE_DIR / "staticfiles"
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+    }
+}
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"


### PR DESCRIPTION
The latter is deprecated since django 4.2
https://docs.djangoproject.com/en/5.0/ref/settings/#staticfiles-storage

And then it was dropped in 5.1
https://docs.djangoproject.com/en/5.1/releases/5.1/#features-removed-in-5-1

This broke our cache busting URLs, added in https://github.com/ministryofjustice/find-moj-data/pull/331