### PR TITLE
Disable datahub telemetry and force debug off

### DIFF
--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -38,7 +38,9 @@ spec:
             - name: CATALOGUE_URL
               value: "${CATALOGUE_URL}"
             - name: DEBUG
-              value: "${DEBUG}"
+              value: "0"
+            - name: DATAHUB_TELEMETRY_ENABLED
+              value: "0"
             - name: GIT_REF
               value: "${GIT_REF}"
             - name: DJANGO_ALLOWED_HOSTS


### PR DESCRIPTION
[Datahub has some telemetry](https://github.com/datahub-project/datahub/blob/master/metadata-ingestion/src/datahub/ingestion/graph/client.py#L143). This seems to be disabled on the server side, but unless we set this flag, the GraphQL client will issue a request to the server asking for a clientId. This always returns a 404 on our deployment.

This request adds delay to response times in Find MoJ data, and this happens more than once per request due to us instantiating the client in multiple places.

The `test_connection` call itself seems to be a bottleneck, so we might want to look at refactoring the code to avoid this as well.

<img width="1248" alt="Flamegraph showing that the majority of the response time is spend testing the connection to Datahub" src="https://github.com/user-attachments/assets/b0ba7588-6f9c-423b-95c2-6563e9cbed95">


From local testing, setting this variable to 0 seems to reduce homepage response times to < 500ms when the django cache is primed (requests still take longer than this when the domains need to be refetched from Datahub).


I've also hardcoded DEBUG to 0 since we will never have this on outside of local development.