### PR TITLE
feat: link to analytical platform control panel

### DIFF
--- a/templates/base/navigation.html
+++ b/templates/base/navigation.html
@@ -78,6 +78,11 @@
               Contact us
             </a>
           </li>
+          <li class="moj-primary-navigation__item">
+            <a class="moj-primary-navigation__link" rel="noreferrer noopener" target="_blank" href="https://controlpanel.services.analytical-platform.service.justice.gov.uk">
+              Analytical Platform <span class="govuk-visually-hidden">(opens in new tab)</span>
+            </a>
+          </li>
         </ul>
 
       </nav>


### PR DESCRIPTION
https://github.com/ministryofjustice/find-moj-data/issues/1250

The Analytical Platform is a closely related service, and we anticipate AP and Find MoJ data being more closely integrated eventually. For now, we think it would be good to link to AP's control panel in the header, so that are users can easily get to it from any page on the catalogue.

AP already link to Find MoJ data on their side.

We're not sure about putting this link in the primary nav, but this is the simplest option so we're going to try this out and see if it causes any issues.

The link opens in a new tab because we're linking to an external service and the link back to Find MoJ data from AP also opens in a new tab, so we wanted to be consistent. To mitigate against the accessibility issue of people not perceiving that a new tab has opened, I've added a visually hidden "(opens in new tab)" to the link text, as per https://design-system.service.gov.uk/styles/links/#:~:text=link%20icon.-,Opening%20links%20in%20a%20new%20tab,-Avoid%20opening%20links

<img width="622" alt="Screenshot showing the nav with a new item, 'Analytical Platform'" src="https://github.com/user-attachments/assets/08605c83-598c-4082-93eb-8d031f9ac51e" />
