### PR TITLE
Add url encoding to encode spaces in some urls

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -46,7 +46,7 @@
           <h2 id="browse-by-domain" class="govuk-heading-l">Browse by subject area</h2>
           <ul id="domain-list" class="govuk-list govuk-list--bullet">
             {% for domain in domains  %}
-              <li><a aria-label="Browse data for {{domain.name}} ({{domain.total}} result{{ domain.total|pluralize }})" href="{% url 'home:search' %}?domain={{domain.urn}}">{{domain.name}} ({{domain.total}} result{{ domain.total|pluralize }})</a></li>
+              <li><a aria-label="Browse data for {{domain.name}} ({{domain.total}} result{{ domain.total|pluralize }})" href="{% url 'home:search' %}?domain={{domain.urn|urlencode:":"}}">{{domain.name}} ({{domain.total}} result{{ domain.total|pluralize }})</a></li>
             {% endfor %}
           </ul>
         {% endif %}


### PR DESCRIPTION
- Ensures non standard url characters in domain urls are encoded correctly. This was highlighted by the issue with `electronic monitoring` in the web crawler.  The space is now correctly encoded, `:` are ignored for brevity.

`<a aria-label="Browse data for Electronic monitoring (32 results)" href="/search?domain=urn:li:domain:Electronic%20monitoring">Electronic monitoring (32 results)</a>`