### PR TITLE
design: remove padding above masthead

### DIFF
--- a/scss/base.scss
+++ b/scss/base.scss
@@ -57,7 +57,7 @@ code {
 
 .main-wrapper-with-masthead {
   @extend .govuk-main-wrapper;
-  padding-top: govuk-spacing(3);
+  padding-top: govuk-spacing(0);
 }
 
 // we've reduced the minimum here as the default value was higher


### PR DESCRIPTION
This padding was introduced to avoid the blue underline of the home link bumping into the blue masthead. However, we've decided this isn't worth the extra whitespace that pushes down the content of the page.

<img width="756" alt="Screenshot with padding removed" src="https://github.com/user-attachments/assets/7c29c339-04e8-44b3-badb-cdcdb93195e2" />
