### PR TITLE
Fix broken labels on home page

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -15,8 +15,8 @@
               <div
                 class="app-search app-search--compact app-search--on-govuk-blue govuk-form-group govuk-!-padding-bottom-0 govuk-!-margin-bottom-2"
               >
-                <input id="search-input" name="query" class="search-input govuk-input" type="search" aria-label="search-input"/>
-                <button type="submit" aria-label="search-button">
+                <input id="search-input" name="query" class="search-input govuk-input" type="search" aria-label="Search input"/>
+                <button type="submit" aria-label="Search button">
                   <svg
                     aria-hidden="true"
                     focusable="false"
@@ -30,37 +30,33 @@
                       fill="currentColor"
                     ></path>
                   </svg>
-                  <span
-                    class="govuk-label govuk-visually-hidden-focusable"
-                  >{% translate "Search"}</span
-                    >
-                  </button>
-                </div>
-              </form>
-            </div>
+                </button>
+              </div>
+            </form>
           </div>
         </div>
       </div>
-      <div class="govuk-main-wrapper govuk-main-wrapper--l">
-        <div class="govuk-width-container app-width-container">
-          {% if domains %}
-            <h2 id="browse-by-domain" class="govuk-heading-l">{% translate "Browse by domain" %}</h2>
-            <ul id="domain-list" class="govuk-list govuk-list--bullet">
-              {% for domain in domains  %}
-                <li><a aria-label="Browse data for {{domain.name}} ({{domain.total}} result{{ domain.total|pluralize }})" href="{% url 'home:search' %}?domain={{domain.urn}}">{{domain.name}} ({{domain.total}} result{{ domain.total|pluralize }})</a></li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-          <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-          <h2 class="govuk-heading-l">{% translate "Help us grow" %} </h2>
-          <p class="govuk-body-m">{% translate "Find MoJ data is a new service with a growing catalogue of data. You can help us improve the service by:" %}</p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li><a href="https://user-guide.find-moj-data.service.justice.gov.uk/#adding-to-find-moj-data">{% translate "adding a new data source" %}</a></li>
-            <li><a href="https://user-guide.find-moj-data.service.justice.gov.uk/#contact-us">{% translate "telling us about data you would like to see" %}</a></li>
-            <li><a href="https://find-moj-data.service.justice.gov.uk/feedback/">{% translate "giving us feedback" %}</a></li>
+    </div>
+    <div class="govuk-main-wrapper govuk-main-wrapper--l">
+      <div class="govuk-width-container app-width-container">
+        {% if domains %}
+          <h2 id="browse-by-domain" class="govuk-heading-l">{% translate "Browse by domain" %}</h2>
+          <ul id="domain-list" class="govuk-list govuk-list--bullet">
+            {% for domain in domains  %}
+              <li><a aria-label="Browse data for {{domain.name}} ({{domain.total}} result{{ domain.total|pluralize }})" href="{% url 'home:search' %}?domain={{domain.urn}}">{{domain.name}} ({{domain.total}} result{{ domain.total|pluralize }})</a></li>
+            {% endfor %}
           </ul>
-        </div>
+        {% endif %}
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        <h2 class="govuk-heading-l">{% translate "Help us grow" %} </h2>
+        <p class="govuk-body-m">{% translate "Find MoJ data is a new service with a growing catalogue of data. You can help us improve the service by:" %}</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a href="https://user-guide.find-moj-data.service.justice.gov.uk/#adding-to-find-moj-data">{% translate "adding a new data source" %}</a></li>
+          <li><a href="https://user-guide.find-moj-data.service.justice.gov.uk/#contact-us">{% translate "telling us about data you would like to see" %}</a></li>
+          <li><a href="https://find-moj-data.service.justice.gov.uk/feedback/">{% translate "giving us feedback" %}</a></li>
+        </ul>
       </div>
-    </main>
+    </div>
+  </main>
 
 {% endblock main %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -12,9 +12,9 @@
         <div class="govuk-form-group">
           <h1 class="govuk-heading-l">{{h1_value}}</h1>
           <div class="app-search app-search--compact">
-            <label for="{{ form.query.id_for_label }}" class="govuk-label govuk-visually-hidden-focusable">{% translate "Search MOJ data" %}</label>
+            <label for="{{ form.query.id_for_label }}" class="govuk-label govuk-visually-hidden-focusable">{% translate "Search input" %}</label>
             {{ form.query }}
-            <button class="search-button" type="submit" id="search-button" aria-label="search-button">
+            <button class="search-button" type="submit" id="search-button" aria-label="Search button">
               <svg aria-hidden="true" class="search-icon" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" width="40" height="40">
                 <path d="M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z" fill="currentColor"></path>
               </svg>


### PR DESCRIPTION
Noticed when testing something else that

a) in the process of fixing a contrast issue, I mangled a translate tag on the search button
b) that button either way has an aria label, so we shouldn't need visually hidden text

I've removed the broken text, and made the labels consistent on both the home page and the search form.

Tested both pages in voiceover.