### PR TITLE
💬 Update audience property

### DIFF
--- a/datahub_client/entities.py
+++ b/datahub_client/entities.py
@@ -114,9 +114,19 @@ Mappers = [
 ]
 
 
-class Audience(Enum):
-    INTERNAL = "Internal"
-    PUBLISHED = "Published"
+class Classification(Enum):
+    """Enumeration representing the security classification of the data.
+    Attributes:
+        OFFICIAL (str): Represents data classified as "Official".
+        OFFICIAL_SENSITIVE (str): Represents data classified as "Official-Sensitive".
+    Notes:
+        This enumeration replaces the Audience entity.
+        - "Published" becomes "Official".
+        - "Internal" becomes "Official-Sensitive".
+    """
+
+    OFFICIAL = "Official"
+    OFFICIAL_SENSITIVE = "Official-Sensitive"
 
 
 class EntityRef(BaseModel):
@@ -445,9 +455,9 @@ class CustomEntityProperties(BaseModel):
         description="Routes to further information about the data",
         default_factory=FurtherInformation,
     )
-    audience: Audience = Field(
+    classification: Classification = Field(
         description="If the data is published or not",
-        default="Internal",
+        default="Official-Sensitive",
     )
 
     class Config:

--- a/datahub_client/parsers.py
+++ b/datahub_client/parsers.py
@@ -191,7 +191,9 @@ class EntityParser:
         cadet_refresh_period = self.get_refresh_period_from_cadet_tags(tags)
         if cadet_refresh_period:
             data_summary.refresh_period = cadet_refresh_period
-        audience = custom_properties_dict.get("audience", "Internal")
+        classification = custom_properties_dict.get(
+            "classification", "Official-Sensitive"
+        )
 
         further_information = FurtherInformation.model_validate(custom_properties_dict)
 
@@ -200,7 +202,7 @@ class EntityParser:
             usage_restrictions=usage_restrictions,
             data_summary=data_summary,
             further_information=further_information,
-            audience=audience,
+            classification=classification,
         )
 
         return properties, custom_properties

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -73,10 +73,10 @@
                 <span class="govuk-!-font-weight-bold">Refresh period:</span>
                 {{entity.custom_properties.data_summary.refresh_period | default:'Not provided' }}
               </li>
-            {% if entity.custom_properties.audience %}
+            {% if entity.custom_properties.classification %}
               <li>
-                <span class="govuk-!-font-weight-bold">Audience:</span>
-                {{entity.custom_properties.audience}}
+                <span class="govuk-!-font-weight-bold">Classification:</span>
+                {{entity.custom_properties.classification}}
               </li>
             {% endif %}
             <!-- {% if entity.last_datajob_run_date %}

--- a/tests/datahub_client/search/test_search_client.py
+++ b/tests/datahub_client/search/test_search_client.py
@@ -1061,7 +1061,7 @@ def test_search_for_container(mock_graph, searcher):
                     "name": "test_db",
                 },
                 metadata={
-                    "audience": "Internal",
+                    "classification": "Official-Sensitive",
                     "owner": "Shannon Lovett",
                     "owner_email": "shannon@longtail.com",
                     "usage_restrictions": UsageRestrictions(

--- a/tests/datahub_client/snapshots/test_upsert_table.json
+++ b/tests/datahub_client/snapshots/test_upsert_table.json
@@ -1,126 +1,126 @@
 [
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dpia_required": "True",
-                "dpia_location": "",
-                "dc_where_to_access_dataset": "",
-                "source_dataset_name": "",
-                "s3_location": "",
-                "dc_access_requirements": "",
-                "row_count": "5",
-                "refresh_period": "",
-                "dc_slack_channel_name": "test-channel",
-                "dc_slack_channel_url": "test-url",
-                "dc_teams_channel_name": "",
-                "dc_teams_channel_url": "",
-                "dc_team_email": "",
-                "audience": "Internal"
-            },
-            "name": "Dataset",
-            "qualifiedName": "database.Dataset",
-            "description": "Dataset",
-            "tags": []
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "datasetProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dpia_required": "True",
+                    "dpia_location": "",
+                    "dc_where_to_access_dataset": "",
+                    "source_dataset_name": "",
+                    "s3_location": "",
+                    "dc_access_requirements": "",
+                    "row_count": "5",
+                    "refresh_period": "",
+                    "dc_slack_channel_name": "test-channel",
+                    "dc_slack_channel_url": "test-url",
+                    "dc_teams_channel_name": "",
+                    "dc_teams_channel_url": "",
+                    "dc_team_email": "",
+                    "classification": "Official-Sensitive"
+                },
+                "name": "Dataset",
+                "qualifiedName": "database.Dataset",
+                "description": "Dataset",
+                "tags": []
+            }
         }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-        "json": {
-            "schemaName": "Dataset",
-            "platform": "urn:li:dataPlatform:athena",
-            "version": 1,
-            "created": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            },
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            },
-            "hash": "",
-            "platformSchema": {
-                "com.linkedin.schema.OtherSchema": {
-                    "rawSchema": ""
-                }
-            },
-            "fields": [
-                {
-                    "fieldPath": "urn",
-                    "nullable": false,
-                    "description": "The primary identifier for the dataset entity.",
-                    "type": {
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "schemaMetadata",
+        "aspect": {
+            "json": {
+                "schemaName": "Dataset",
+                "platform": "urn:li:dataPlatform:athena",
+                "version": 1,
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "hash": "",
+                "platformSchema": {
+                    "com.linkedin.schema.OtherSchema": {
+                        "rawSchema": ""
+                    }
+                },
+                "fields": [
+                    {
+                        "fieldPath": "urn",
+                        "nullable": false,
+                        "description": "The primary identifier for the dataset entity.",
                         "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "string",
-                    "recursive": false,
-                    "isPartOfKey": false
-                }
-            ]
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "string",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Table"
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "container",
+        "aspect": {
+            "json": {
+                "container": "urn:li:container:my_database"
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:some-tag"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "domains",
+        "aspect": {
+            "json": {
+                "domains": [
+                    "urn:li:domain:LAA"
+                ]
+            }
         }
     }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Table"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:my_database"
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:some-tag"
-                }
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "domains",
-    "aspect": {
-        "json": {
-            "domains": [
-                "urn:li:domain:LAA"
-            ]
-        }
-    }
-}
 ]

--- a/tests/datahub_client/snapshots/test_upsert_table_and_database.json
+++ b/tests/datahub_client/snapshots/test_upsert_table_and_database.json
@@ -1,226 +1,226 @@
 [
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:my_database",
-    "changeType": "UPSERT",
-    "aspectName": "domains",
-    "aspect": {
-        "json": {
-            "domains": [
-                "urn:li:domain:LAA"
-            ]
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:my_database",
+        "changeType": "UPSERT",
+        "aspectName": "domains",
+        "aspect": {
+            "json": {
+                "domains": [
+                    "urn:li:domain:LAA"
+                ]
+            }
         }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:my_database",
-    "changeType": "UPSERT",
-    "aspectName": "containerProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dpia_required": "False",
-                "dpia_location": "",
-                "dc_where_to_access_dataset": "analytical_platform",
-                "source_dataset_name": "",
-                "s3_location": "s3://databucket/",
-                "dc_access_requirements": "",
-                "row_count": "",
-                "refresh_period": "",
-                "dc_slack_channel_name": "test-channel",
-                "dc_slack_channel_url": "test-url",
-                "dc_teams_channel_name": "",
-                "dc_teams_channel_url": "",
-                "dc_team_email": "",
-                "audience": "Internal"
-            },
-            "name": "my_database",
-            "description": "little test db"
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:my_database",
+        "changeType": "UPSERT",
+        "aspectName": "containerProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dpia_required": "False",
+                    "dpia_location": "",
+                    "dc_where_to_access_dataset": "analytical_platform",
+                    "source_dataset_name": "",
+                    "s3_location": "s3://databucket/",
+                    "dc_access_requirements": "",
+                    "row_count": "",
+                    "refresh_period": "",
+                    "dc_slack_channel_name": "test-channel",
+                    "dc_slack_channel_url": "test-url",
+                    "dc_teams_channel_name": "",
+                    "dc_teams_channel_url": "",
+                    "dc_team_email": "",
+                    "classification": "Official-Sensitive"
+                },
+                "name": "my_database",
+                "description": "little test db"
+            }
         }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:my_database",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Database"
-            ]
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:my_database",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Database"
+                ]
+            }
         }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:my_database",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:athena"
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:my_database",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:athena"
+            }
         }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:my_database",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:test"
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:my_database",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:test"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:my_database",
+        "changeType": "UPSERT",
+        "aspectName": "ownership",
+        "aspect": {
+            "json": {
+                "owners": [
+                    {
+                        "owner": "2e1fa91a-c607-49e4-9be2-6f072ebe27c7",
+                        "type": "TECHNICAL_OWNER"
+                    }
+                ],
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
                 }
-            ]
+            }
         }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:my_database",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "2e1fa91a-c607-49e4-9be2-6f072ebe27c7",
-                    "type": "TECHNICAL_OWNER"
-                }
-            ],
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "datasetProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "dpia_required": "True",
+                    "dpia_location": "",
+                    "dc_where_to_access_dataset": "",
+                    "source_dataset_name": "",
+                    "s3_location": "",
+                    "dc_access_requirements": "",
+                    "row_count": "5",
+                    "refresh_period": "",
+                    "dc_slack_channel_name": "test-channel",
+                    "dc_slack_channel_url": "test-url",
+                    "dc_teams_channel_name": "",
+                    "dc_teams_channel_url": "",
+                    "dc_team_email": "",
+                    "classification": "Official-Sensitive"
+                },
+                "name": "Dataset",
+                "qualifiedName": "database.Dataset",
+                "description": "Dataset",
+                "tags": []
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "schemaMetadata",
+        "aspect": {
+            "json": {
+                "schemaName": "Dataset",
+                "platform": "urn:li:dataPlatform:athena",
+                "version": 1,
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "hash": "",
+                "platformSchema": {
+                    "com.linkedin.schema.OtherSchema": {
+                        "rawSchema": ""
+                    }
+                },
+                "fields": [
+                    {
+                        "fieldPath": "urn",
+                        "nullable": false,
+                        "description": "The primary identifier for the dataset entity.",
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "string",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Table"
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "container",
+        "aspect": {
+            "json": {
+                "container": "urn:li:container:my_database"
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:some-tag"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "domains",
+        "aspect": {
+            "json": {
+                "domains": [
+                    "urn:li:domain:LAA"
+                ]
             }
         }
     }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "dpia_required": "True",
-                "dpia_location": "",
-                "dc_where_to_access_dataset": "",
-                "source_dataset_name": "",
-                "s3_location": "",
-                "dc_access_requirements": "",
-                "row_count": "5",
-                "refresh_period": "",
-                "dc_slack_channel_name": "test-channel",
-                "dc_slack_channel_url": "test-url",
-                "dc_teams_channel_name": "",
-                "dc_teams_channel_url": "",
-                "dc_team_email": "",
-                "audience": "Internal"
-            },
-            "name": "Dataset",
-            "qualifiedName": "database.Dataset",
-            "description": "Dataset",
-            "tags": []
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-        "json": {
-            "schemaName": "Dataset",
-            "platform": "urn:li:dataPlatform:athena",
-            "version": 1,
-            "created": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            },
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            },
-            "hash": "",
-            "platformSchema": {
-                "com.linkedin.schema.OtherSchema": {
-                    "rawSchema": ""
-                }
-            },
-            "fields": [
-                {
-                    "fieldPath": "urn",
-                    "nullable": false,
-                    "description": "The primary identifier for the dataset entity.",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "string",
-                    "recursive": false,
-                    "isPartOfKey": false
-                }
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Table"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:my_database"
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:some-tag"
-                }
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,database.Dataset,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "domains",
-    "aspect": {
-        "json": {
-            "domains": [
-                "urn:li:domain:LAA"
-            ]
-        }
-    }
-}
 ]

--- a/tests/datahub_client/test_datahub_client.py
+++ b/tests/datahub_client/test_datahub_client.py
@@ -6,8 +6,8 @@ import pytest
 from datahub_client.client import DataHubCatalogueClient
 from datahub_client.entities import (
     AccessInformation,
-    Audience,
     Chart,
+    Classification,
     Column,
     ColumnRef,
     CustomEntityProperties,
@@ -463,7 +463,7 @@ class TestCatalogueClientWithDatahub:
                 ),
                 data_summary=DataSummary(),
                 further_information=FurtherInformation(),
-                audience=Audience.INTERNAL,
+                classification=Classification.OFFICIAL_SENSITIVE,
             ),
             column_details=[],
         )
@@ -523,7 +523,7 @@ class TestCatalogueClientWithDatahub:
                 ),
                 data_summary=DataSummary(),
                 further_information=FurtherInformation(),
-                audience=Audience.INTERNAL,
+                classification=Classification.OFFICIAL_SENSITIVE,
             ),
             external_url="https://data.justice.gov.uk/prisons/public-protection/absconds",
         )
@@ -609,7 +609,7 @@ class TestCatalogueClientWithDatahub:
                 dc_teams_channel_url="",
                 dc_team_email="",
             ),
-            audience="Internal",
+            classification=Classification.OFFICIAL_SENSITIVE,
         )
 
         expected = PublicationCollection(

--- a/tests/datahub_client/test_parsers.py
+++ b/tests/datahub_client/test_parsers.py
@@ -2,8 +2,8 @@ import pytest
 
 from datahub_client.entities import (
     AccessInformation,
-    Audience,
     Chart,
+    Classification,
     Column,
     ColumnRef,
     CustomEntityProperties,
@@ -55,7 +55,7 @@ def mock_dataset_graphql_entity():
                 {"key": "source_dataset_name", "value": ""},
                 {"key": "s3_location", "value": "s3://databucket/"},
                 {"key": "row_count", "value": 100},
-                {"key": "audience", "value": "Internal"},
+                {"key": "classification", "value": "Official-Sensitive"},
                 {"key": "refresh_period", "value": "Weekly"},
             ],
         },
@@ -415,7 +415,7 @@ class TestEntityParser:
                     {"key": "s3_location", "value": "s3://databucket/"},
                     {"key": "row_count", "value": 100},
                     {"key": "Not_IN", "value": "dddd"},
-                    {"key": "audience", "value": "Internal"},
+                    {"key": "classification", "value": "Official-Sensitive"},
                     {"key": "refresh_period", "value": "Weekly"},
                 ],
                 "name": "test",
@@ -445,7 +445,7 @@ class TestEntityParser:
             further_information=FurtherInformation(
                 dc_slack_channel_name="test-channel", dc_slack_channel_url="test-url"
             ),
-            audience=Audience.INTERNAL,
+            classification=Classification.OFFICIAL_SENSITIVE,
         )
 
     def test_parse_properties_with_none_values(self, parser):
@@ -463,7 +463,7 @@ class TestEntityParser:
                     {"key": "s3_location", "value": "s3://databucket/"},
                     {"key": "row_count", "value": 100},
                     {"key": "Not_IN", "value": "dddd"},
-                    {"key": "audience", "value": "Internal"},
+                    {"key": "classification", "value": "Official-Sensitive"},
                 ],
                 "name": "test",
                 "description": None,
@@ -492,7 +492,7 @@ class TestEntityParser:
             ),
             data_summary=DataSummary(row_count=100),
             further_information=FurtherInformation(),
-            audience=Audience.INTERNAL,
+            classification=Classification.OFFICIAL_SENSITIVE,
         )
 
     def test_parse_columns_with_empty_fields(self, parser):


### PR DESCRIPTION
### Summary
Changes the audience property name to classification and applies the appropriate security classification and additional marking where appropriate based on [this](https://www.gov.uk/government/publications/government-security-classifications/government-security-classifications-policy-quick-read-html) guidance.

`Published` becomes `Official`
`Internal` becomes `Official-Sensitive` (Security Classification-Additional Marking)

- Defines new `Classification` entity
- Changes audience property to classification
- Updates tests