### PR TITLE
CSV exports

### DIFF
--- a/home/service/details_csv.py
+++ b/home/service/details_csv.py
@@ -1,0 +1,69 @@
+from home.service.details import (
+    DashboardDetailsService,
+    DatabaseDetailsService,
+    DatasetDetailsService,
+)
+
+
+class DatasetDetailsCsvFormatter:
+    def __init__(self, details_service: DatasetDetailsService):
+        self.details_service = details_service
+
+    def data(self):
+        return [
+            (
+                column.name,
+                column.display_name,
+                column.is_primary_key,
+                column.type,
+                column.nullable,
+                column.description,
+            )
+            for column in self.details_service.table_metadata.column_details
+        ]
+
+    def headers(self):
+        return [
+            "name",
+            "display_name",
+            "is_primary_key",
+            "type",
+            "nullable",
+            "description",
+        ]
+
+
+class DatabaseDetailsCsvFormatter:
+    def __init__(self, details_service: DatabaseDetailsService):
+        self.details_service = details_service
+
+    def data(self):
+        return [
+            (
+                table.entity_ref.urn,
+                table.entity_ref.display_name,
+                table.description,
+            )
+            for table in self.details_service.entities_in_database
+        ]
+
+    def headers(self):
+        return [
+            "urn",
+            "display_name",
+            "description",
+        ]
+
+
+class DashboardDetailsCsvFormatter:
+    def __init__(self, details_service: DashboardDetailsService):
+        self.details_service = details_service
+
+    def data(self):
+        return [
+            (chart.entity_ref.urn, chart.entity_ref.display_name, chart.description)
+            for chart in self.details_service.children
+        ]
+
+    def headers(self):
+        return ["urn", "display_name", "description"]

--- a/home/service/details_csv.py
+++ b/home/service/details_csv.py
@@ -15,7 +15,6 @@ class DatasetDetailsCsvFormatter:
                 column.name,
                 column.display_name,
                 column.type,
-                column.nullable,
                 column.description,
             )
             for column in self.details_service.table_metadata.column_details
@@ -26,7 +25,6 @@ class DatasetDetailsCsvFormatter:
             "name",
             "display_name",
             "type",
-            "nullable",
             "description",
         ]
 

--- a/home/service/details_csv.py
+++ b/home/service/details_csv.py
@@ -14,7 +14,6 @@ class DatasetDetailsCsvFormatter:
             (
                 column.name,
                 column.display_name,
-                column.is_primary_key,
                 column.type,
                 column.nullable,
                 column.description,
@@ -26,7 +25,6 @@ class DatasetDetailsCsvFormatter:
         return [
             "name",
             "display_name",
-            "is_primary_key",
             "type",
             "nullable",
             "description",

--- a/home/tests.py
+++ b/home/tests.py
@@ -1,3 +1,0 @@
-# from django.test import TestCase
-
-# Create your tests here.

--- a/home/urls.py
+++ b/home/urls.py
@@ -14,6 +14,11 @@ urlpatterns = [
         name="metadata_specification",
     ),
     path(
+        "details/<str:result_type>/<str:urn>.csv",
+        views.details_view_csv,
+        name="details_csv",
+    ),
+    path(
         "details/<str:result_type>/<str:urn>",
         views.details_view,
         name="details",

--- a/home/views.py
+++ b/home/views.py
@@ -33,60 +33,26 @@ def home_view(request):
 
 @cache_control(max_age=300, private=True)
 def details_view(request, result_type, urn):
-    if result_type == "table":
-        service = dataset_service(urn)
-        return render(request, service.template, service.context)
-    if result_type == "database":
-        context = database_details(urn)
-        return render(request, "details_database.html", context)
-    if result_type == "chart":
-        context = chart_details(urn)
-        return render(request, "details_chart.html", context)
-    if result_type == "dashboard":
-        context = dashboard_details(urn)
-        return render(request, "details_dashboard.html", context)
-
-
-def database_details(urn):
     try:
-        service = DatabaseDetailsService(urn)
+        if result_type == "table":
+            service = DatasetDetailsService(urn)
+            template = service.template
+        elif result_type == "database":
+            service = DatabaseDetailsService(urn)
+            template = "details_database.html"
+        elif result_type == "chart":
+            service = ChartDetailsService(urn)
+            template = "details_chart.html"
+        elif result_type == "dashboard":
+            service = DashboardDetailsService(urn)
+            template = "details_dashboard.html"
+        else:
+            raise Http404("Invalid result type")
+
+        return render(request, template, service.context)
+
     except EntityDoesNotExist:
-        raise Http404("Asset does not exist")
-
-    context = service.context
-
-    return context
-
-
-def dataset_service(urn):
-    try:
-        service = DatasetDetailsService(urn)
-    except EntityDoesNotExist:
-        raise Http404("Asset does not exist")
-
-    return service
-
-
-def chart_details(urn):
-    try:
-        service = ChartDetailsService(urn)
-    except EntityDoesNotExist:
-        raise Http404("Asset does not exist")
-
-    context = service.context
-
-    return context
-
-
-def dashboard_details(urn):
-    try:
-        service = DashboardDetailsService(urn)
-    except EntityDoesNotExist:
-        raise Http404("Asset does not exist")
-
-    context = service.context
-
-    return context
+        raise Http404(f"{result_type} '{urn}' does not exist")
 
 
 @cache_control(max_age=60, private=True)

--- a/lib/datahub-client/data_platform_catalogue/entities.py
+++ b/lib/datahub-client/data_platform_catalogue/entities.py
@@ -265,7 +265,7 @@ class EntitySummary(BaseModel):
     )
     description: str = Field(description="A description of the entity")
     entity_type: str = Field(
-        description="indicates the tpye of entity that is summarised"
+        description="indicates the type of entity that is summarised"
     )
     tags: list[TagRef] = Field(description="Any tags associated with the entity")
 

--- a/templates/details_dashboard.html
+++ b/templates/details_dashboard.html
@@ -33,6 +33,11 @@
             {% endfor %}
           </tbody>
         </table>
+        <form action="{% url 'home:details_csv' result_type='dashboard' urn=entity.urn %}">
+          <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+            {% translate 'Download chart descriptions (CSV format)' %}
+          </button>
+        </form>
       {% else %}
         <h2 class="govuk-heading-m">{% translate "Dashboard content" %}</h2>
         <p class="govuk-body">{% translate "This dashboard is missing chart information." %}</p>

--- a/templates/details_database.html
+++ b/templates/details_database.html
@@ -39,6 +39,11 @@
             {% endfor %}
           </tbody>
         </table>
+        <form action="{% url 'home:details_csv' result_type='database' urn=entity.urn %}">
+          <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+            {% translate 'Download table descriptions (CSV format)' %}
+          </button>
+        </form>
       {% else %}
         <h2 class="govuk-heading-m">{% translate "Database content" %}</h2>
         <p class="govuk-body">{% translate "This database is missing table information." %}</p>

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -40,6 +40,12 @@
             {% endfor %}
           </tbody>
         </table>
+
+        <form action="{% url 'home:details_csv' result_type='table' urn=entity.urn %}">
+          <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+            {% translate 'Download table schema (CSV format)' %}
+          </button>
+        </form>
       {% else %}
         <h2 class="govuk-heading-m">{% translate "Table schema" %}</h2>
         <p class="govuk-body">{% translate "The schema for this table is not available." %}</p>

--- a/tests/home/service/test_details_csv.py
+++ b/tests/home/service/test_details_csv.py
@@ -42,7 +42,6 @@ def test_dataset_details_csv_formatter(example_table):
         "name",
         "display_name",
         "type",
-        "nullable",
         "description",
     ]
     assert csv_formatter.data() == [
@@ -50,14 +49,12 @@ def test_dataset_details_csv_formatter(example_table):
             "foo",
             "Foo",
             "string",
-            False,
             "an example",
         ),
         (
             "bar",
             "Bar",
             "integer",
-            True,
             "another example",
         ),
     ]

--- a/tests/home/service/test_details_csv.py
+++ b/tests/home/service/test_details_csv.py
@@ -41,7 +41,6 @@ def test_dataset_details_csv_formatter(example_table):
     assert csv_formatter.headers() == [
         "name",
         "display_name",
-        "is_primary_key",
         "type",
         "nullable",
         "description",
@@ -50,7 +49,6 @@ def test_dataset_details_csv_formatter(example_table):
         (
             "foo",
             "Foo",
-            True,
             "string",
             False,
             "an example",
@@ -58,7 +56,6 @@ def test_dataset_details_csv_formatter(example_table):
         (
             "bar",
             "Bar",
-            False,
             "integer",
             True,
             "another example",

--- a/tests/home/service/test_details_csv.py
+++ b/tests/home/service/test_details_csv.py
@@ -1,0 +1,122 @@
+from unittest.mock import MagicMock
+
+from data_platform_catalogue.entities import Column, EntityRef, EntitySummary
+
+from home.service.details import (
+    DashboardDetailsService,
+    DatabaseDetailsService,
+    DatasetDetailsService,
+)
+from home.service.details_csv import (
+    DashboardDetailsCsvFormatter,
+    DatabaseDetailsCsvFormatter,
+    DatasetDetailsCsvFormatter,
+)
+
+
+def test_dataset_details_csv_formatter(example_table):
+    details_service = MagicMock(spec=DatasetDetailsService)
+    columns = [
+        Column(
+            name="foo",
+            display_name="Foo",
+            type="string",
+            description="an example",
+            nullable=False,
+            is_primary_key=True,
+        ),
+        Column(
+            name="bar",
+            display_name="Bar",
+            type="integer",
+            description="another example",
+            nullable=True,
+            is_primary_key=False,
+        ),
+    ]
+    details_service.table_metadata = example_table
+    example_table.column_details = columns
+    csv_formatter = DatasetDetailsCsvFormatter(details_service)
+
+    assert csv_formatter.headers() == [
+        "name",
+        "display_name",
+        "is_primary_key",
+        "type",
+        "nullable",
+        "description",
+    ]
+    assert csv_formatter.data() == [
+        (
+            "foo",
+            "Foo",
+            True,
+            "string",
+            False,
+            "an example",
+        ),
+        (
+            "bar",
+            "Bar",
+            False,
+            "integer",
+            True,
+            "another example",
+        ),
+    ]
+
+
+def test_database_details_csv_formatter(example_database):
+    tables = [
+        EntitySummary(
+            entity_ref=EntityRef(display_name="foo", urn="urn:foo"),
+            description="an example",
+            entity_type="Table",
+            tags=[],
+        ),
+        EntitySummary(
+            entity_ref=EntityRef(display_name="bar", urn="urn:bar"),
+            description="another example",
+            entity_type="Table",
+            tags=[],
+        ),
+    ]
+
+    details_service = MagicMock(spec=DatabaseDetailsService)
+    details_service.entities_in_database = tables
+
+    csv_formatter = DatabaseDetailsCsvFormatter(details_service)
+
+    assert csv_formatter.headers() == ["urn", "display_name", "description"]
+    assert csv_formatter.data() == [
+        ("urn:foo", "foo", "an example"),
+        ("urn:bar", "bar", "another example"),
+    ]
+
+
+def test_dashboard_details_csv_formatter(example_dashboard):
+    charts = [
+        EntitySummary(
+            entity_ref=EntityRef(display_name="foo", urn="urn:foo"),
+            description="an example",
+            entity_type="Chart",
+            tags=[],
+        ),
+        EntitySummary(
+            entity_ref=EntityRef(display_name="bar", urn="urn:bar"),
+            description="another example",
+            entity_type="Chart",
+            tags=[],
+        ),
+    ]
+
+    details_service = MagicMock(spec=DashboardDetailsService)
+    details_service.children = charts
+
+    csv_formatter = DashboardDetailsCsvFormatter(details_service)
+
+    assert csv_formatter.headers() == ["urn", "display_name", "description"]
+    assert csv_formatter.data() == [
+        ("urn:foo", "foo", "an example"),
+        ("urn:bar", "bar", "another example"),
+    ]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -68,8 +68,8 @@ class TestTableView:
             response.headers["Content-Disposition"] == 'attachment; filename="fake.csv"'
         )
         assert response.content == (
-            b"name,display_name,is_primary_key,type,nullable,description\r\n"
-            + b"urn,urn,True,string,False,description **with markdown**\r\n"
+            b"name,display_name,type,nullable,description\r\n"
+            + b"urn,urn,string,False,description **with markdown**\r\n"
         )
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -68,8 +68,8 @@ class TestTableView:
             response.headers["Content-Disposition"] == 'attachment; filename="fake.csv"'
         )
         assert response.content == (
-            b"name,display_name,type,nullable,description\r\n"
-            + b"urn,urn,string,False,description **with markdown**\r\n"
+            b"name,display_name,type,description\r\n"
+            + b"urn,urn,string,description **with markdown**\r\n"
         )
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -51,8 +51,64 @@ class TestTableView:
             response = client.get(
                 reverse("home:details", kwargs={"urn": "fake", "result_type": "table"})
             )
+
         assert response.status_code == 200
         assert response.headers["Cache-Control"] == "max-age=300, private"
+
+    @pytest.mark.django_db
+    def test_csv_output(self, client):
+        response = client.get(
+            reverse(
+                "home:details_csv",
+                kwargs={"urn": "fake", "result_type": "table"},
+            )
+        )
+        assert response.status_code == 200
+        assert (
+            response.headers["Content-Disposition"] == 'attachment; filename="fake.csv"'
+        )
+        assert response.content == (
+            b"name,display_name,is_primary_key,type,nullable,description\r\n"
+            + b"urn,urn,True,string,False,description **with markdown**\r\n"
+        )
+
+
+class TestDatabaseView:
+    @pytest.mark.django_db
+    def test_csv_output(self, client):
+        response = client.get(
+            reverse(
+                "home:details_csv",
+                kwargs={"urn": "fake", "result_type": "database"},
+            )
+        )
+        assert response.status_code == 200
+        assert (
+            response.headers["Content-Disposition"] == 'attachment; filename="fake.csv"'
+        )
+        assert response.content == (
+            b"urn,display_name,description\r\n"
+            + b"urn:li:dataset:fake_table,fake_table,table description\r\n"
+        )
+
+
+class TestDashboardView:
+    @pytest.mark.django_db
+    def test_csv_output(self, client):
+        response = client.get(
+            reverse(
+                "home:details_csv",
+                kwargs={"urn": "fake", "result_type": "dashboard"},
+            )
+        )
+        assert response.status_code == 200
+        assert (
+            response.headers["Content-Disposition"] == 'attachment; filename="fake.csv"'
+        )
+        assert response.content == (
+            b"urn,display_name,description\r\n"
+            + b"urn:li:chart:fake_chart,fake_chart,chart description\r\n"
+        )
 
 
 class TestChartView:


### PR DESCRIPTION
Add buttons to export metadata as CSV, where we present it in tables.

- [x] Table schema
- [x] List of tables in a database
- [x] List of charts in a dashboard

![Screenshot 2024-11-08 at 09 30 55](https://github.com/user-attachments/assets/bebd7687-64b1-4696-9236-0c56f6eeccf0)

### Questions for design review
- Is it worth moving the button closer to the data table?
- Does the copy make sense?