### PR TITLE
Fix sentence casing on subject area, entity type labels when filters are selected

### DIFF
--- a/home/templatetags/clear_filter.py
+++ b/home/templatetags/clear_filter.py
@@ -22,4 +22,4 @@ def get_keys(dictionary: dict[str, dict]) -> list[str] | list:
 
 @register.filter
 def format_label(label: str) -> str:
-    return label.replace("_", " ").title() if "_" in label else label
+    return label.replace("_", " ").capitalize() if "_" in label else label

--- a/templates/partial/selected_filters.html
+++ b/templates/partial/selected_filters.html
@@ -20,7 +20,7 @@
     </div>
     {% for key in remove_filter_hrefs|get_keys %}
         {% if remove_filter_hrefs|get_item:key|length > 0 %}
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0">{{key|title}}</h3>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0">{{key|capfirst}}</h3>
             <ul class="moj-filter-tags">
                 <input type="hidden" name="clear_label" value="">
                 {% for label, href in remove_filter_hrefs|get_items:key %}

--- a/tests/home/templatetags/test_clearfilter.py
+++ b/tests/home/templatetags/test_clearfilter.py
@@ -1,0 +1,10 @@
+import pytest
+
+from home.templatetags.clear_filter import format_label
+
+
+@pytest.mark.parametrize(
+    "label, expected", [("electronic_monitoring", "Electronic monitoring")]
+)
+def test_format_label(label, expected):
+    assert format_label(label) == expected

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
+
+phase_report_key = pytest.StashKey[dict[str, pytest.CollectReport]]()
+
+TMP_DIR = (Path(__file__).parent.parent / "tmp").resolve()
+
+
+@pytest.hookimpl(wrapper=True, tryfirst=True)
+def pytest_runtest_makereport(item, call):
+    # execute all other hooks to obtain the report object
+    rep = yield
+
+    # store test results for each phase of a call, which can
+    # be "setup", "call", "teardown"
+    item.stash.setdefault(phase_report_key, {})[rep.when] = rep
+
+    return rep
+
+
+@pytest.fixture(autouse=True)
+def screenshotter(request, selenium: RemoteWebDriver):
+    yield
+
+    testname = request.node.name
+    report = request.node.stash[phase_report_key]
+
+    if report["setup"].failed:
+        # Nothing to screenshot
+        pass
+
+    elif ("call" not in report) or report["call"].failed:
+        timestamp = datetime.now().strftime(r"%Y%m%d%H%M%S")
+        TMP_DIR.mkdir(exist_ok=True)
+        path = str(TMP_DIR / f"{timestamp}-{testname}-failed.png")
+        total_height = selenium.execute_script(
+            "return document.body.parentNode.scrollHeight"
+        )
+        selenium.set_window_size(1920, total_height)
+        selenium.save_screenshot(path)
+        print(f"Screenshot saved to {path}")


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/find-moj-data/issues/784
and also fixes an unrelated issue with the tests, caused by the screenshot helper being moved to the top level. This massively slowed down the tests because it has autouse=True and it depends on the selenium driver being initialised.