### PR TITLE
Small tweaks to the new homepage designs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,13 @@ Switches can be managed via the [cli](https://waffle.readthedocs.io/en/stable/us
 
 Our switches are created via the cli; the commands can be seen in the Dockerfile.
 
-Current swicthes and default settings:
+Current switches and default settings:
 
 - `search-sort-radio-buttons` off - switches on/off radio selection buttons for sort order of search results.
 - `display-result-tags` off - switches on/off the display of tags in search and results pages
 - `show_is_nullable_in_table_details_column` off - switches on/off the `Is Nullable` column in the table details page
+
+Current flags and default settings:
+
+- `home_variant_a` off - shows the new homepage design (variant A)
+- `home_variant_b` off - shows the new homepage design (variant B)

--- a/scripts/app-entrypoint.sh
+++ b/scripts/app-entrypoint.sh
@@ -14,5 +14,7 @@ python manage.py migrate
 python manage.py waffle_switch search-sort-radio-buttons off --create # create switch with default setting
 python manage.py waffle_switch display-result-tags off --create # create display tags switch with default off
 python manage.py waffle_switch show_is_nullable_in_table_details_column off --create # create isnullable column switch with default off
+python manage.py waffle_flag home_variant_a --testing --create
+python manage.py waffle_flag home_variant_b --testing --create
 
 gunicorn --bind 0.0.0.0:8000 core.wsgi:application --workers 2 --threads 4

--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -14,7 +14,7 @@
       border-top: 0;
 
       .app-cards__list-item-wrapper {
-        margin-top: -19px;
+        margin-top: -15px;
       }
     }
   }
@@ -33,7 +33,7 @@
   // this wrapper ensures that the clickable area of the card only
   // covers the area of the card containing text so in a grid of cards
   // there is space above and below each link
-  padding: 19px 0 4px;
+  padding: 15px 0 0px;
   position: relative;
 }
 

--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -6,8 +6,6 @@
   padding: 0;
   margin: 0;
   display: grid;
-  grid-column-gap: govuk-spacing(6); // Use deprecated grid-column-gap for Grade C browser support
-  column-gap: govuk-spacing(6);
  }
 
 .app-cards__list--one-column {
@@ -16,7 +14,7 @@
       border-top: 0;
 
       .app-cards__list-item-wrapper {
-        padding-top: 0;
+        margin-top: -19px;
       }
     }
   }
@@ -27,7 +25,7 @@
   padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
 
   &:first-child {
-    padding-top: 0;
+    margin-top: -5px;
   }
 }
 

--- a/templates/partial/home/subject_area_grid.html
+++ b/templates/partial/home/subject_area_grid.html
@@ -5,7 +5,7 @@
     <ul id="subject-area-list" class="app-card-grid__list">
       {% for subject_area in subject_areas  %}
       <li class="app-card-grid__list-item">
-          <h3 class="app-card-grid__sub-heading govuk-heading-s"><a class="govuk-link app-card-grid__link" aria-label="Browse data for {{subject_area.name}} ({{subject_area.total}} result{{ subject_area.total|pluralize }})" href="{% url 'home:search' %}?subject_area={{subject_area.urn|urlencode:':'}}">{{subject_area.name}} ({{subject_area.total}} result{{ subject_area.total|pluralize }})</a></h3>
+          <h3 class="app-card-grid__sub-heading govuk-heading-s"><a class="govuk-link app-card-grid__link" aria-label="Browse data for {{subject_area.name}} ({{subject_area.total}} result{{ subject_area.total|pluralize }})" href="{% url 'home:search' %}?subject_area={{subject_area.urn|urlencode:':'}}">{{subject_area.name}} ({{subject_area.total}})</a></h3>
           <p class="govuk-body app-card-grid__description">{{subject_area.description}}</p>
       </li>
       {% endfor %}

--- a/templates/partial/home/subject_area_list.html
+++ b/templates/partial/home/subject_area_list.html
@@ -6,7 +6,7 @@
       {% for subject_area in subject_areas  %}
       <li class="app-cards__list-item">
         <div class="app-cards__list-item-wrapper">
-          <h3 class="app-cards__sub-heading govuk-heading-s"><a class="govuk-link app-cards__link" aria-label="Browse data for {{subject_area.name}} ({{subject_area.total}} result{{ subject_area.total|pluralize }})" href="{% url 'home:search' %}?subject_area={{subject_area.urn|urlencode:':'}}">{{subject_area.name}} ({{subject_area.total}} result{{ subject_area.total|pluralize }})</a></h3>
+          <h3 class="app-cards__sub-heading govuk-heading-s"><a class="govuk-link app-cards__link" aria-label="Browse data for {{subject_area.name}} ({{subject_area.total}} result{{ subject_area.total|pluralize }})" href="{% url 'home:search' %}?subject_area={{subject_area.urn|urlencode:':'}}">{{subject_area.name}} ({{subject_area.total}})</a></h3>
           <p class="govuk-body app-cards__description">{{subject_area.description}}</p>
         </div>
       </li>

--- a/templates/partial/home/subject_area_list.html
+++ b/templates/partial/home/subject_area_list.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-static-margin-bottom-6">
-    <div class="app-cards">
+    <div class="app-cards govuk-!-margin-right-3">
     <h2 id="browse-by-subject-area" class="govuk-heading-l">Browse by subject area</h2>
     <ul id="subject-area-list" class="app-cards__list app-cards__list--one-column">
       {% for subject_area in subject_areas  %}

--- a/templates/partial/home/subject_area_list.html
+++ b/templates/partial/home/subject_area_list.html
@@ -16,7 +16,7 @@
   </div>
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-l">Help us grow</h2>
-    <ul class="govuk-list govuk-!-font-weight-bold">
+    <ul class="govuk-list">
       <li class="govuk-!-margin-bottom-4"><a href="https://user-guide.find-moj-data.service.justice.gov.uk/#adding-to-find-moj-data">Add a new data source</a></li>
       <li class="govuk-!-margin-bottom-4"><a href="https://user-guide.find-moj-data.service.justice.gov.uk/#contact-us">Suggest data you would like to see</a></li>
         <li class="govuk-!-margin-bottom-4"><a href="https://find-moj-data.service.justice.gov.uk/feedback/">Give us feedback</a></li>


### PR DESCRIPTION
- [x] Remove " results"
- [x] Remove some of the vertical spacing to make items more compact
- [x] Add some spacing between the two columns
- [x] Fix first arrow appearing a bit too close to the separator line
- [x] Remove bold weight from help us grow links

## Before
![Screenshot 2025-01-28 at 12 26 22](https://github.com/user-attachments/assets/ae088ada-8288-4d85-81fa-9891c3043bb4)

## After
![Screenshot 2025-01-28 at 13 52 51](https://github.com/user-attachments/assets/349dca43-a9e8-44f4-b289-886f84e79ce9)


