### PR TITLE
Redesign search result metadata

### DIFF
--- a/scss/base.scss
+++ b/scss/base.scss
@@ -16,6 +16,7 @@ $govuk-new-typography-scale: true;
 @import "./components/table";
 @import "./components/cards";
 @import "./components/card-grid";
+@import "./components/metadata-list";
 
 .js-required {
   display: none;

--- a/scss/components/_metadata-list.scss
+++ b/scss/components/_metadata-list.scss
@@ -1,0 +1,33 @@
+.app-metadata-list {
+    @extend .govuk-summary-list;
+    @extend .govuk-summary-list--no-border;
+    @include govuk-responsive-margin(4, "bottom");
+
+    .app-metadata-list__row {
+        @extend .govuk-summary-list__row;
+    }
+
+    .app-metadata-list__key {
+        @extend .govuk-summary-list__key;
+
+        @include govuk-media-query($from: tablet) {
+            padding-top: govuk-spacing(1);
+            padding-bottom: govuk-spacing(1);
+        }
+    }
+
+    .app-metadata-list__value {
+        @extend .govuk-summary-list__value;
+
+        @include govuk-media-query($from: tablet) {
+            padding-top: govuk-spacing(1);
+            padding-bottom: govuk-spacing(1);
+        }
+
+        &:has(.govuk-tag) {
+            /* Prevent rows with tags from being taller than other rows */
+            padding-top: govuk-spacing(0);
+            padding-bottom: govuk-spacing(0);
+        }
+    }
+}

--- a/templates/partial/search_result.html
+++ b/templates/partial/search_result.html
@@ -1,6 +1,5 @@
 {% load markdown %}
 {% load humanize %}
-{% load waffle_tags %}
 
 <div id="search-results">
   {% for result in highlighted_results %}
@@ -10,47 +9,13 @@
           {% with result_type=result.result_type.url_formatted %}
             <a href="{% url 'home:details' result_type=result_type urn=result.urn %}" class="govuk-link">{{result.name}}</a>
           {% endwith %}
-          <strong class="govuk-tag govuk-!-margin-left-2">
-            {{ result.result_type.find_moj_data_type.value }}
-          </strong>
         </h3>
         {% if result.description %}
           <div class="govuk-body-m">
             {{ result.description|truncate_snippet:300|markdown:3 }}
           </div>
         {% endif %}
-        <ul class="govuk-list govuk-body">
-          <li>
-            {% include 'partial/subject_area_list.html' with subject_areas=result.subject_areas %}
-          </li>
-          {% if result.result_type.name == "TABLE" %}
-            <li>
-              <span class="govuk-!-font-weight-bold">Database:</span>
-              <span>{{result.parent_entity.display_name}}</span>
-            </li>
-          {% endif %}
-          {% switch 'display-result-tags' %}
-            <li>
-              <span class="govuk-!-font-weight-bold">Tags:</span>
-              <span>
-                {% if result.tags_to_display %}
-                  {% for tag in result.tags_to_display %}
-                    <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% querystring clear_label=None clear_filter=None new=None tags=tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
-                  {% endfor %}
-                {% endif %}
-              </span>
-            </li>
-          {% endswitch %}
-
-          {% with match_reasons=result.matches|lookup:readable_match_reasons|join:", " %}
-            {% if match_reasons %}
-              <li>
-                <span class="govuk-!-font-weight-bold">Matched fields:</span>
-                <span>{{ match_reasons }}</span>
-              </li>
-            {% endif %}
-          {% endwith %}
-        </ul>
+        {% include 'partial/search_result_metadata.html' %}
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
       </div>
     </div>

--- a/templates/partial/search_result_metadata.html
+++ b/templates/partial/search_result_metadata.html
@@ -1,0 +1,65 @@
+{% load waffle_tags %}
+{% load lookup %}
+<dl class="app-metadata-list">
+  <div class="app-metadata-list__row">
+    <dt class="app-metadata-list__key">
+      Entity type
+    </dt>
+    <dd class="app-metadata-list__value">
+      <strong class="govuk-tag">
+        {{ result.result_type.find_moj_data_type.value }}
+      </strong>
+    </dd>
+  </div>
+
+  <div class="app-metadata-list__row">
+    <dt class="app-metadata-list__key">
+      Subject area{{result.subject_areas|length|pluralize}}
+    </dt>
+    <dd class="app-metadata-list__value">
+      {% for subject_area in result.subject_areas %}
+      {{ subject_area.display_name }}{% if not forloop.last %}, {% endif %}
+      {% endfor %}
+      {% if not result.subject_areas %}
+      Not provided
+      {% endif %}
+    </dd>
+  </div>
+
+  {% if result.result_type.find_moj_data_type.name == "TABLE" and result.parent_entity %}
+  <div class="app-metadata-list__row">
+    <dt class="app-metadata-list__key">
+      Database
+    </dt>
+    <dd class="app-metadata-list__value">
+      {{result.parent_entity.display_name}}
+    </dd>
+  </div>
+  {% endif %}
+
+  {% switch 'display-result-tags' %}
+  <div class="app-metadata-list__row">
+    <dt class="app-metadata-list__key">
+      Tags
+    </dt>
+    <dd class="app-metadata-list__value">
+      {% for tag in result.tags_to_display %}
+      <a aria-label="link to search results for all entities tagged {{ tag }}" href="{% url 'home:search' %}{% querystring clear_label=None clear_filter=None new=None tags=tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+      {% endfor %}
+    </dd>
+  </div>
+  {% endswitch %}
+
+  {% with match_reasons=result.matches|lookup:readable_match_reasons|join:", " %}
+  {% if match_reasons %}
+  <div class="app-metadata-list__row">
+    <dt class="app-metadata-list__key">
+      Matched fields
+    </dt>
+    <dd class="app-metadata-list__value">
+      {{ match_reasons }}
+    </dd>
+  </div>
+  {% endif %}
+  {% endwith %}
+</dl>

--- a/templates/search.html
+++ b/templates/search.html
@@ -47,7 +47,7 @@
         <p class="govuk-error-message">Some results were malformed and are not shown</p>
       {% endif %}
       {% if results %}
-        <h2 class="govuk-heading-l govuk-!-display-inline-block" id="result-count">{{total_results_str|intcomma}} results</h2>
+        <h2 class="govuk-heading-m govuk-!-display-inline-block" id="result-count">{{total_results_str|intcomma}} results</h2>
       {% else %}
         {% include "partial/no_results.html" %}
       {% endif %}

--- a/tests/integration/test_search_result_metadata.py
+++ b/tests/integration/test_search_result_metadata.py
@@ -31,7 +31,7 @@ class TestSearchResultMetadata:
 
         self.selenium.get(f"{self.live_server_url}/search")
 
-        assert "Matched fields:" not in self.selenium.page_source
+        assert "Matched fields" not in self.selenium.page_source
 
     def test_matched_fields_shown(self, mock_catalogue):
         result = SearchResult(
@@ -46,4 +46,4 @@ class TestSearchResultMetadata:
 
         self.selenium.get(f"{self.live_server_url}/search?query=bla")
 
-        assert "Matched fields:" in self.selenium.page_source
+        assert "Matched fields" in self.selenium.page_source


### PR DESCRIPTION
This implements https://github.com/ministryofjustice/find-moj-data/issues/1291 and https://github.com/ministryofjustice/find-moj-data/issues/1290

- Move entity type tag into the metadata list
- Adopt summary list instead of govuk-list (but reduce the padding)
- Reduce the size of the "123 results" heading

## Before
Note - in both screenshots, the "Database" field is not showing for table entries - this is a problem with the dev environment, unrelated to this change.

![Screenshot 2025-01-29 at 14 22 11](https://github.com/user-attachments/assets/6492ffb3-b7fa-47c0-a8ee-6a2c74e13684)

## After
![Screenshot 2025-01-29 at 16 20 16](https://github.com/user-attachments/assets/ac238a1e-4717-461d-9f4d-4031a05844fb)

