### PR TITLE
fix: remove left margin on tags that flow onto a new line

### DIFF
--- a/scss/base.scss
+++ b/scss/base.scss
@@ -64,8 +64,15 @@ code {
   min-width: 5.5em;
 }
 
-// We've increased the max width of this tag as it was wrapping
-// the text for "Publication collection"
-.govuk-tag {
-  max-width: 180px
+.app-heading-with-tag {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: govuk-spacing(1) govuk-spacing(2);
+
+  // We've increased the max width of this tag as it was wrapping
+  // the text for "Publication collection"
+  .govuk-tag {
+    max-width: 180px
+  }
 }

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -33,10 +33,12 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">{{h1_value}}
-        <strong class="govuk-tag govuk-!-margin-left-2">
-          {{entity_type}}
-        </strong>
+      <h1 class="govuk-heading-l app-heading-with-tag"><span>{{h1_value}}</span>
+        <span class="app-heading-with-tag__tag">
+          <strong class="govuk-tag">
+            {{entity_type}}
+          </strong>
+        </span>
       </h1>
     </div>
   </div>

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -6,13 +6,15 @@
   {% for result in highlighted_results %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-2 app-heading-with-tag">
           {% with result_type=result.result_type.url_formatted %}
             <a href="{% url 'home:details' result_type=result_type urn=result.urn %}" class="govuk-link">{{result.name}}</a>
           {% endwith %}
-          <strong class="govuk-tag govuk-!-margin-left-2">
+          <span class="app-heading-with-tag__tag">
+            <strong class="govuk-tag">
             {{ result.result_type.find_moj_data_type.value }}
-          </strong>
+            </strong>
+          </span>
         </h3>
         {% if result.description %}
           <div class="govuk-body-m">


### PR DESCRIPTION
Search results with long titles currently render strangely because the tag always has a left margin, but it can wrap onto a new line.

Workaround this by using flexbox to align the title and the tag. 

## Before
<img width="721" alt="Screenshot 2025-01-16 at 16 49 48" src="https://github.com/user-attachments/assets/f1ddb959-0f94-4154-a636-7f8fd50f2c72" />

## After
<img width="758" alt="Screenshot 2025-01-16 at 17 02 39" src="https://github.com/user-attachments/assets/e0f1a054-5f8d-44a2-9f5a-e93f07b95a6b" />
