### PR TITLE
Change casing of success status

### DIFF
--- a/.github/workflows/deploy-staged.yml
+++ b/.github/workflows/deploy-staged.yml
@@ -57,7 +57,7 @@ jobs:
       # Notify Slack - data-catalogue
       - uses: ravsamhq/notify-slack-action@v2
         with:
-          status: Success
+          status: success
           notification_title: "Deployment Successful"
           message_format: ":rocket: <https://preprod.find-moj-data.service.justice.gov.uk/|New Preproduction Deployment>"
           footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View>"


### PR DESCRIPTION
I have noticed that the preprod success slack notification isn't being triggered and I believe that it is a result of the status configuration casing. 
I believe the success status needs to match ` notify_when: success,failure,cancelled,warnings,skipped` as per `if: github.event.workflow_run.conclusion == 'success'`

```Run ravsamhq/notify-slack-action@v2
  with:
    status: Success
    notification_title: Deployment Successful
    message_format: :rocket: <https://preprod.find-moj-data.service.justice.gov.uk/|New Preproduction Deployment>
    footer: Linked Repo <https://github.com/ministryofjustice/find-moj-data|ministryofjustice/find-moj-data> | <https://github.com/ministryofjustice/find-moj-data/actions/runs/|View>
    notify_when: success,failure,cancelled,warnings,skipped
    mention_users_when: success,failure,cancelled,warnings,skipped
    mention_groups_when: success,failure,cancelled,warnings,skipped
    icon_success: :heavy_check_mark:
    icon_failure: :x:
    icon_cancelled: :x:
    icon_warnings: :large_orange_diamond:
    icon_skipped: :fast_forward:
  env:
    SLACK_WEBHOOK_URL: ***