### PR TITLE
feat: Hide request access contact section for publications

### DIFF
--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -109,7 +109,7 @@
       </div>
     </div>
     <div class="govuk-grid-column-one-third">
-      {% include "partial/contact_info.html" with entity_name=entity.name governance=entity.governance further_information=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_url=is_access_requirements_a_url platform=entity.platform %}
+      {% include "partial/contact_info.html" with entity_name=entity.name governance=entity.governance further_information=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_url=is_access_requirements_a_url platform=entity.platform entity_type=entity_type %}
     </div>
   </div>
 

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -109,7 +109,7 @@
       </div>
     </div>
     <div class="govuk-grid-column-one-third">
-      {% include "partial/contact_info.html" with entity_name=entity.name governance=entity.governance further_information=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_url=is_access_requirements_a_url platform=entity.platform entity_type=entity_type %}
+      {% include "partial/contact_info.html" with entity_name=entity.name governance=entity.governance further_information=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_url=is_access_requirements_a_url platform=entity.platform security_classification=entity.custom_properties.security_classification %}
     </div>
   </div>
 

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -1,19 +1,21 @@
 <div class="govuk-body">
-  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Request access</h2>
-  <p id="request_access" class="govuk-body">
+  {% if entity_type != "Publication collection" and entity_type != "Publication dataset" %}
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Request access</h2>
+    <p id="request_access" class="govuk-body">
 
-    {% if access_requirements %}
-      {% if is_access_url %}
-        <a onclick="gtag('event', 'click_access_link', {'entity_name': '{{ entity_name }}'})" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Select this link for access information (opens in new tab)</a>
+      {% if access_requirements %}
+        {% if is_access_url %}
+          <a onclick="gtag('event', 'click_access_link', {'entity_name': '{{ entity_name }}'})" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Select this link for access information (opens in new tab)</a>
+        {% else %}
+          {{ access_requirements }}
+        {% endif %}
+      {% elif governance.data_custodians or governance.data_owner.email %}
+        Contact the data custodian to request access.
       {% else %}
-        {{ access_requirements }}
+        Not provided.
       {% endif %}
-    {% elif governance.data_custodians or governance.data_owner.email %}
-      Contact the data custodian to request access.
-    {% else %}
-      Not provided.
-    {% endif %}
-  </p>
+    </p>
+  {% endif %}
 </div>
 
 <div class="govuk-body">

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -1,5 +1,5 @@
 <div class="govuk-body">
-  {% if entity_type != "Publication collection" and entity_type != "Publication dataset" %}
+  {% if security_classification != "Official-Sensitive"%}
     <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Request access</h2>
     <p id="request_access" class="govuk-body">
 

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -1,5 +1,5 @@
 <div class="govuk-body">
-  {% if security_classification != "Official-Sensitive"%}
+  {% if security_classification == "Official-Sensitive"%}
     <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Request access</h2>
     <p id="request_access" class="govuk-body">
 


### PR DESCRIPTION
* Hide Request Access section for non-sensitive data, where there is already an "Access this data" section
* The other point on the ticket is to change the "Access this data" to an h2 - this is already done

https://github.com/ministryofjustice/find-moj-data/issues/1295

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/15cf048f-08bb-416f-81f2-be363732232f" />
