### PR TITLE
feat: add switch for table details is_nullable column

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ migrate:
 setup_waffle_switches:
 	poetry run python manage.py waffle_switch search-sort-radio-buttons off --create
 	poetry run python manage.py waffle_switch display-result-tags off --create
+	poetry run python manage.py waffle_switch show_is_nullable_in_table_details_column off --create
 
 # Run makemessages
 messages:

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -1,6 +1,7 @@
 {% extends "details_base.html" %}
 {% load markdown %}
 {% load i18n %}
+{% load waffle_tags %}
 
 {% block extra_details %}
   <div class="govuk-grid-row">
@@ -13,7 +14,9 @@
               <th scope="col" class="govuk-table__header">{% translate "Column name" %}</th>
               <th scope="col" class="govuk-table__header">{% translate "Description" %}</th>
               <th scope="col" class="govuk-table__header">{% translate "Type" %}</th>
-              <th scope="col" class="govuk-table__header">{% translate "Is Nullable" %}</th>
+              {% switch 'show_is_nullable_in_table_details_column' %}
+                <th scope="col" class="govuk-table__header">{% translate "Is Nullable" %}</th>
+              {% endswitch %}
             </tr>
           </thead>
           <tbody class="govuk-table__body">
@@ -28,7 +31,9 @@
                 {% endif %}
                 </td>
                 <td class="govuk-table__cell">{{column.type|title}}</td>
-                <td class="govuk-table__cell">{{column.nullable|yesno:"Yes,No,"}}</td>
+                {% switch 'show_is_nullable_in_table_details_column' %}
+                  <td class="govuk-table__cell">{{column.nullable|yesno:"Yes,No,"}}</td>
+                {% endswitch %}
               </tr>
             {% endfor %}
           </tbody>

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,6 @@
 import pytest
 from django.urls import reverse
+from waffle.testutils import override_switch
 
 
 class TestHomePage:
@@ -41,10 +42,15 @@ class TestSearchView:
 
 
 class TestTableView:
-    def test_table(self, client):
-        response = client.get(
-            reverse("home:details", kwargs={"urn": "fake", "result_type": "table"})
-        )
+    @pytest.mark.parametrize("switch_bool", [True, False])
+    @pytest.mark.django_db
+    def test_table(self, client, switch_bool):
+        with override_switch(
+            name="show_is_nullable_in_table_details_column", active=switch_bool
+        ):
+            response = client.get(
+                reverse("home:details", kwargs={"urn": "fake", "result_type": "table"})
+            )
         assert response.status_code == 200
         assert response.headers["Cache-Control"] == "max-age=300, private"
 


### PR DESCRIPTION
we are turning this off because currently is nullable metadata are not accurate