### PR TITLE
Enhance GraphQL queries to includeSoftDelete parameter for relationships

### DIFF
--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getChartDetails.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getChartDetails.graphql
@@ -6,7 +6,13 @@ query getChartDetails($urn: String!) {
       name
     }
     relationships(
-      input: { types: ["Contains"], direction: INCOMING, start: 0, count: 10 }
+      input: {
+        types: ["Contains"]
+        direction: INCOMING
+        start: 0
+        count: 10
+        includeSoftDelete: false
+      }
     ) {
       total
       relationships {

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getContainerDetails.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getContainerDetails.graphql
@@ -31,7 +31,15 @@ query getContainer($urn: String!) {
     subTypes {
       typeNames
     }
-    relationships(input: {types: ["IsPartOf"], direction:INCOMING start: 0, count: 500 }) {
+    relationships(
+      input: {
+        types: ["IsPartOf"]
+        direction: INCOMING
+        start: 0
+        count: 500
+        includeSoftDelete: false
+      }
+    ) {
       total
       relationships {
         entity {
@@ -44,7 +52,9 @@ query getContainer($urn: String!) {
             }
             tags {
               tags {
-                tag{urn}
+                tag {
+                  urn
+                }
               }
             }
             subTypes {

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getDashboardDetails.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getDashboardDetails.graphql
@@ -23,7 +23,13 @@ query getDashboard($urn: String!) {
       description
     }
     relationships(
-      input: { types: ["Contains"], direction: OUTGOING, start: 0, count: 500 }
+      input: {
+        types: ["Contains"]
+        direction: OUTGOING
+        start: 0
+        count: 500
+        includeSoftDelete: false
+      }
     ) {
       total
       relationships {

--- a/lib/datahub-client/data_platform_catalogue/client/graphql/getDatasetDetails.graphql
+++ b/lib/datahub-client/data_platform_catalogue/client/graphql/getDatasetDetails.graphql
@@ -57,7 +57,12 @@ query getDatasetDetails($urn: String!) {
       typeNames
     }
     parent_container_relations: relationships(
-      input: { types: ["IsPartOf"], direction: OUTGOING, count: 10 }
+      input: {
+        types: ["IsPartOf"]
+        direction: OUTGOING
+        count: 10
+        includeSoftDelete: false
+      }
     ) {
       total
       relationships {

--- a/lib/datahub-client/data_platform_catalogue/client/parsers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/parsers.py
@@ -430,9 +430,12 @@ class EntityParser:
                     if relation.get("entity", {}).get("properties") is not None
                     else relation.get("entity").get("name", "")
                 )
+                properties = relation.get("entity", {}).get("properties")
+                description_field = relation.get("entity").get("properties", {}).get("description", "")
                 description = (
-                    relation.get("entity").get("properties", {}).get("description", "")
-                    if relation.get("entity", {}).get("properties") is not None
+                    description_field
+                    if properties is not None
+                    and description_field is not None
                     else ""
                 )
                 tags = self.parse_tags(relation.get("entity"))

--- a/lib/datahub-client/data_platform_catalogue/client/parsers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/parsers.py
@@ -47,8 +47,6 @@ DATA_CUSTODIAN = "urn:li:ownershipType:data_custodian"
 
 
 class EntityParser:
-    def __init__(self):
-        pass
 
     def parse(self, search_response) -> SearchResult:
         """Parse graphql response to a SearchResult object"""
@@ -431,13 +429,10 @@ class EntityParser:
                     else relation.get("entity").get("name", "")
                 )
                 properties = relation.get("entity", {}).get("properties")
-                description_field = relation.get("entity").get("properties", {}).get("description", "")
-                description = (
-                    description_field
-                    if properties is not None
-                    and description_field is not None
-                    else ""
-                )
+                if properties is not None:
+                    description = properties.get("description") or ""
+                else:
+                    description = ""
                 tags = self.parse_tags(relation.get("entity"))
                 related_entities.append(
                     EntitySummary(

--- a/lib/datahub-client/data_platform_catalogue/client/parsers.py
+++ b/lib/datahub-client/data_platform_catalogue/client/parsers.py
@@ -431,7 +431,7 @@ class EntityParser:
                 properties = relation.get("entity", {}).get("properties")
                 if properties is not None:
                     description = properties.get("description") or ""
-                else:
+                elif properties is None:
                     description = ""
                 tags = self.parse_tags(relation.get("entity"))
                 related_entities.append(


### PR DESCRIPTION
* We're getting [errors](https://mojdt.slack.com/archives/C07SFN0MHRP/p1736258081094319) to do with the caseman database, as table descriptions are empty. There's a related issue which is that soft deleted tables are being listed in the database's relationships, which are removed by stateful ingestion
* This fix sets an empty string as a description for all tables in a database where there is no description
* The parameter to exclude soft deleted relationships is also there, but it doesn't seem to work