### PR TITLE
fix: remove dynamic content from translations

### DIFF
--- a/home/service/details.py
+++ b/home/service/details.py
@@ -40,6 +40,13 @@ def is_access_requirements_a_url(access_requirements) -> bool:
     return is_url
 
 
+def friendly_platform_name(platform_name):
+    if platform_name == "justice-data":
+        return "Justice Data"
+    else:
+        return platform_name
+
+
 class DatabaseDetailsService(GenericService):
     def __init__(self, urn: str):
         self.urn = urn
@@ -146,7 +153,9 @@ class ChartDetailsService(GenericService):
         return {
             "entity": self.chart_metadata,
             "entity_type": _("Chart"),
-            "platform_name": _(self.chart_metadata.platform.display_name),
+            "platform_name": friendly_platform_name(
+                self.chart_metadata.platform.display_name
+            ),
             "parent_entity": self.parent_entity,
             "parent_type": ResultType.DASHBOARD.name.lower(),
             "h1_value": self.chart_metadata.name,
@@ -169,7 +178,9 @@ class DashboardDetailsService(GenericService):
             "entity": self.dashboard_metadata,
             "entity_type": "Dashboard",
             "h1_value": self.dashboard_metadata.name,
-            "platform_name": _(self.dashboard_metadata.platform.display_name),
+            "platform_name": friendly_platform_name(
+                self.dashboard_metadata.platform.display_name
+            ),
             "charts": sorted(
                 self.children,
                 key=lambda d: d.entity_ref.display_name,

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Find MoJ data\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-14 11:45+0100\n"
+"POT-Creation-Date: 2024-10-22 15:17+0100\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -81,20 +81,15 @@ msgstr "Analytical Platform"
 msgid "Domain"
 msgstr "Subject area"
 
-#: home/forms/search.py:55
+#: home/forms/search.py:55 templates/partial/filter.html:36
 msgid "filter-refresh"
 msgstr "selection will trigger the filter and refresh the search results"
-
-#: home/forms/search.py:56 home/service/search.py:136
-#: templates/partial/filter.html:33
-msgid "Entity Types"
-msgstr "Entity types"
 
 #: home/service/details.py:65 templates/partial/search_result.html:20
 msgid "Database"
 msgstr "Database"
 
-#: home/service/details.py:139 templates/partial/search_result.html:24
+#: home/service/details.py:148 templates/partial/search_result.html:24
 msgid "Chart"
 msgstr "Chart"
 
@@ -105,6 +100,10 @@ msgstr "Glossary"
 #: home/service/metadata_specification.py:28
 msgid "Metadata specification"
 msgstr "Metadata specification"
+
+#: home/service/search.py:136 templates/partial/filter.html:33
+msgid "Entity Types"
+msgstr "Entity types"
 
 #: home/service/search.py:146
 msgid "Where To Access"
@@ -257,32 +256,36 @@ msgstr "Contact us"
 msgid "No description available."
 msgstr "No description available."
 
-#: templates/details_base.html:60
+#: templates/details_base.html:62
 msgid "First created:"
 msgstr "First created:"
 
-#: templates/details_base.html:66
+#: templates/details_base.html:68
 msgid "Last updated:"
 msgstr "Last updated:"
 
-#: templates/details_base.html:77 templates/partial/search_result.html:39
+#: templates/details_base.html:79 templates/partial/search_result.html:39
 msgid "Domain:"
 msgstr "Subject area:"
 
-#: templates/details_base.html:78 templates/partial/contact_info.html:15
+#: templates/details_base.html:80 templates/partial/contact_info.html:15
 #: templates/partial/contact_info.html:30
 #: templates/partial/search_result.html:40
 msgid "Not provided"
 msgstr "Not provided."
 
-#: templates/details_chart.html:8
+#: templates/details_chart.html:8 templates/details_dashboard.html:43
 msgid "Access this data"
 msgstr "Access this data"
 
-#: templates/details_chart.html:12
+#: templates/details_chart.html:11
 #, python-format
-msgid "%(display_name)s on Justice Data (opens in new tab)"
-msgstr "%(display_name)s on Justice Data (opens in new tab)"
+msgid "\"%(display_name)s\" on %(platform_name)s"
+msgstr ""
+
+#: templates/details_chart.html:11 templates/details_dashboard.html:46
+msgid "(opens in new tab)"
+msgstr "(opens in new tab)"
 
 #: templates/details_dashboard.html:10 templates/details_dashboard.html:35
 msgid "Dashboard content"
@@ -295,10 +298,6 @@ msgstr "Chart name"
 #: templates/details_dashboard.html:36
 msgid "This dashboard is missing chart information."
 msgstr "This dashboard is missing table information."
-
-#: templates/details_dashboard.html:47
-msgid "Justice Data (opens in new tab)"
-msgstr "Justice Data (opens in new tab)"
 
 #: templates/details_database.html:10 templates/details_database.html:39
 msgid "Database content"
@@ -363,15 +362,15 @@ msgstr ""
 "label=\"Learn more about Find MoJ data\" href=\"https://user-guide.find-moj-"
 "data.service.justice.gov.uk/\">Learn more</a>"
 
-#: templates/home.html:47
+#: templates/home.html:43
 msgid "Browse by domain"
 msgstr "Browse by subject area"
 
-#: templates/home.html:55
+#: templates/home.html:51
 msgid "Help us grow"
 msgstr "Help us grow"
 
-#: templates/home.html:56
+#: templates/home.html:52
 msgid ""
 "Find MoJ data is a new service with a growing catalogue of data. You can "
 "help us improve the service by:"
@@ -379,15 +378,15 @@ msgstr ""
 "Find MoJ data is a new service with a growing catalogue of data. You can "
 "help us improve the service by:"
 
-#: templates/home.html:58
+#: templates/home.html:54
 msgid "adding a new data source"
 msgstr "adding a new data source"
 
-#: templates/home.html:59
+#: templates/home.html:55
 msgid "telling us about data you would like to see"
 msgstr "telling us about data you would like to see"
 
-#: templates/home.html:60
+#: templates/home.html:56
 msgid "giving us feedback"
 msgstr "giving us feedback"
 
@@ -415,7 +414,7 @@ msgstr "Contact the data owner with questions."
 msgid "IAO or Data Owner"
 msgstr "Data owner"
 
-#: templates/partial/contact_info.html:41
+#: templates/partial/contact_info.html:43
 msgid ""
 "Not provided - <a href=\"https://moj.enterprise.slack.com/archives/"
 "C06NPM2200N\" class=\"govuk-link\">contact the Data Catalogue team</a> about "
@@ -538,8 +537,8 @@ msgid "Sort results"
 msgstr "Sort results"
 
 #: templates/search.html:15
-msgid "Search MOJ data"
-msgstr "Search MoJ data"
+msgid "Search input"
+msgstr "Search input"
 
 #: templates/search.html:28
 msgid "Search query tips"
@@ -594,7 +593,3 @@ msgstr "first name"
 #: users/models.py:12
 msgid "last name"
 msgstr "last name"
-
-# Workaround for Justice Data platform not having a readable display name
-msgid "justice-data"
-msgstr "Justice Data"


### PR DESCRIPTION
The po file was a bit messed up, because I stuck an extra translation for "Justice Data" in there. When makemessages ran again, it was removing this translation. Also there were some missing msgstrs and fuzzy matches.

This commit moves the justice-data -> Justice Data translation into the code instead.