### PR TITLE
refactor: rename timestamps

### DIFF
--- a/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
+++ b/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
@@ -40,19 +40,19 @@ from data_platform_catalogue.client.exceptions import (
 )
 from data_platform_catalogue.client.graphql_helpers import (
     parse_columns,
-    parse_created_and_modified,
     parse_custodians,
+    parse_data_created,
     parse_data_owner,
     parse_domain,
     parse_glossary_terms,
-    parse_last_modified,
+    parse_last_datajob_run_date,
+    parse_metadata_last_ingested,
     parse_names,
     parse_properties,
     parse_relations,
     parse_stewards,
     parse_subtypes,
     parse_tags,
-    parse_updated,
 )
 from data_platform_catalogue.client.search import SearchClient
 from data_platform_catalogue.entities import (
@@ -275,9 +275,9 @@ class DataHubCatalogueClient:
             custodians = parse_custodians(response)
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
-            created, modified = parse_created_and_modified(properties)
-            modified = parse_last_modified(response)
-            updated = parse_updated(response)
+            created = parse_data_created(properties)
+            modified = parse_metadata_last_ingested(response)
+            updated = parse_last_datajob_run_date(response)
             name, display_name, qualified_name = parse_names(response, properties)
 
             lineage_relations = parse_relations(
@@ -373,8 +373,8 @@ class DataHubCatalogueClient:
             custodians = parse_custodians(response)
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
-            created, modified = parse_created_and_modified(properties)
-            modified = parse_last_modified(response)
+            created = parse_data_created(properties)
+            modified = parse_metadata_last_ingested(response)
             name, display_name, qualified_name = parse_names(response, properties)
 
             child_relations = parse_relations(
@@ -417,8 +417,8 @@ class DataHubCatalogueClient:
             custodians = parse_custodians(response)
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
-            created, modified = parse_created_and_modified(properties)
-            modified = parse_last_modified(response)
+            created = parse_data_created(properties)
+            modified = parse_metadata_last_ingested(response)
             name, display_name, qualified_name = parse_names(response, properties)
             children = parse_relations(
                 RelationshipType.CHILD, [response["relationships"]]

--- a/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
+++ b/lib/datahub-client/data_platform_catalogue/client/datahub_client.py
@@ -42,6 +42,7 @@ from data_platform_catalogue.client.graphql_helpers import (
     parse_columns,
     parse_custodians,
     parse_data_created,
+    parse_data_last_modified,
     parse_data_owner,
     parse_domain,
     parse_glossary_terms,
@@ -276,8 +277,9 @@ class DataHubCatalogueClient:
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
             created = parse_data_created(properties)
-            modified = parse_metadata_last_ingested(response)
-            updated = parse_last_datajob_run_date(response)
+            modified = parse_data_last_modified(properties)
+            last_ingested = parse_metadata_last_ingested(response)
+            last_run_date = parse_last_datajob_run_date(response)
             name, display_name, qualified_name = parse_names(response, properties)
 
             lineage_relations = parse_relations(
@@ -311,9 +313,10 @@ class DataHubCatalogueClient:
                 subtypes=subtypes,
                 tags=tags,
                 glossary_terms=glossary_terms,
-                last_modified=modified,
-                last_updated=updated,
+                metadata_last_ingested=last_ingested,
+                last_datajob_run_date=last_run_date,
                 created=created,
+                data_last_modified=modified,
                 column_details=columns,
                 custom_properties=custom_properties,
                 platform=EntityRef(display_name=platform_name, urn=platform_name),
@@ -333,6 +336,8 @@ class DataHubCatalogueClient:
             custodians = parse_custodians(response)
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
+            created = parse_data_created(properties)
+            modified = parse_data_last_modified(properties)
             name, display_name, qualified_name = parse_names(response, properties)
 
             parent_relations = parse_relations(
@@ -354,6 +359,8 @@ class DataHubCatalogueClient:
                 relationships=relations_to_display,
                 tags=tags,
                 glossary_terms=glossary_terms,
+                created=created,
+                data_last_modified=modified,
                 platform=EntityRef(display_name=platform_name, urn=platform_name),
                 custom_properties=custom_properties,
             )
@@ -374,7 +381,8 @@ class DataHubCatalogueClient:
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
             created = parse_data_created(properties)
-            modified = parse_metadata_last_ingested(response)
+            modified = parse_data_last_modified(properties)
+            last_ingested = parse_metadata_last_ingested(response)
             name, display_name, qualified_name = parse_names(response, properties)
 
             child_relations = parse_relations(
@@ -397,8 +405,9 @@ class DataHubCatalogueClient:
                 ),
                 tags=tags,
                 glossary_terms=glossary_terms,
-                last_modified=modified,
+                metadata_last_ingested=last_ingested,
                 created=created,
+                data_last_modified=modified,
                 custom_properties=custom_properties,
                 platform=EntityRef(display_name=platform_name, urn=platform_name),
             )
@@ -418,7 +427,8 @@ class DataHubCatalogueClient:
             tags = parse_tags(response)
             glossary_terms = parse_glossary_terms(response)
             created = parse_data_created(properties)
-            modified = parse_metadata_last_ingested(response)
+            modified = parse_data_last_modified(properties)
+            last_ingested = parse_metadata_last_ingested(response)
             name, display_name, qualified_name = parse_names(response, properties)
             children = parse_relations(
                 RelationshipType.CHILD, [response["relationships"]]
@@ -439,8 +449,9 @@ class DataHubCatalogueClient:
                 external_url=properties.get("externalUrl", ""),
                 tags=tags,
                 glossary_terms=glossary_terms,
-                last_modified=modified,
+                metadata_last_ingested=last_ingested,
                 created=created,
+                data_last_modified=modified,
                 custom_properties=custom_properties,
                 platform=EntityRef(display_name=platform_name, urn=platform_name),
             )

--- a/lib/datahub-client/data_platform_catalogue/client/search.py
+++ b/lib/datahub-client/data_platform_catalogue/client/search.py
@@ -278,7 +278,7 @@ class SearchClient:
         properties, custom_properties = parse_properties(entity)
         tags = parse_tags(entity)
         terms = parse_glossary_terms(entity)
-        last_modified = parse_metadata_last_ingested(entity)
+        last_ingested = parse_metadata_last_ingested(entity)
         name, display_name, qualified_name = parse_names(entity, properties)
         container = entity.get("container")
         if container:
@@ -319,7 +319,7 @@ class SearchClient:
             metadata=metadata,
             tags=tags,
             glossary_terms=terms,
-            last_modified=modified or last_modified,
+            last_modified=modified or last_ingested,
         )
 
     def _parse_facets(self, facets: list[dict[str, Any]]) -> SearchFacets:
@@ -422,7 +422,7 @@ class SearchClient:
         """
         tags = parse_tags(entity)
         terms = parse_glossary_terms(entity)
-        last_modified = parse_metadata_last_ingested(entity)
+        last_ingested = parse_metadata_last_ingested(entity)
         properties, custom_properties = parse_properties(entity)
         domain = parse_domain(entity)
         owner = parse_data_owner(entity)
@@ -449,7 +449,7 @@ class SearchClient:
             metadata=metadata,
             tags=tags,
             glossary_terms=terms,
-            last_modified=last_modified,
+            last_modified=last_ingested,
         )
 
     def _parse_types_and_sub_types(self, entity: dict, entity_type: str) -> dict:

--- a/lib/datahub-client/data_platform_catalogue/client/search.py
+++ b/lib/datahub-client/data_platform_catalogue/client/search.py
@@ -8,11 +8,11 @@ from datahub.ingestion.graph.client import DataHubGraph  # pylint: disable=E0611
 from data_platform_catalogue.client.exceptions import CatalogueError
 from data_platform_catalogue.client.graphql_helpers import (
     get_graphql_query,
-    parse_created_and_modified,
+    parse_data_last_modified,
     parse_data_owner,
     parse_domain,
     parse_glossary_terms,
-    parse_last_modified,
+    parse_metadata_last_ingested,
     parse_names,
     parse_properties,
     parse_tags,
@@ -278,7 +278,7 @@ class SearchClient:
         properties, custom_properties = parse_properties(entity)
         tags = parse_tags(entity)
         terms = parse_glossary_terms(entity)
-        last_modified = parse_last_modified(entity)
+        last_modified = parse_metadata_last_ingested(entity)
         name, display_name, qualified_name = parse_names(entity, properties)
         container = entity.get("container")
         if container:
@@ -301,7 +301,7 @@ class SearchClient:
         metadata.update(custom_properties.access_information.model_dump())
         metadata.update(custom_properties.data_summary.model_dump())
 
-        _, modified = parse_created_and_modified(properties)
+        modified = parse_data_last_modified(properties)
 
         return SearchResult(
             urn=entity["urn"],
@@ -422,7 +422,7 @@ class SearchClient:
         """
         tags = parse_tags(entity)
         terms = parse_glossary_terms(entity)
-        last_modified = parse_last_modified(entity)
+        last_modified = parse_metadata_last_ingested(entity)
         properties, custom_properties = parse_properties(entity)
         domain = parse_domain(entity)
         owner = parse_data_owner(entity)

--- a/lib/datahub-client/data_platform_catalogue/entities.py
+++ b/lib/datahub-client/data_platform_catalogue/entities.py
@@ -445,13 +445,18 @@ class Entity(BaseModel):
             ]
         ],
     )
-    last_modified: Optional[datetime] = Field(
+    metadata_last_ingested: Optional[datetime] = Field(
         description="When the metadata was last updated in the catalogue",
         default=None,
         examples=[datetime(2011, 10, 2, 3, 0, 0)],
     )
     created: Optional[datetime] = Field(
         description="When the data entity was first created",
+        default=None,
+        examples=[datetime(2011, 10, 2, 3, 0, 0)],
+    )
+    data_last_modified: Optional[datetime] = Field(
+        description="When the data entity was last modified in the source system",
         default=None,
         examples=[datetime(2011, 10, 2, 3, 0, 0)],
     )
@@ -525,7 +530,7 @@ class Table(Entity):
             ]
         ],
     )
-    last_updated: Optional[datetime] = Field(
+    last_datajob_run_date: Optional[datetime] = Field(
         description="Indicates the time when the data were last refreshed (eg pipeline run with dbt).",
         default=None,
         examples=[datetime(2011, 10, 2, 3, 0, 0)],

--- a/lib/datahub-client/tests/client/datahub/test_datahub_client.py
+++ b/lib/datahub-client/tests/client/datahub/test_datahub_client.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -13,8 +12,8 @@ from data_platform_catalogue.client.exceptions import (
     ReferencedEntityMissing,
 )
 from data_platform_catalogue.entities import (
-    Audience,
     AccessInformation,
+    Audience,
     Chart,
     Column,
     ColumnRef,
@@ -81,7 +80,7 @@ class TestCatalogueClientWithDatahub:
                     )
                 ]
             },
-            last_modified=1710426920000,
+            metadata_last_ingested=1710426920000,
             created=1710426920000,
             tags=[TagRef(urn="test", display_name="test")],
             platform=EntityRef(urn="urn:li:dataPlatform:athena", display_name="athena"),
@@ -138,7 +137,7 @@ class TestCatalogueClientWithDatahub:
                 ],
             ),
             tags=[TagRef(display_name="some-tag", urn="urn:li:tag:Entity")],
-            last_modified=1710426920000,
+            metadata_last_ingested=1710426920000,
             created=None,
             column_details=[
                 Column(
@@ -206,7 +205,7 @@ class TestCatalogueClientWithDatahub:
                 ],
             ),
             tags=[TagRef(display_name="some-tag", urn="urn:li:tag:Entity")],
-            last_modified=1710426920000,
+            metadata_last_ingested=1710426920000,
             created=None,
             column_details=[
                 Column(
@@ -399,7 +398,8 @@ class TestCatalogueClientWithDatahub:
                 data_stewards=[],
             ),
             tags=[TagRef(display_name="some-tag", urn="urn:li:tag:Entity")],
-            last_modified=1709619407814,
+            metadata_last_ingested=1709619407814,
+            data_last_modified=1709619407814,
             provider="LAA",
             created=None,
             platform=EntityRef(urn="datahub", display_name="datahub"),
@@ -467,7 +467,7 @@ class TestCatalogueClientWithDatahub:
                 data_stewards=[],
             ),
             tags=[],
-            last_modified=None,
+            metadata_last_ingested=None,
             created=None,
             platform=EntityRef(urn="datahub", display_name="datahub"),
             custom_properties=CustomEntityProperties(
@@ -527,7 +527,7 @@ class TestCatalogueClientWithDatahub:
                 data_stewards=[],
             ),
             tags=[],
-            last_modified=None,
+            metadata_last_ingested=None,
             created=None,
             platform=EntityRef(urn="justice-data", display_name="justice-data"),
             custom_properties=CustomEntityProperties(

--- a/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
+++ b/lib/datahub-client/tests/client/datahub/test_graphql_helpers.py
@@ -1,6 +1,3 @@
-from datetime import datetime, timezone
-
-import pytest
 import pytest
 
 from data_platform_catalogue.client.graphql_helpers import (
@@ -9,18 +6,19 @@ from data_platform_catalogue.client.graphql_helpers import (
     _parse_owners_by_type,
     get_refresh_period_from_cadet_tags,
     parse_columns,
-    parse_created_and_modified,
+    parse_data_created,
+    parse_data_last_modified,
     parse_data_owner,
     parse_glossary_terms,
+    parse_last_datajob_run_date,
     parse_properties,
     parse_relations,
     parse_subtypes,
     parse_tags,
-    parse_updated,
 )
 from data_platform_catalogue.entities import (
-    Audience,
     AccessInformation,
+    Audience,
     Column,
     ColumnRef,
     CustomEntityProperties,
@@ -266,7 +264,8 @@ def test_parse_created_and_modified(
         "lastModified": raw_last_modified,
     }
 
-    created, modified = parse_created_and_modified(properties)
+    created = parse_data_created(properties)
+    modified = parse_data_last_modified(properties)
 
     assert created == expected_created
     assert modified == expected_modified
@@ -649,16 +648,12 @@ def test_parse_owners():
 def test_parse_updated():
     expected_timestamp = 12345678
     example_with_updated = {
-        "runs": {
-            "runs": [
-                {"created": {"time": expected_timestamp}}
-            ]
-        }
+        "runs": {"runs": [{"created": {"time": expected_timestamp}}]}
     }
     example_no_updated = {}
 
-    assert parse_updated(example_with_updated) == expected_timestamp
-    assert parse_updated(example_no_updated) is None
+    assert parse_last_datajob_run_date(example_with_updated) == expected_timestamp
+    assert parse_last_datajob_run_date(example_no_updated) is None
 
 
 @pytest.mark.parametrize(
@@ -670,9 +665,9 @@ def test_parse_updated():
         (
             [
                 TagRef(display_name="daily", urn="urn:li:tag:dc_cadet"),
-                TagRef(display_name="monthly", urn="urn:li:tag:dc_cadet")
+                TagRef(display_name="monthly", urn="urn:li:tag:dc_cadet"),
             ],
-            "Daily, monthly"
+            "Daily, monthly",
         ),
     ],
 )

--- a/lib/datahub-client/tests/test_integration_with_datahub_server.py
+++ b/lib/datahub-client/tests/test_integration_with_datahub_server.py
@@ -12,6 +12,7 @@ import time
 from datetime import datetime, timezone
 
 import pytest
+
 from data_platform_catalogue.client.datahub_client import DataHubCatalogueClient
 from data_platform_catalogue.entities import (
     AccessInformation,
@@ -107,7 +108,7 @@ def test_domain_facets_are_returned():
                 }
             }
         ],
-        last_modified=datetime(2020, 5, 17),
+        metadata_last_ingested=datetime(2020, 5, 17),
         created=datetime(2020, 5, 17),
         tags=[TagRef(urn="test", display_name="test")],
         platform=EntityRef(urn="urn:li:dataPlatform:athena", display_name="athena"),
@@ -156,7 +157,7 @@ def test_filter_by_urn():
         ),
         domain=DomainRef(urn="LAA", display_name="LAA"),
         tables=[],
-        last_modified=datetime(2020, 5, 17),
+        metadata_last_ingested=datetime(2020, 5, 17),
         created=datetime(2020, 5, 17),
         tags=[TagRef(urn="test", display_name="test")],
         platform=EntityRef(urn="urn:li:dataPlatform:athena", display_name="athena"),

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -82,10 +82,10 @@
                 {{entity.custom_properties.audience}}
               </li>
             {% endif %}
-            <!-- {% if entity.last_updated %}
+            <!-- {% if entity.last_datajob_run_date %}
               <li>
                 <span class="govuk-!-font-weight-bold">Data last updated:</span>
-                {{entity.last_updated|date:"d M Y"}}
+                {{entity.last_datajob_run_date|date:"d M Y"}}
               </li>
             {% endif %} -->
             <li>
@@ -105,9 +105,9 @@
           </ul>
           {% include "partial/esda_info.html" with is_esda=is_esda %}
         {% endblock metadata_list %}
-        {% if entity.last_updated %}
+        {% if entity.metadata_last_ingested %}
           <div class="govuk-body-s app-summary-card__footer">
-            Updated {{entity.last_modified|timesince|format_timesince}} ago
+            Updated {{entity.metadata_last_ingested|timesince|format_timesince}} ago
           </div>
         {% endif %}
       </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,25 @@ from typing import Any, Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.conf import settings
+from django.test import Client
+from faker import Faker
+from home.forms.search import SearchForm
+from home.models.domain_model import DomainModel
+from home.service.details import DatabaseDetailsService
+from home.service.domain_fetcher import DomainFetcher
+from home.service.search import SearchService
+from home.service.search_facet_fetcher import SearchFacetFetcher
+from home.service.search_tag_fetcher import SearchTagFetcher
+from notifications_python_client.notifications import NotificationsAPIClient
+from pytest import CollectReport, StashKey
+from selenium.webdriver import ChromeOptions
+from selenium.webdriver.chrome.webdriver import WebDriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.support.select import Select
+
 from data_platform_catalogue.client.datahub_client import DataHubCatalogueClient
 from data_platform_catalogue.entities import (
     Chart,
@@ -31,25 +50,6 @@ from data_platform_catalogue.search_types import (
     SearchResponse,
     SearchResult,
 )
-from django.conf import settings
-from django.test import Client
-from faker import Faker
-from notifications_python_client.notifications import NotificationsAPIClient
-from pytest import CollectReport, StashKey
-from selenium.webdriver import ChromeOptions
-from selenium.webdriver.chrome.webdriver import WebDriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
-from selenium.webdriver.remote.webelement import WebElement
-from selenium.webdriver.support.select import Select
-
-from home.forms.search import SearchForm
-from home.models.domain_model import DomainModel
-from home.service.details import DatabaseDetailsService
-from home.service.domain_fetcher import DomainFetcher
-from home.service.search import SearchService
-from home.service.search_facet_fetcher import SearchFacetFetcher
-from home.service.search_tag_fetcher import SearchTagFetcher
 
 fake = Faker()
 
@@ -374,7 +374,7 @@ def generate_table_metadata(
                 description="some description",
             )
         ],
-        last_modified=1710426920000,
+        metadata_last_ingested=1710426920000,
         created=None,
         column_details=[
             Column(
@@ -435,7 +435,7 @@ def generate_chart_metadata(
                 description="some description",
             )
         ],
-        last_modified=1710426920000,
+        metadata_last_ingested=1710426920000,
         created=None,
         platform=EntityRef(urn="urn:li:dataPlatform:athena", display_name="athena"),
         custom_properties=custom_properties or CustomEntityProperties(),
@@ -495,7 +495,7 @@ def generate_database_metadata(
                 description="some description",
             )
         ],
-        last_modified=1710426920000,
+        metadata_last_ingested=1710426920000,
         created=None,
         platform=EntityRef(urn="urn:li:dataPlatform:athena", display_name="athena"),
         custom_properties=custom_properties or CustomEntityProperties(),
@@ -553,7 +553,7 @@ def generate_dashboard_metadata(
                 description="some description",
             )
         ],
-        last_modified=1710426920000,
+        metadata_last_ingested=1710426920000,
         created=None,
         platform=EntityRef(urn="urn:li:dataPlatform:athena", display_name="athena"),
         custom_properties=custom_properties or CustomEntityProperties(),


### PR DESCRIPTION
There are various datetimes returned by Datahub, and it's easy to confuse them. It seems like we are not always using the right one, so as a first step I'm renaming all the fields and parse functions to clearly describe what they are actually returning.

I've also exposed Datahub's lastModified value as I think this is the one we should be using for data last updated.

> A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)

This does not change what is displayed yet, I'll do that in a follow up PR.