### PR TITLE
perf: remove unused javascripts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -111,16 +111,6 @@
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
-  "results": {
-    "templates/base/base.html": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "templates/base/base.html",
-        "hashed_secret": "f6538b22f89b1e2b05570de751f2932c6bca9969",
-        "is_verified": false,
-        "line_number": 33
-      }
-    ]
-  },
-  "generated_at": "2024-08-05T12:27:05Z"
+  "results": {},
+  "generated_at": "2024-09-12T13:54:50Z"
 }

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -26,17 +26,9 @@
       </div>
     {% endblock main %}
     {% include "base/footer.html" %}
-    <script type="module" src="{% static 'assets/js/govuk-frontend.min.js' %}"></script>
-    <script src="{% static 'assets/js/moj-frontend.min.js' %}"></script>
-    <script
-      src="https://code.jquery.com/jquery-3.6.0.min.js"
-      integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
-      crossorigin="anonymous"
-    ></script>
     <script type="module">
       import {initAll} from "{% static 'assets/js/govuk-frontend.min.js' %}"
       initAll();
-      window.MOJFrontend.initAll();
     </script>
     {% block scripts %}
     {% endblock scripts %}


### PR DESCRIPTION
We are not using any components from the MoJ design system that use javascript, so we can remove the script from our template.