### PR TITLE
fix(docs) fix bug in metadata spec generation

### DIFF
--- a/home/templatetags/format_metadata_field_type.py
+++ b/home/templatetags/format_metadata_field_type.py
@@ -5,12 +5,13 @@ register = template.Library()
 
 @register.filter
 def format_metadata_field_type(value: dict) -> str:
+    output = ""
     if value.get("title"):
         if value.get("type"):
             type_string = value["type"]
         if value.get("anyOf"):
             type_string = " or ".join(item["type"] for item in value["anyOf"])
         output = type_string
-    if value.get("allOf"):
+    elif value.get("allOf") or value.get("$ref"):
         output = "object"
     return output


### PR DESCRIPTION
It was returning an error due to `output` being undefined.