### PR TITLE
feat: add trivy image scanning

### DIFF
--- a/.github/workflows/scan-image.yml
+++ b/.github/workflows/scan-image.yml
@@ -1,0 +1,48 @@
+---
+name: Scan Image
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  scan-image:
+    name: Scan Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build Image
+        id: build_image
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          push: false
+          load: true
+          tags: ingestion-notify
+
+      - name: Scan Image (Produce SARIF)
+        id: scan_image
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
+        with:
+          image-ref: ingestion-notify
+          format: sarif
+          output: trivy-results.sarif
+          trivyignores: .trivyignore.yaml
+
+      - name: Upload SARIF
+        if: always()
+        id: upload_sarif
+        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v2.2.7
+        with:
+          sarif_file: trivy-results.sarif

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,4 @@
+# vulnerabilities:
+#   - id: CVE-2023-XXXXX
+#     statement: Bla bla bla
+#     expired_at: 2023-09-01


### PR DESCRIPTION
The cloud platform uses Trivy to scan container images for vulnerabilities, while they are running in the cluster. However we should also be scanning the images before we deploy to the cluster.

The kinds of vulnerabilities we are catching here are known vulnerabilities in the packages managed by the operating system in the container. They mostly come from our base images.

This PR runs a trivy scan on each PR.

We send the discovered vulnerabilities to the [code scanning page in github](https://github.com/ministryofjustice/find-moj-data/security/code-scanning?query=is%3Aopen+branch%3Afmj-810-container-scanning), and the "code scanning results" check reports [whether any new vulnerabilities were introduced as part of the PR](https://github.com/ministryofjustice/find-moj-data/pull/1030/checks?check_run_id=32816683933).

It's possible to configure the scan image job to fail depending on whether there are any vulnerabilities at all above a severity threshold (e.g. high or critical), but I don't think this is worth doing right now. I'm expecting we won't be able to fix everything right away, and it would force us to add a lot of exceptions to the ignore file in order to unblock builds.

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/trivy-image-scanning.html#trivy-vulnerability-scanning
https://dsdmoj.atlassian.net/wiki/spaces/APPSEC/pages/4988895576/CI+CD+Pipeline+Tooling#Vulnerability-Scan