### PR TITLE
feat: add new subject areas behind a switch

### DIFF
--- a/datahub_client/entities.py
+++ b/datahub_client/entities.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Literal, Optional
 
+import waffle
 from pydantic import AfterValidator, BaseModel, EmailStr, Field
 from typing_extensions import Annotated
 
@@ -693,7 +694,7 @@ class Dashboard(Entity):
 
 
 class SubjectAreaTaxonomy:
-    ALL_SUBJECT_AREAS = [
+    ALL_SUBJECT_AREAS_OLD = [
         TagRef.from_name("Bold"),
         TagRef.from_name("Civil"),
         TagRef.from_name("Courts"),
@@ -709,9 +710,24 @@ class SubjectAreaTaxonomy:
         TagRef.from_name("Risk"),
     ]
 
+    ALL_SUBJECT_AREAS = [
+        TagRef.from_name("Prisons and probation"),
+        TagRef.from_name("Courts and tribunals"),
+        TagRef.from_name("Corporate"),
+        TagRef.from_name("Office of the Public Guardian"),
+        TagRef.from_name("Legal aid"),
+        TagRef.from_name("Crime and policing"),
+        TagRef.from_name("Reference data"),
+    ]
+
     @classmethod
     def get_by_name(cls, name):
-        matches = [i for i in cls.ALL_SUBJECT_AREAS if i.display_name == name]
+        subject_areas = (
+            cls.ALL_SUBJECT_AREAS
+            if waffle.switch_is_active("new_subject_areas")
+            else cls.ALL_SUBJECT_AREAS_OLD
+        )
+        matches = [i for i in subject_areas if i.display_name == name]
         return matches[0] if matches else None
 
     @classmethod

--- a/scripts/app-entrypoint.sh
+++ b/scripts/app-entrypoint.sh
@@ -14,6 +14,7 @@ python manage.py migrate
 python manage.py waffle_switch search-sort-radio-buttons off --create # create switch with default setting
 python manage.py waffle_switch display-result-tags off --create # create display tags switch with default off
 python manage.py waffle_switch show_is_nullable_in_table_details_column off --create # create isnullable column switch with default off
+python manage.py waffle_switch new_subject_areas off --create # remove this once deployed
 python manage.py waffle_flag home_variant_a --testing --create
 python manage.py waffle_flag home_variant_b --testing --create
 

--- a/tests/datahub_client/search/test_search_client.py
+++ b/tests/datahub_client/search/test_search_client.py
@@ -71,6 +71,7 @@ def test_no_search_results(mock_graph, searcher):
     assert response == expected
 
 
+@pytest.mark.django_db
 def test_one_search_result(mock_graph, searcher):
     subject_area = SubjectAreaTaxonomy.get_by_name("Prison")
     assert subject_area
@@ -157,6 +158,7 @@ def test_one_search_result(mock_graph, searcher):
     assert response == expected
 
 
+@pytest.mark.django_db
 def test_dataset_result(mock_graph, searcher):
     subject_area = SubjectAreaTaxonomy.get_by_name("Prison")
     assert subject_area
@@ -278,8 +280,9 @@ def test_bad_entity_type(mock_graph, searcher):
     assert response == expected
 
 
+@pytest.mark.django_db
 def test_2_dataset_results_with_one_malformed_result(mock_graph, searcher):
-    subject_area = SubjectAreaTaxonomy.ALL_SUBJECT_AREAS[0]
+    subject_area = SubjectAreaTaxonomy.get_by_name("Prison")
     datahub_response = {
         "searchAcrossEntities": {
             "start": 0,
@@ -966,6 +969,7 @@ def test_search_for_charts(mock_graph, searcher):
     assert expected == response
 
 
+@pytest.mark.django_db
 def test_search_for_container(mock_graph, searcher):
     subject_area = SubjectAreaTaxonomy.get_by_name("Prison")
     assert subject_area

--- a/tests/datahub_client/test_datahub_client.py
+++ b/tests/datahub_client/test_datahub_client.py
@@ -27,6 +27,7 @@ from datahub_client.entities import (
 from datahub_client.exceptions import EntityDoesNotExist
 
 
+@pytest.mark.django_db
 class TestCatalogueClientWithDatahub:
     """
     Test that the contract with DataHubGraph has not changed, using a mock.

--- a/tests/datahub_client/test_parsers.py
+++ b/tests/datahub_client/test_parsers.py
@@ -120,6 +120,7 @@ def mock_graphql_search_result(mock_dataset_graphql_entity):
     return {"entity": mock_dataset_graphql_entity, "matchedFields": []}
 
 
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "parser, entity_object_type",
     [


### PR DESCRIPTION
Once we're happy things have been tagged to the new subject areas in prod, we can switch this on. This switch is independent of the new homepage design.

This extra code should be removed once this is live, I've just added it to help with the release.