### PR TITLE
fix: properly set is nullable column waffle switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ Current swicthes and default settings:
 
 - `search-sort-radio-buttons` off - switches on/off radio selection buttons for sort order of search results.
 - `display-result-tags` off - switches on/off the display of tags in search and results pages
+- `show_is_nullable_in_table_details_column` - swicthes on/off the `Is Nullable` column in the table details page

--- a/scripts/app-entrypoint.sh
+++ b/scripts/app-entrypoint.sh
@@ -13,6 +13,6 @@ fi
 python manage.py migrate
 python manage.py waffle_switch search-sort-radio-buttons off --create # create switch with default setting
 python manage.py waffle_switch display-result-tags off --create # create display tags switch with default off
-
+python manage.py waffle_switch show_is_nullable_in_table_details_column off --create # create isnullable column switch with default off
 
 gunicorn --bind 0.0.0.0:8000 core.wsgi:application --workers 2 --threads 4


### PR DESCRIPTION
part of [#1097](https://github.com/ministryofjustice/find-moj-data/issues/1097)

The switch was missing from the app-entrypoint.sh script and was not documented in the readme