### PR TITLE
Show data custodian if set in datahub

### DIFF
--- a/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
+++ b/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
@@ -42,10 +42,10 @@ from data_platform_catalogue.client.graphql_helpers import (
     parse_columns,
     parse_created_and_modified,
     parse_custodians,
+    parse_data_owner,
     parse_domain,
     parse_glossary_terms,
     parse_names,
-    parse_owner,
     parse_properties,
     parse_relations,
     parse_stewards,
@@ -268,7 +268,7 @@ class DataHubCatalogueClient:
             properties, custom_properties = parse_properties(response)
             columns = parse_columns(response)
             domain = parse_domain(response)
-            owner = parse_owner(response)
+            owner = parse_data_owner(response)
             stewards = parse_stewards(response)
             custodians = parse_custodians(response)
             tags = parse_tags(response)
@@ -323,7 +323,7 @@ class DataHubCatalogueClient:
             platform_name = response["platform"]["name"]
             properties, custom_properties = parse_properties(response)
             domain = parse_domain(response)
-            owner = parse_owner(response)
+            owner = parse_data_owner(response)
             stewards = parse_stewards(response)
             custodians = parse_custodians(response)
             tags = parse_tags(response)
@@ -363,7 +363,7 @@ class DataHubCatalogueClient:
             platform_name = response["platform"]["name"]
             properties, custom_properties = parse_properties(response)
             domain = parse_domain(response)
-            owner = parse_owner(response)
+            owner = parse_data_owner(response)
             stewards = parse_stewards(response)
             custodians = parse_custodians(response)
             tags = parse_tags(response)
@@ -406,7 +406,7 @@ class DataHubCatalogueClient:
             platform_name = response["platform"]["name"]
             properties, custom_properties = parse_properties(response)
             domain = parse_domain(response)
-            owner = parse_owner(response)
+            owner = parse_data_owner(response)
             stewards = parse_stewards(response)
             custodians = parse_custodians(response)
             tags = parse_tags(response)

--- a/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
+++ b/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
@@ -3,47 +3,6 @@ import logging
 from importlib.resources import files
 from typing import Sequence
 
-from data_platform_catalogue.client.exceptions import (
-    AspectDoesNotExist,
-    ConnectivityError,
-    EntityDoesNotExist,
-    InvalidDomain,
-    InvalidUser,
-    ReferencedEntityMissing,
-)
-from data_platform_catalogue.client.graphql_helpers import (
-    parse_columns,
-    parse_created_and_modified,
-    parse_domain,
-    parse_glossary_terms,
-    parse_names,
-    parse_owner,
-    parse_properties,
-    parse_relations,
-    parse_subtypes,
-    parse_tags,
-)
-from data_platform_catalogue.client.search import SearchClient
-from data_platform_catalogue.entities import (
-    Chart,
-    CustomEntityProperties,
-    Dashboard,
-    Database,
-    EntityRef,
-    EntitySummary,
-    Governance,
-    OwnerRef,
-    RelationshipType,
-    Table,
-)
-from data_platform_catalogue.search_types import (
-    DomainOption,
-    MultiSelectFilter,
-    ResultType,
-    SearchFacets,
-    SearchResponse,
-    SortOption,
-)
 from datahub.configuration.common import ConfigurationError
 from datahub.emitter import mce_builder
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
@@ -69,6 +28,49 @@ from datahub.metadata.schema_classes import (
     SchemaFieldDataTypeClass,
     SchemaMetadataClass,
     SubTypesClass,
+)
+
+from data_platform_catalogue.client.exceptions import (
+    AspectDoesNotExist,
+    ConnectivityError,
+    EntityDoesNotExist,
+    InvalidDomain,
+    InvalidUser,
+    ReferencedEntityMissing,
+)
+from data_platform_catalogue.client.graphql_helpers import (
+    parse_columns,
+    parse_created_and_modified,
+    parse_custodians,
+    parse_domain,
+    parse_glossary_terms,
+    parse_names,
+    parse_owner,
+    parse_properties,
+    parse_relations,
+    parse_stewards,
+    parse_subtypes,
+    parse_tags,
+)
+from data_platform_catalogue.client.search import SearchClient
+from data_platform_catalogue.entities import (
+    Chart,
+    CustomEntityProperties,
+    Dashboard,
+    Database,
+    EntityRef,
+    EntitySummary,
+    Governance,
+    RelationshipType,
+    Table,
+)
+from data_platform_catalogue.search_types import (
+    DomainOption,
+    MultiSelectFilter,
+    ResultType,
+    SearchFacets,
+    SearchResponse,
+    SortOption,
 )
 
 logger = logging.getLogger(__name__)
@@ -267,6 +269,8 @@ class DataHubCatalogueClient:
             columns = parse_columns(response)
             domain = parse_domain(response)
             owner = parse_owner(response)
+            stewards = parse_stewards(response)
+            custodians = parse_custodians(response)
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
             created, modified = parse_created_and_modified(properties)
@@ -298,8 +302,7 @@ class DataHubCatalogueClient:
                 relationships={**lineage_relations, **parent_relations_to_display},
                 domain=domain,
                 governance=Governance(
-                    data_owner=owner,
-                    data_stewards=[owner],
+                    data_owner=owner, data_stewards=stewards, data_custodians=custodians
                 ),
                 subtypes=subtypes,
                 tags=tags,
@@ -321,6 +324,8 @@ class DataHubCatalogueClient:
             properties, custom_properties = parse_properties(response)
             domain = parse_domain(response)
             owner = parse_owner(response)
+            stewards = parse_stewards(response)
+            custodians = parse_custodians(response)
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
             name, display_name, qualified_name = parse_names(response, properties)
@@ -339,12 +344,7 @@ class DataHubCatalogueClient:
                 fully_qualified_name=qualified_name,
                 domain=domain,
                 governance=Governance(
-                    data_owner=owner,
-                    data_stewards=[
-                        OwnerRef(
-                            display_name="", email="Contact email for the user", urn=""
-                        )
-                    ],
+                    data_owner=owner, data_stewards=stewards, data_custodians=custodians
                 ),
                 relationships=relations_to_display,
                 tags=tags,
@@ -364,6 +364,8 @@ class DataHubCatalogueClient:
             properties, custom_properties = parse_properties(response)
             domain = parse_domain(response)
             owner = parse_owner(response)
+            stewards = parse_stewards(response)
+            custodians = parse_custodians(response)
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
             created, modified = parse_created_and_modified(properties)
@@ -385,8 +387,7 @@ class DataHubCatalogueClient:
                 relationships=relations_to_display,
                 domain=domain,
                 governance=Governance(
-                    data_owner=owner,
-                    data_stewards=[owner],
+                    data_owner=owner, data_custodians=custodians, data_stewards=stewards
                 ),
                 tags=tags,
                 glossary_terms=glossary_terms,
@@ -406,6 +407,8 @@ class DataHubCatalogueClient:
             properties, custom_properties = parse_properties(response)
             domain = parse_domain(response)
             owner = parse_owner(response)
+            stewards = parse_stewards(response)
+            custodians = parse_custodians(response)
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
             created, modified = parse_created_and_modified(properties)
@@ -424,8 +427,7 @@ class DataHubCatalogueClient:
                 relationships=relations_to_display,
                 domain=domain,
                 governance=Governance(
-                    data_owner=owner,
-                    data_stewards=[owner],
+                    data_owner=owner, data_stewards=stewards, data_custodians=custodians
                 ),
                 external_url=properties.get("externalUrl", ""),
                 tags=tags,

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getChartDetails.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getChartDetails.graphql
@@ -5,7 +5,9 @@ query getChartDetails($urn: String!) {
     platform {
       name
     }
-    relationships(input: {types: ["Contains"], direction:INCOMING start: 0, count: 10 }) {
+    relationships(
+      input: { types: ["Contains"], direction: INCOMING, start: 0, count: 10 }
+    ) {
       total
       relationships {
         entity {
@@ -18,7 +20,9 @@ query getChartDetails($urn: String!) {
             }
             tags {
               tags {
-                tag{urn}
+                tag {
+                  urn
+                }
               }
             }
             subTypes {
@@ -50,24 +54,7 @@ query getChartDetails($urn: String!) {
       }
     }
     ownership {
-      owners {
-        owner {
-          ... on CorpUser {
-            urn
-            properties {
-              fullName
-              email
-            }
-          }
-          ... on CorpGroup {
-            urn
-            properties {
-              displayName
-              email
-            }
-          }
-        }
-      }
+      ...ownershipFields
     }
     properties {
       name
@@ -81,6 +68,34 @@ query getChartDetails($urn: String!) {
       lastModified {
         time
         actor
+      }
+    }
+  }
+}
+
+fragment ownershipFields on Ownership {
+  owners {
+    owner {
+      ... on CorpUser {
+        urn
+        properties {
+          email
+          fullName
+        }
+      }
+      ... on CorpGroup {
+        urn
+        properties {
+          displayName
+          email
+        }
+      }
+    }
+    ownershipType {
+      urn
+      type
+      info {
+        name
       }
     }
   }

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getDashboardDetails.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getDashboardDetails.graphql
@@ -19,7 +19,9 @@ query getDashboard($urn: String!) {
     editableProperties {
       description
     }
-    relationships(input: {types: ["Contains"], direction:OUTGOING start: 0, count: 500 }) {
+    relationships(
+      input: { types: ["Contains"], direction: OUTGOING, start: 0, count: 500 }
+    ) {
       total
       relationships {
         entity {
@@ -32,7 +34,9 @@ query getDashboard($urn: String!) {
             }
             tags {
               tags {
-                tag{urn}
+                tag {
+                  urn
+                }
               }
             }
           }

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getDashboardDetails.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getDashboardDetails.graphql
@@ -7,6 +7,9 @@ query getDashboard($urn: String!) {
       urn
       name
     }
+    ownership {
+      ...ownershipFields
+    }
     properties {
       name
       description
@@ -41,6 +44,34 @@ query getDashboard($urn: String!) {
             }
           }
         }
+      }
+    }
+  }
+}
+
+fragment ownershipFields on Ownership {
+  owners {
+    owner {
+      ... on CorpUser {
+        urn
+        properties {
+          email
+          fullName
+        }
+      }
+      ... on CorpGroup {
+        urn
+        properties {
+          displayName
+          email
+        }
+      }
+    }
+    ownershipType {
+      urn
+      type
+      info {
+        name
       }
     }
   }

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getDatasetDetails.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getDatasetDetails.graphql
@@ -86,24 +86,7 @@ query getDatasetDetails($urn: String!) {
       }
     }
     ownership {
-      owners {
-        owner {
-          ... on CorpUser {
-            urn
-            properties {
-              fullName
-              email
-            }
-          }
-          ... on CorpGroup {
-            urn
-            properties {
-              displayName
-              email
-            }
-          }
-        }
-      }
+      ...ownershipFields
     }
     name
     properties {
@@ -170,6 +153,34 @@ query getDatasetDetails($urn: String!) {
         sourceFields {
           fieldPath
         }
+      }
+    }
+  }
+}
+
+fragment ownershipFields on Ownership {
+  owners {
+    owner {
+      ... on CorpUser {
+        urn
+        properties {
+          email
+          fullName
+        }
+      }
+      ... on CorpGroup {
+        urn
+        properties {
+          displayName
+          email
+        }
+      }
+    }
+    ownershipType {
+      urn
+      type
+      info {
+        name
       }
     }
   }

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/search.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/search.graphql
@@ -61,24 +61,7 @@ query Search(
             name
           }
           ownership {
-            owners {
-              owner {
-                ... on CorpUser {
-                  urn
-                  properties {
-                    fullName
-                    email
-                  }
-                }
-                ... on CorpGroup {
-                  urn
-                  properties {
-                    displayName
-                    email
-                  }
-                }
-              }
-            }
+            ...ownershipFields
           }
           tags {
             tags {
@@ -130,24 +113,7 @@ query Search(
             typeNames
           }
           ownership {
-            owners {
-              owner {
-                ... on CorpUser {
-                  urn
-                  properties {
-                    fullName
-                    email
-                  }
-                }
-                ... on CorpGroup {
-                  urn
-                  properties {
-                    displayName
-                    email
-                  }
-                }
-              }
-            }
+            ...ownershipFields
           }
           properties {
             name
@@ -207,24 +173,7 @@ query Search(
             typeNames
           }
           ownership {
-            owners {
-              owner {
-                ... on CorpUser {
-                  urn
-                  properties {
-                    fullName
-                    email
-                  }
-                }
-                ... on CorpGroup {
-                  urn
-                  properties {
-                    displayName
-                    email
-                  }
-                }
-              }
-            }
+            ...ownershipFields
           }
           name
           properties {
@@ -285,24 +234,7 @@ query Search(
             typeNames
           }
           ownership {
-            owners {
-              owner {
-                ... on CorpUser {
-                  urn
-                  properties {
-                    fullName
-                    email
-                  }
-                }
-                ... on CorpGroup {
-                  urn
-                  properties {
-                    displayName
-                    email
-                  }
-                }
-              }
-            }
+            ...ownershipFields
           }
           properties {
             name
@@ -345,6 +277,34 @@ query Search(
             }
           }
         }
+      }
+    }
+  }
+}
+
+fragment ownershipFields on Ownership {
+  owners {
+    owner {
+      ... on CorpUser {
+        urn
+        properties {
+          email
+          fullName
+        }
+      }
+      ... on CorpGroup {
+        urn
+        properties {
+          displayName
+          email
+        }
+      }
+    }
+    ownershipType {
+      urn
+      type
+      info {
+        name
       }
     }
   }

--- a/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
@@ -39,7 +39,7 @@ def get_graphql_query(graphql_query_file_name: str) -> str:
     return query_text
 
 
-def _parse_owner(owner: dict):
+def _parse_owner_object(owner: dict):
     properties = owner.get("properties") or {}
     display_name = (
         properties.get("displayName")
@@ -56,9 +56,8 @@ def _parse_owner(owner: dict):
     )
 
 
-def parse_owner(
+def parse_data_owner(
     entity: dict[str, Any],
-    ownership_type_urn: str = DATA_OWNER,
 ) -> OwnerRef:
     """
     Parse ownership information, if it is set, and return the first owner of
@@ -69,16 +68,16 @@ def parse_owner(
     owners = [
         i["owner"]
         for i in ownership.get("owners", [])
-        if i["ownershipType"]["urn"] == ownership_type_urn
+        if i["ownershipType"]["urn"] == DATA_OWNER
     ]
 
     if owners:
-        return _parse_owner(owners[0])
+        return _parse_owner_object(owners[0])
     else:
         return OwnerRef(display_name="", email="", urn="")
 
 
-def parse_owners(
+def _parse_owners_by_type(
     entity: dict[str, Any],
     ownership_type_urn: str,
 ) -> list[OwnerRef]:
@@ -94,7 +93,7 @@ def parse_owners(
         if i["ownershipType"]["urn"] == ownership_type_urn
     ]
 
-    return [_parse_owner(owner) for owner in owners]
+    return [_parse_owner_object(owner) for owner in owners]
 
 
 def parse_custodians(entity: dict[str, Any]) -> list[OwnerRef]:
@@ -102,7 +101,7 @@ def parse_custodians(entity: dict[str, Any]) -> list[OwnerRef]:
     Parse ownership information, if it is set, and return a list of data custodians.
     If no owners exist with a matching ownership type, the list will be empty.
     """
-    return parse_owners(entity, DATA_CUSTODIAN)
+    return _parse_owners_by_type(entity, DATA_CUSTODIAN)
 
 
 def parse_stewards(entity: dict[str, Any]) -> list[OwnerRef]:
@@ -110,7 +109,7 @@ def parse_stewards(entity: dict[str, Any]) -> list[OwnerRef]:
     Parse ownership information, if it is set, and return a list of data stewards.
     If no owners exist with a matching ownership type, the list will be empty.
     """
-    return parse_owners(entity, DATA_STEWARD)
+    return _parse_owners_by_type(entity, DATA_STEWARD)
 
 
 def parse_last_modified(entity: dict[str, Any]) -> datetime | None:

--- a/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
@@ -22,6 +22,13 @@ from data_platform_catalogue.entities import (
 
 PROPERTIES_EMPTY_STRING_FIELDS = ("description", "externalUrl")
 
+# Note: Data owner is missing as an ownershipType entity in Datahub, but it still seems to be
+# a system type, and if you set up an add_owner meta mapping in the DBT source, this is what
+# gets used by default.
+DATA_OWNER = "urn:li:ownershipType:__system__dataowner"
+DATA_STEWARD = "urn:li:ownershipType:__system__data_steward"
+DATA_CUSTODIAN = "urn:li:ownershipType:data_custodian"
+
 
 def get_graphql_query(graphql_query_file_name: str) -> str:
     query_text = (
@@ -32,12 +39,30 @@ def get_graphql_query(graphql_query_file_name: str) -> str:
     return query_text
 
 
+def _parse_owner(owner: dict):
+    properties = owner.get("properties") or {}
+    display_name = (
+        properties.get("displayName")
+        if properties.get("displayName") is not None
+        else properties.get("fullName", "")
+    )
+    return OwnerRef(
+        display_name=display_name or "",
+        email=properties.get(
+            "email",
+            _make_user_email_from_urn(owner.get("urn")),
+        ),
+        urn=owner.get("urn", ""),
+    )
+
+
 def parse_owner(
     entity: dict[str, Any],
-    ownership_type_urn: str = "urn:li:ownershipType:__system__dataowner",
+    ownership_type_urn: str = DATA_OWNER,
 ) -> OwnerRef:
     """
-    Parse ownership information, if it is set.
+    Parse ownership information, if it is set, and return the first owner of
+    type `ownership_type_urn`.
     If no owner information exists, return an OwnerRef populated with blank strings
     """
     ownership = entity.get("ownership") or {}
@@ -48,24 +73,44 @@ def parse_owner(
     ]
 
     if owners:
-        properties = owners[0].get("properties") or {}
-        display_name = (
-            properties.get("displayName")
-            if properties.get("displayName") is not None
-            else properties.get("fullName", "")
-        )
-        owner_details = OwnerRef(
-            display_name=display_name or "",
-            email=properties.get(
-                "email",
-                _make_user_email_from_urn(owners[0].get("urn")),
-            ),
-            urn=owners[0].get("urn", ""),
-        )
+        return _parse_owner(owners[0])
     else:
-        owner_details = OwnerRef(display_name="", email="", urn="")
+        return OwnerRef(display_name="", email="", urn="")
 
-    return owner_details
+
+def parse_owners(
+    entity: dict[str, Any],
+    ownership_type_urn: str,
+) -> list[OwnerRef]:
+    """
+    Parse ownership information, if it is set, and return a list of owners
+    of type `ownership_type_urn`.
+    If no owner information exists, the list will be empty.
+    """
+    ownership = entity.get("ownership") or {}
+    owners = [
+        i["owner"]
+        for i in ownership.get("owners", [])
+        if i["ownershipType"]["urn"] == ownership_type_urn
+    ]
+
+    return [_parse_owner(owner) for owner in owners]
+
+
+def parse_custodians(entity: dict[str, Any]) -> list[OwnerRef]:
+    """
+    Parse ownership information, if it is set, and return a list of data custodians.
+    If no owners exist with a matching ownership type, the list will be empty.
+    """
+    return parse_owners(entity, DATA_CUSTODIAN)
+
+
+def parse_stewards(entity: dict[str, Any]) -> list[OwnerRef]:
+    """
+    Parse ownership information, if it is set, and return a list of data stewards.
+    If no owners exist with a matching ownership type, the list will be empty.
+    """
+    return parse_owners(entity, DATA_STEWARD)
 
 
 def parse_last_modified(entity: dict[str, Any]) -> datetime | None:

--- a/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql_helpers.py
@@ -32,13 +32,21 @@ def get_graphql_query(graphql_query_file_name: str) -> str:
     return query_text
 
 
-def parse_owner(entity: dict[str, Any]) -> OwnerRef:
+def parse_owner(
+    entity: dict[str, Any],
+    ownership_type_urn: str = "urn:li:ownershipType:__system__dataowner",
+) -> OwnerRef:
     """
     Parse ownership information, if it is set.
     If no owner information exists, return an OwnerRef populated with blank strings
     """
     ownership = entity.get("ownership") or {}
-    owners = [i["owner"] for i in ownership.get("owners", [])]
+    owners = [
+        i["owner"]
+        for i in ownership.get("owners", [])
+        if i["ownershipType"]["urn"] == ownership_type_urn
+    ]
+
     if owners:
         properties = owners[0].get("properties") or {}
         display_name = (

--- a/lib/datahub-client/data_platform_catalogue/client/search.py
+++ b/lib/datahub-client/data_platform_catalogue/client/search.py
@@ -9,11 +9,11 @@ from data_platform_catalogue.client.exceptions import CatalogueError
 from data_platform_catalogue.client.graphql_helpers import (
     get_graphql_query,
     parse_created_and_modified,
+    parse_data_owner,
     parse_domain,
     parse_glossary_terms,
     parse_last_modified,
     parse_names,
-    parse_owner,
     parse_properties,
     parse_tags,
 )
@@ -274,7 +274,7 @@ class SearchClient:
         """
         Map a dataset entity to a SearchResult
         """
-        owner = parse_owner(entity)
+        owner = parse_data_owner(entity)
         properties, custom_properties = parse_properties(entity)
         tags = parse_tags(entity)
         terms = parse_glossary_terms(entity)
@@ -425,7 +425,7 @@ class SearchClient:
         last_modified = parse_last_modified(entity)
         properties, custom_properties = parse_properties(entity)
         domain = parse_domain(entity)
-        owner = parse_owner(entity)
+        owner = parse_data_owner(entity)
         name, display_name, qualified_name = parse_names(entity, properties)
 
         metadata = {

--- a/lib/datahub-client/data_platform_catalogue/client/search.py
+++ b/lib/datahub-client/data_platform_catalogue/client/search.py
@@ -2,6 +2,9 @@ import json
 import logging
 from typing import Any, Sequence, Tuple
 
+from datahub.configuration.common import GraphError  # pylint: disable=E0611
+from datahub.ingestion.graph.client import DataHubGraph  # pylint: disable=E0611
+
 from data_platform_catalogue.client.exceptions import CatalogueError
 from data_platform_catalogue.client.graphql_helpers import (
     get_graphql_query,
@@ -25,8 +28,6 @@ from data_platform_catalogue.search_types import (
     SearchResult,
     SortOption,
 )
-from datahub.configuration.common import GraphError  # pylint: disable=E0611
-from datahub.ingestion.graph.client import DataHubGraph  # pylint: disable=E0611
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +137,7 @@ class SearchClient:
                 else:
                     raise Exception
             except Exception:
-                logger.warn(f"Parsing for result {entity_urn} failed")
+                logger.exception(f"Parsing for result {entity_urn} failed")
                 malformed_result_urns.append(entity_urn)
 
         return page_results, malformed_result_urns

--- a/lib/datahub-client/data_platform_catalogue/entities.py
+++ b/lib/datahub-client/data_platform_catalogue/entities.py
@@ -120,7 +120,7 @@ class Governance(BaseModel):
     """
 
     data_owner: OwnerRef = Field(
-        description="The senior individual responsible for the data.",
+        description="Senior leader within the business (DD and above) who sponsors and champions data governance work within their data domain.",  # noqa: E501
         examples=[
             OwnerRef(
                 display_name="John Doe",
@@ -130,7 +130,7 @@ class Governance(BaseModel):
         ],
     )
     data_stewards: list[OwnerRef] = Field(
-        description="Experts who manage the data day-to-day.",
+        description="Subject matter expert within a business area (SEO – DD) or the associated data domain, acting as a go-between for business users and digital teams/system owners.",  # noqa: E501
         examples=[
             [
                 OwnerRef(
@@ -140,6 +140,20 @@ class Governance(BaseModel):
                 )
             ]
         ],
+        default_factory=list,
+    )
+    data_custodians: list[OwnerRef] = Field(
+        description="Responsible for the capture, storage, and disposal of data as per the Data owner and Data steward’s requirements, and within the limits of data quality and security limitations.",  # noqa: E501
+        examples=[
+            [
+                OwnerRef(
+                    display_name="Rosanne Columns",
+                    email="rosanne.columns@justice.gov.uk",
+                    urn="urn:li:corpuser:rosanne.columns",
+                )
+            ]
+        ],
+        default_factory=list,
     )
 
 

--- a/lib/datahub-client/tests/client/datahub/test_datahub_client.py
+++ b/lib/datahub-client/tests/client/datahub/test_datahub_client.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from data_platform_catalogue.client.datahub_client import (
     DataHubCatalogueClient,
     InvalidDomain,
@@ -393,7 +394,7 @@ class TestCatalogueClientWithDatahub:
             domain=DomainRef(display_name="", urn=""),
             governance=Governance(
                 data_owner=OwnerRef(display_name="", email="", urn=""),
-                data_stewards=[OwnerRef(display_name="", email="", urn="")],
+                data_stewards=[],
             ),
             tags=[TagRef(display_name="some-tag", urn="urn:li:tag:Entity")],
             last_modified=datetime(2024, 3, 5, 6, 16, 47, 814000, tzinfo=timezone.utc),
@@ -460,7 +461,7 @@ class TestCatalogueClientWithDatahub:
             domain=DomainRef(display_name="", urn=""),
             governance=Governance(
                 data_owner=OwnerRef(display_name="", email="", urn=""),
-                data_stewards=[OwnerRef(display_name="", email="", urn="")],
+                data_stewards=[],
             ),
             tags=[],
             last_modified=None,
@@ -519,11 +520,7 @@ class TestCatalogueClientWithDatahub:
             domain=DomainRef(display_name="", urn=""),
             governance=Governance(
                 data_owner=OwnerRef(display_name="", email="", urn=""),
-                data_stewards=[
-                    OwnerRef(
-                        display_name="", email="Contact email for the user", urn=""
-                    )
-                ],
+                data_stewards=[],
             ),
             tags=[],
             last_modified=None,

--- a/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
+++ b/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
@@ -5,11 +5,11 @@ import pytest
 from data_platform_catalogue.client.graphql_helpers import (
     DATA_CUSTODIAN,
     _make_user_email_from_urn,
+    _parse_owners_by_type,
     parse_columns,
     parse_created_and_modified,
+    parse_data_owner,
     parse_glossary_terms,
-    parse_owner,
-    parse_owners,
     parse_properties,
     parse_relations,
     parse_subtypes,
@@ -551,26 +551,6 @@ def test_parse_missing_subtypes():
     assert result == []
 
 
-def test_parse_owner_of_wrong_type():
-    entity = {
-        "ownership": {
-            "owners": [
-                {
-                    "owner": {"urn": "urn:li:corpuser:joe.bloggs", "properties": None},
-                    "ownershipType": {
-                        "urn": "urn:li:ownershipType:__system__dataowner",
-                        "type": "CUSTOM_OWNERSHIP_TYPE",
-                        "info": None,
-                    },
-                }
-            ]
-        }
-    }
-
-    owner = parse_owner(entity, ownership_type_urn="urn:li:ownershipType:chiefMouser")
-    assert owner == OwnerRef(display_name="", email="", urn="")
-
-
 def test_parse_owner_without_account():
     entity = {
         "ownership": {
@@ -586,7 +566,7 @@ def test_parse_owner_without_account():
             ]
         }
     }
-    owner = parse_owner(entity)
+    owner = parse_data_owner(entity)
     assert owner.email == "joe.bloggs@justice.gov.uk"
 
 
@@ -611,7 +591,7 @@ def test_parse_owner_with_account():
             ]
         }
     }
-    owner = parse_owner(entity)
+    owner = parse_data_owner(entity)
     assert owner.email == "joeseph.bloggerson-bloggs@justice.gov.uk"
 
 
@@ -642,7 +622,7 @@ def test_parse_owners():
             ]
         }
     }
-    owners = parse_owners(entity, ownership_type_urn=DATA_CUSTODIAN)
+    owners = _parse_owners_by_type(entity, ownership_type_urn=DATA_CUSTODIAN)
     assert owners == [
         OwnerRef(
             urn="urn:li:corpuser:word.smith",

--- a/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
+++ b/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
@@ -3,11 +3,13 @@ from datetime import datetime, timezone
 import pytest
 
 from data_platform_catalogue.client.graphql_helpers import (
+    DATA_CUSTODIAN,
     _make_user_email_from_urn,
     parse_columns,
     parse_created_and_modified,
     parse_glossary_terms,
     parse_owner,
+    parse_owners,
     parse_properties,
     parse_relations,
     parse_subtypes,
@@ -611,3 +613,45 @@ def test_parse_owner_with_account():
     }
     owner = parse_owner(entity)
     assert owner.email == "joeseph.bloggerson-bloggs@justice.gov.uk"
+
+
+def test_parse_owners():
+    entity = {
+        "ownership": {
+            "owners": [
+                {
+                    "owner": {
+                        "urn": "urn:li:corpuser:word.smith",
+                        "properties": None,
+                    },
+                    "ownershipType": {
+                        "urn": "urn:li:ownershipType:data_custodian",
+                        "type": "CUSTOM_OWNERSHIP_TYPE",
+                    },
+                },
+                {
+                    "owner": {
+                        "urn": "urn:li:corpuser:mo.numbers",
+                        "properties": None,
+                    },
+                    "ownershipType": {
+                        "urn": "urn:li:ownershipType:data_custodian",
+                        "type": "CUSTOM_OWNERSHIP_TYPE",
+                    },
+                },
+            ]
+        }
+    }
+    owners = parse_owners(entity, ownership_type_urn=DATA_CUSTODIAN)
+    assert owners == [
+        OwnerRef(
+            urn="urn:li:corpuser:word.smith",
+            email="word.smith@justice.gov.uk",
+            display_name="",
+        ),
+        OwnerRef(
+            urn="urn:li:corpuser:mo.numbers",
+            email="mo.numbers@justice.gov.uk",
+            display_name="",
+        ),
+    ]

--- a/lib/datahub-client/tests/client/datahub/test_search.py
+++ b/lib/datahub-client/tests/client/datahub/test_search.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
+
 from data_platform_catalogue.client.search import SearchClient
 from data_platform_catalogue.entities import (
     AccessInformation,
@@ -661,7 +662,10 @@ def test_result_with_owner(mock_graph, searcher):
                                             "fullName": "Shannon Lovett",
                                             "email": "shannon@longtail.com",
                                         },
-                                    }
+                                    },
+                                    "ownershipType": {
+                                        "urn": "urn:li:ownershipType:__system__dataowner"
+                                    },
                                 }
                             ]
                         },
@@ -1126,7 +1130,10 @@ def test_search_for_container(mock_graph, searcher):
                                             "fullName": "Shannon Lovett",
                                             "email": "shannon@longtail.com",
                                         },
-                                    }
+                                    },
+                                    "ownershipType": {
+                                        "urn": "urn:li:ownershipType:__system__dataowner"
+                                    },
                                 }
                             ]
                         },

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Find MoJ data\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 15:17+0100\n"
+"POT-Creation-Date: 2024-10-28 12:09+0000\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,27 +32,27 @@ msgstr "There is a problem with this service"
 msgid "Page not found"
 msgstr "Page not found"
 
-#: feedback/models.py:19
+#: feedback/models.py:17
 msgid "Satisfaction survey"
 msgstr "Satisfaction survey"
 
-#: feedback/models.py:25
+#: feedback/models.py:23
 msgid "How can we improve this service?"
 msgstr "How can we improve this service?"
 
-#: feedback/models.py:45
+#: feedback/models.py:40
 msgid "What is wrong with this page?"
 msgstr ""
 
-#: feedback/models.py:50
+#: feedback/models.py:45
 msgid "Can you provide more detail?"
 msgstr ""
 
-#: feedback/templates/feedback.html:18 feedback/templates/report_issue.html:23
+#: feedback/templates/feedback.html:18 feedback/templates/report_issue.html:17
 msgid "There is a problem"
 msgstr "There is a problem"
 
-#: feedback/templates/feedback.html:21 feedback/templates/report_issue.html:26
+#: feedback/templates/feedback.html:21 feedback/templates/report_issue.html:20
 msgid "Make sure you have filled in all the fields."
 msgstr "Make sure you have filled in all the fields."
 
@@ -64,11 +64,11 @@ msgstr ""
 "Do not include personal or financial information, like your National "
 "Insurance number or credit card details."
 
-#: feedback/templates/report_issue.html:64
+#: feedback/templates/report_issue.html:58
 msgid "Please provide as much information as possible about the issue."
 msgstr ""
 
-#: feedback/templates/thanks.html:9 feedback/views.py:38
+#: feedback/templates/thanks.html:9 feedback/views.py:39
 msgid "Thank you for your feedback"
 msgstr "Thank you for your feedback"
 
@@ -76,17 +76,13 @@ msgstr "Thank you for your feedback"
 msgid "Your feedback will help us improve the service."
 msgstr "Your feedback will help us improve the service."
 
-#: feedback/views.py:28
+#: feedback/views.py:29
 msgid "Give feedback on Find MOJ data"
 msgstr "Give feedback on Find MOJ data"
 
-#: feedback/views.py:64
-msgid "Report an issue with {request.session.get('entity_name')}"
-msgstr ""
-
-#: feedback/views.py:83
-#, python-brace-format
-msgid "Report an issue with {entity_name}"
+#: feedback/views.py:64 feedback/views.py:83
+#, python-format
+msgid "Report an issue with %s"
 msgstr ""
 
 #: home/forms/search.py:16
@@ -106,11 +102,11 @@ msgstr "Subject area"
 msgid "filter-refresh"
 msgstr "selection will trigger the filter and refresh the search results"
 
-#: home/service/details.py:65 templates/partial/search_result.html:20
+#: home/service/details.py:72 templates/partial/search_result.html:20
 msgid "Database"
 msgstr "Database"
 
-#: home/service/details.py:148 templates/partial/search_result.html:24
+#: home/service/details.py:155 templates/partial/search_result.html:24
 msgid "Chart"
 msgstr "Chart"
 
@@ -289,8 +285,8 @@ msgstr "Last updated:"
 msgid "Domain:"
 msgstr "Subject area:"
 
-#: templates/details_base.html:80 templates/partial/contact_info.html:15
-#: templates/partial/contact_info.html:30
+#: templates/details_base.html:80 templates/partial/contact_info.html:17
+#: templates/partial/contact_info.html:34
 #: templates/partial/search_result.html:40
 msgid "Not provided"
 msgstr "Not provided."
@@ -383,15 +379,15 @@ msgstr ""
 "label=\"Learn more about Find MoJ data\" href=\"https://user-guide.find-moj-"
 "data.service.justice.gov.uk/\">Learn more</a>"
 
-#: templates/home.html:43
+#: templates/home.html:44
 msgid "Browse by domain"
 msgstr "Browse by subject area"
 
-#: templates/home.html:51
+#: templates/home.html:52
 msgid "Help us grow"
 msgstr "Help us grow"
 
-#: templates/home.html:52
+#: templates/home.html:53
 msgid ""
 "Find MoJ data is a new service with a growing catalogue of data. You can "
 "help us improve the service by:"
@@ -399,15 +395,15 @@ msgstr ""
 "Find MoJ data is a new service with a growing catalogue of data. You can "
 "help us improve the service by:"
 
-#: templates/home.html:54
+#: templates/home.html:55
 msgid "adding a new data source"
 msgstr "adding a new data source"
 
-#: templates/home.html:55
+#: templates/home.html:56
 msgid "telling us about data you would like to see"
 msgstr "telling us about data you would like to see"
 
-#: templates/home.html:56
+#: templates/home.html:57
 msgid "giving us feedback"
 msgstr "giving us feedback"
 
@@ -420,22 +416,34 @@ msgid "Click link for access information (opens in new tab)"
 msgstr "Select this link for access information (opens in new tab)"
 
 #: templates/partial/contact_info.html:13
+msgid "Please contact the data custodian for access information."
+msgstr "Contact the data custodian to request access."
+
+#: templates/partial/contact_info.html:15
 msgid "Please contact the data owner for access information."
 msgstr "Contact the data owner to request access."
 
-#: templates/partial/contact_info.html:22
+#: templates/partial/contact_info.html:24
 msgid "Contact channels for questions"
 msgstr "Ask a question"
 
-#: templates/partial/contact_info.html:28
+#: templates/partial/contact_info.html:30
+msgid "Contact the data custodian with questions."
+msgstr ""
+
+#: templates/partial/contact_info.html:32
 msgid "Contact the data owner with questions."
 msgstr "Contact the data owner with questions."
 
-#: templates/partial/contact_info.html:36
+#: templates/partial/contact_info.html:41
+msgid "Data custodian"
+msgstr "Data custodian (technical contact)"
+
+#: templates/partial/contact_info.html:48
 msgid "IAO or Data Owner"
 msgstr "Data owner"
 
-#: templates/partial/contact_info.html:43
+#: templates/partial/contact_info.html:55
 msgid ""
 "Not provided - <a href=\"https://moj.enterprise.slack.com/archives/"
 "C06NPM2200N\" class=\"govuk-link\">contact the Data Catalogue team</a> about "
@@ -557,15 +565,15 @@ msgstr "Remove this filter"
 msgid "Sort results"
 msgstr "Sort results"
 
-#: templates/search.html:15
+#: templates/search.html:16
 msgid "Search input"
 msgstr "Search input"
 
-#: templates/search.html:28
+#: templates/search.html:29
 msgid "Search query tips"
 msgstr "Search tips"
 
-#: templates/search.html:33
+#: templates/search.html:34
 #, python-format
 msgid ""
 "<ul class=\"govuk-list govuk-list--bullet\"> <li><p>Use multiple words to "
@@ -595,7 +603,7 @@ msgstr ""
 "li>            </ul>            <p><a href=\"%(more_examples_href)s\">More "
 "advanced search options</a></p>"
 
-#: templates/search.html:50
+#: templates/search.html:51
 msgid "Some results were malformed and are not shown"
 msgstr "Some results were malformed and are not shown"
 

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -95,7 +95,7 @@
       </div>
     </div>
     <div class="govuk-grid-column-one-third">
-      {% include "partial/contact_info.html" with entity_name=entity.name data_owner=entity.governance.data_owner.display_name data_owner_email=entity.governance.data_owner.email further_information=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_url=is_access_requirements_a_url platform=entity.platform %}
+      {% include "partial/contact_info.html" with entity_name=entity.name governance=entity.governance further_information=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_url=is_access_requirements_a_url platform=entity.platform %}
     </div>
   </div>
 

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -9,7 +9,9 @@
       {% else %}
         {{ access_requirements }}
       {% endif %}
-    {% elif data_owner_email %}
+    {% elif governance.data_custodians %}
+      {% translate "Please contact the data custodian for access information." %}
+    {% elif governance.data_owner.email %}
       {% translate "Please contact the data owner for access information." %}
     {% else %}
       {% translate "Not provided" %}
@@ -34,20 +36,32 @@
     {% if further_information.dc_team_email %}
       <li id="contact_channels_team_email" >{{ further_information.dc_team_email|urlize }}</li>
     {% endif %}
-    {% if data_owner_email and not further_information.dc_teams_channel_url and not further_information.dc_slack_channel_url and not further_information.dc_team_email %}
+    
+    {% if not further_information.dc_teams_channel_url and not further_information.dc_slack_channel_url and not further_information.dc_team_email %}
+      {% if governance.data_custodians %}
+      <li id="contact_channels_data_owner">{% translate "Contact the data custodian with questions." %}</li>
+      {% elif governance.data_owner.email %}
       <li id="contact_channels_data_owner">{% translate "Contact the data owner with questions." %}</li>
-    {% endif %}
-    {% if not further_information.dc_teams_channel_url and not further_information.dc_slack_channel_url and not further_information.dc_team_email and not data_owner_email%}
-     <li id="contact_channels_not_provided">{% translate "Not provided" %}</li>
+      {% else %}
+      <li id="contact_channels_not_provided">{% translate "Not provided" %}</li>
+      {% endif %}
     {% endif %}
   </ul>
 </div>
 
+{% if governance.data_custodians and governance.data_custodians.0.email %}
+<div class="govuk-body">
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "Data custodian" %}</h2>
+  <p id="data_owner" class="govuk-body">
+      {{ governance.data_custodians.0.email|urlize }}
+  </p>
+</div>
+{% else %}
 <div class="govuk-body">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{% translate "IAO or Data Owner" %}</h2>
   <p id="data_owner" class="govuk-body">
-    {% if data_owner_email %}
-      {{ data_owner_email|urlize }}
+    {% if governance.data_owner.email %}
+      {{ governance.data_owner.email|urlize }}
     {% elif platform.urn == 'performance-hub' %}
       No owner is listed as this data is undergoing a review of ownership.
     {% else %}
@@ -55,6 +69,7 @@
     {% endif %}
   </p>
 </div>
+{% endif %}
 
 {% if NOTIFY_ENABLED and entity_name %}
   <div class="govuk-body">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,7 @@ class DetailsPage(Page):
     def contact_channels_not_provided(self):
         return self.selenium.find_element(By.ID, "contact_channels_not_provided")
 
-    def data_owner(self):
+    def data_owner_or_custodian(self):
         return self.selenium.find_element(By.ID, "data_owner")
 
 
@@ -482,6 +482,9 @@ def generate_database_metadata(
             ),
             data_stewards=[
                 OwnerRef(display_name="", email="Contact email for the user", urn="")
+            ],
+            data_custodians=[
+                OwnerRef(display_name="", email="custodian@justice.gov.uk", urn="")
             ],
         ),
         tags=[TagRef(display_name="some-tag", urn="urn:li:tag:Entity")],


### PR DESCRIPTION
This PR extends the `Governance` object to include data owner, data stewards, and data custodians, based on the `ownershipType` in Datahub.

If an owner of type data custodian exists, then Find MoJ data will render "Data custodian (technical owner)" rather than "Data owner".

To ease deployment, I've kept it rendering "Data owner" if the data custodian is not set. We can remove this once the ingestion has been updated to use data custodian instead of data owner.