### PR TITLE
Fix low colour contrast and incorrect label markup

### DIFF
--- a/scss/components/_search.scss
+++ b/scss/components/_search.scss
@@ -72,7 +72,7 @@
 
   button {
     background-color: #d2e2f1;
-    color: govuk-colour("blue");
+    color: govuk-colour("dark-blue");
 
     &:hover {
       background-color: lighten(#d2e2f1, 5%);

--- a/templates/home.html
+++ b/templates/home.html
@@ -34,9 +34,9 @@
                       fill="currentColor"
                     ></path>
                   </svg>
-                  <label
+                  <span
                     class="govuk-label govuk-visually-hidden-focusable"
-                  >{% translate "Search"}</label
+                  >{% translate "Search"}</span
                     >
                   </button>
                 </div>


### PR DESCRIPTION
The markup is wrong because [`<button>`s should not have a separate `<label>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#buttons) - a button's label is its text content.

This was originally flagged as a low contrast issue by WAVE, but when I corrected the markup it went away. 

Although the existing colour [meets the requirement for non-text elements](https://www.w3.org/TR/WCAG22/#non-text-contrast) at a ratio of 3.91:1, I thought I may as well switch it to the darker blue to make it clearer (9.37:1).

Before:
<img width="84" alt="Screenshot 2024-09-26 at 15 46 45" src="https://github.com/user-attachments/assets/d21c2644-3784-4b68-a7b8-11fb1b77edfc">

After:
<img width="118" alt="Screenshot 2024-09-26 at 15 46 28" src="https://github.com/user-attachments/assets/42a76e8d-b0df-4a24-8641-f36021a97a43">