### PR TITLE
fix: reenable data last updated field

### DIFF
--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -79,12 +79,12 @@
                 {{entity.custom_properties.audience}}
               </li>
             {% endif %}
-            <!-- {% if entity.last_datajob_run_date %}
+            {% if entity.last_datajob_run_date %}
               <li>
                 <span class="govuk-!-font-weight-bold">Data last updated:</span>
                 {{entity.last_datajob_run_date|date:"d M Y"}}
               </li>
-            {% endif %} -->
+            {% endif %}
             <li>
               {% include 'partial/subject_area_list.html' with subject_areas=entity.subject_areas %}
             </li>


### PR DESCRIPTION
This was disabled because our metadata about dbt runs (DataProcessInstance entities) were unreliable, due to us ingesting run results from the `dbt docs` command in addition to the jobs that actually build the tables.

This issue is now fixed, and I'm confident that we are pulling the correct metadata from DataHub, so I think it's reasonable to start showing this to users.

This comes with a caveat though - we still have entities in DataHub representing dbt runs that were ingested before the issue was fixed (around the 13th Jan). This means that any tables that haven't been built since the 13th (i.e. because they are updated monthly) will incorrectly show up as being last modified on the 13th, when the correct date is some time before this.

This issue will be resolved in one of two ways:
1. after we upgrade Datahub we can configure the new DataHubGc source to clean up DataProcessInstance records that were created on the 13th Jan or earlier.
2. on the first sunday of the month, all the monthly tables will be updated and the issue will go away.