### PR TITLE
Add environment to the ingress name

### DIFF
--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -142,6 +142,8 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - mountPath: /tmp
               name: tmp

--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -1,9 +1,9 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: find-moj-data-ingress
+  name: find-moj-data-ingress-${ENV}
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: find-moj-data-ingress-${NAMESPACE}-green
+    external-dns.alpha.kubernetes.io/set-identifier: find-moj-data-ingress-${ENV}-${NAMESPACE}-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/limit-whitelist: ${LIMIT_WHITELIST}
     nginx.ingress.kubernetes.io/limit-rps: "200"


### PR DESCRIPTION
This pr creates a unique ingress based on the respective environment. This is necessary to distinguish between environments when creating dashboards or troubleshooting. It will be necessary to delete the existing ingress prior to deployment for example.

` kubectl delete ingress find-moj-data-ingress-test -n data-platform-find-moj-data-test`
` kubectl delete ingress find-moj-data-ingress-preprod -n data-platform-find-moj-data-preprod`
` kubectl delete ingress find-moj-data-ingress-prod -n data-platform-find-moj-data-prod`

It also resolves the following deployment  warning `Warning: would violate PodSecurity "restricted:latest": unrestricted capabilities (container "find-moj-data" must set securityContext.capabilities.drop=["ALL"])`