### PR TITLE
fix: update button style for report issue link in contact info template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,4 +177,3 @@ coverage
 # generated translation files
 *.mo
 
-lib/datahub-client/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ coverage
 
 # generated translation files
 *.mo
+
+lib/datahub-client/.vscode

--- a/feedback/templates/feedback.html
+++ b/feedback/templates/feedback.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">{{h1_value}}</h1>
+    <h1 class="govuk-heading-l">{{h1_value}}</h1>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/feedback/templates/feedback.html
+++ b/feedback/templates/feedback.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">{{h1_value}}</h1>
+    <h1 class="govuk-heading-m">{{h1_value}}</h1>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/feedback/templates/feedback.html
+++ b/feedback/templates/feedback.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-m">{{h1_value}}</h1>
+    <h1 class="govuk-heading-l">{{h1_value}}</h1>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/feedback/templates/feedback.html
+++ b/feedback/templates/feedback.html
@@ -49,7 +49,7 @@
       </div>
       <div class="govuk-form-group">
         <h2 class="govuk-label-wrapper">
-          <label class="govuk-label govuk-label--l" for="{{form.how_can_we_improve.id_for_label}}">
+          <label class="govuk-label govuk-label--m" for="{{form.how_can_we_improve.id_for_label}}">
             {{form.how_can_we_improve.label}}
           </label>
         </h2>

--- a/feedback/templates/feedback.html
+++ b/feedback/templates/feedback.html
@@ -25,7 +25,7 @@
 
       <div class="govuk-form-group {% if form.satisfaction_rating.errors %}govuk-form-group-errors{% endif %}">
         <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
             <h2 class="govuk-fieldset__heading">
               {{form.satisfaction_rating.label}}
             </h2>

--- a/feedback/templates/report_issue.html
+++ b/feedback/templates/report_issue.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">{{h1_value}}</h1>
+    <h1 class="govuk-heading-l">{{h1_value}}</h1>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/feedback/templates/report_issue.html
+++ b/feedback/templates/report_issue.html
@@ -49,7 +49,7 @@
 
       <div class="govuk-form-group {% if form.additional_info.errors %}govuk-form-group-errors{% endif %}">
         <h1 class="govuk-label-wrapper">
-          <label class="govuk-label govuk-label--l" for="{{form.additional_info.id_for_label}}">
+          <label class="govuk-label govuk-label--m" for="{{form.additional_info.id_for_label}}">
             {{form.additional_info.label}}
           </label>
         </h1>

--- a/feedback/templates/report_issue.html
+++ b/feedback/templates/report_issue.html
@@ -24,7 +24,7 @@
 
       <div class="govuk-form-group {% if form.reason.errors %}govuk-form-group-errors{% endif %}">
         <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
             <h2 class="govuk-fieldset__heading">
               {{form.reason.label}}
             </h2>
@@ -66,7 +66,7 @@
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
             <h1 class="govuk-fieldset__heading">
               {{form.send_email_to_reporter.label}}
             </h1>

--- a/feedback/templates/thanks.html
+++ b/feedback/templates/thanks.html
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-l">
         Thank you for your feedback
       </h1>
 

--- a/lib/datahub-client/.vscode/settings.json
+++ b/lib/datahub-client/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
+}

--- a/lib/datahub-client/.vscode/settings.json
+++ b/lib/datahub-client/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "python.testing.pytestArgs": [
-    "tests"
-  ],
-  "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
-}

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -68,7 +68,8 @@
 {% endif %}
 
 {% if NOTIFY_ENABLED and entity_name %}
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
   <div class="govuk-body">
-    <a type="button" class="govuk-button" href="{% url 'feedback:report-issue' %}?entity_name={{ entity_name }}&data_custodian_email={{ governance.data_owner.email|urlencode }}&entity_url={{ request.build_absolute_uri}}" class="govuk-link">Report an issue</a>
+    <a type="button" class="govuk-button govuk-button--secondary" href="{% url 'feedback:report-issue' %}?entity_name={{ entity_name }}&data_custodian_email={{ governance.data_owner.email|urlencode }}&entity_url={{ request.build_absolute_uri}}" class="govuk-link">Report an issue</a>
   </div>
 {% endif %}


### PR DESCRIPTION
https://github.com/ministryofjustice/find-moj-data/issues/1294

* Report an issue is now a secondary button
* Added a section break before the report an issue button

https://github.com/ministryofjustice/find-moj-data/issues/1297

* Change heading size to `l` from `xl` on feedback form pages
* Correspondingly drop subheadings from `l` to `m`