### PR TITLE
Don't hardcode platform name on chart/dashboard links

### DIFF
--- a/home/service/details.py
+++ b/home/service/details.py
@@ -146,6 +146,7 @@ class ChartDetailsService(GenericService):
         return {
             "entity": self.chart_metadata,
             "entity_type": _("Chart"),
+            "platform_name": _(self.chart_metadata.platform.display_name),
             "parent_entity": self.parent_entity,
             "parent_type": ResultType.DASHBOARD.name.lower(),
             "h1_value": self.chart_metadata.name,
@@ -168,6 +169,7 @@ class DashboardDetailsService(GenericService):
             "entity": self.dashboard_metadata,
             "entity_type": "Dashboard",
             "h1_value": self.dashboard_metadata.name,
+            "platform_name": _(self.dashboard_metadata.platform.display_name),
             "charts": sorted(
                 self.children,
                 key=lambda d: d.entity_ref.display_name,

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -595,8 +595,6 @@ msgstr "first name"
 msgid "last name"
 msgstr "last name"
 
-#~ msgid "Search metadata catalogue"
-#~ msgstr "Search for data"
-
-#~ msgid "Chart details"
-#~ msgstr "Chart details"
+# Workaround for Justice Data platform not having a readable display name
+msgid "justice-data"
+msgstr "Justice Data"

--- a/templates/details_chart.html
+++ b/templates/details_chart.html
@@ -8,9 +8,7 @@
                 {% translate "Access this data" %}
             </h2>
             <div class="govuk-body">
-                <a href="{{entity.external_url}}" class="govuk-link" rel="noreferrer noopener" target="_blank">
-                    {% blocktranslate with display_name=entity.display_name %}{{ display_name }} on Justice Data (opens in new tab){% endblocktranslate %}
-                </a>
+                <a href="{{entity.external_url}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{% blocktranslate with display_name=entity.display_name platform_name=platform_name %}"{{ display_name }}" on {{platform_name}}{% endblocktranslate %}</a> {% translate '(opens in new tab)' %}
             </div>
         </div>
     </div>

--- a/templates/details_dashboard.html
+++ b/templates/details_dashboard.html
@@ -40,12 +40,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-s govuk-!-margin-top-3">
-        URL
+        {% translate "Access this data" %}
       </h2>
       <div class="govuk-body">
-        <a href="{{entity.external_url}}" class="govuk-link" rel="noreferrer noopener" target="_blank">
-          {% translate "Justice Data (opens in new tab)" %}
-        </a>
+        <a href="{{entity.external_url}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ platform_name }}</a> {% translate "(opens in new tab)" %}
       </div>
     </div>
   </div>

--- a/tests/home/service/test_details.py
+++ b/tests/home/service/test_details.py
@@ -206,7 +206,7 @@ class TestChartDetailsService:
                     )
                 ],
             ),
-            platform=EntityRef(urn="", display_name=""),
+            platform=EntityRef(urn="", display_name="justice-data"),
         )
         mock_catalogue.get_chart_details.return_value = chart_metadata
 
@@ -214,6 +214,7 @@ class TestChartDetailsService:
         expected = {
             "entity": chart_metadata,
             "entity_type": "Chart",
+            "platform_name": "Justice Data",
             "parent_entity": None,
             "parent_type": "dashboard",
             "h1_value": "test",


### PR DESCRIPTION
New link text:

!["Absconds" on Justice Data](https://github.com/user-attachments/assets/18c4d9df-626e-45d5-baea-5febc4e23f04)
!["Receipts at crown court" on Criminal justice delivery data dashboard](https://github.com/user-attachments/assets/82823a66-c296-4417-893a-273129022caf)
