### PR TITLE
ci: enable trivy scan on push to main

### DIFF
--- a/.github/workflows/scan-image.yml
+++ b/.github/workflows/scan-image.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 permissions: {}
 


### PR DESCRIPTION
Previously it was only triggering on PRs. This will ensure the code scanning tab in github is populated for the main branch as well.