### PR TITLE
fix: Hide 'Data custodian (technical contact)' in contact info template

### DIFF
--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -9,8 +9,8 @@
         {% else %}
           {{ access_requirements }}
         {% endif %}
-      {% elif governance.data_custodians or governance.data_owner.email %}
-        Contact the data custodian to request access.
+      <!-- {% elif governance.data_custodians or governance.data_owner.email %}
+        Contact the data custodian to request access. -->
       {% else %}
         Not provided.
       {% endif %}

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -9,8 +9,10 @@
         {% else %}
           {{ access_requirements }}
         {% endif %}
-      <!-- {% elif governance.data_custodians or governance.data_owner.email %}
-        Contact the data custodian to request access. -->
+        {% comment %}
+         {% elif governance.data_custodians or governance.data_owner.email %}
+         Contact the data custodian to request access.
+        {% endcomment %}
       {% else %}
         Not provided.
       {% endif %}

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -45,7 +45,7 @@
   </ul>
 </div>
 
-{% if governance.data_custodians and governance.data_custodians.0.email %}
+<!-- {% if governance.data_custodians and governance.data_custodians.0.email %}
 <div class="govuk-body">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Data custodian (technical contact)</h2>
   <p id="data_owner" class="govuk-body">
@@ -65,7 +65,7 @@
     {% endif %}
   </p>
 </div>
-{% endif %}
+{% endif %} -->
 
 {% if NOTIFY_ENABLED and entity_name %}
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -36,11 +36,12 @@
     {% endif %}
 
     {% if not further_information.dc_teams_channel_url and not further_information.dc_slack_channel_url and not further_information.dc_team_email %}
-      {% if governance.data_custodians or governance.data_owner.email %}
+      <!-- {% if governance.data_custodians or governance.data_owner.email %}
       <li id="contact_channels_data_owner">Contact the data custodian with questions.</li>
       {% else %}
       <li id="contact_channels_not_provided">Not provided.</li>
-      {% endif %}
+      {% endif %} -->
+      <li id="contact_channels_not_provided">Not provided.</li>
     {% endif %}
   </ul>
 </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,8 +113,8 @@ class DetailsPage(Page):
     def contact_channels_not_provided(self):
         return self.selenium.find_element(By.ID, "contact_channels_not_provided")
 
-    # def data_owner_or_custodian(self):
-    #     return self.selenium.find_element(By.ID, "data_owner")
+    def data_owner_or_custodian(self):
+        return self.selenium.find_element(By.ID, "data_owner")
 
 
 class DatabaseDetailsPage(DetailsPage):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,8 +113,8 @@ class DetailsPage(Page):
     def contact_channels_not_provided(self):
         return self.selenium.find_element(By.ID, "contact_channels_not_provided")
 
-    def data_owner_or_custodian(self):
-        return self.selenium.find_element(By.ID, "data_owner")
+    # def data_owner_or_custodian(self):
+    #     return self.selenium.find_element(By.ID, "data_owner")
 
 
 class DatabaseDetailsPage(DetailsPage):

--- a/tests/integration/test_details_contact_contents.py
+++ b/tests/integration/test_details_contact_contents.py
@@ -262,6 +262,6 @@ class TestDetailsPageContactDetails:
         mock_get_database_details_response(mock_catalogue, database)
 
         self.start_on_the_details_page()
-        request_access_metadata = self.details_database_page.data_owner_or_custodian()
+        # request_access_metadata = self.details_database_page.data_owner_or_custodian()
 
-        assert request_access_metadata.text == expected_text
+        # assert request_access_metadata.text == expected_text

--- a/tests/integration/test_details_contact_contents.py
+++ b/tests/integration/test_details_contact_contents.py
@@ -91,18 +91,18 @@ class TestDetailsPageContactDetails:
                 "meta.data@justice.gov.uk",
                 "Some contact info",
             ),
-            (
-                "",
-                "#contact_us",
-                "meta.data@justice.gov.uk",
-                "Contact the data custodian to request access.",
-            ),
-            (
-                "",
-                "",
-                "meta.data@justice.gov.uk",
-                "Contact the data custodian to request access.",
-            ),
+            # (
+            #     "",
+            #     "#contact_us",
+            #     "meta.data@justice.gov.uk",
+            #     "Contact the data custodian to request access.",
+            # ),
+            # (
+            #     "",
+            #     "",
+            #     "meta.data@justice.gov.uk",
+            #     "Contact the data custodian to request access.",
+            # ),
             (
                 "",
                 "",

--- a/tests/integration/test_details_contact_contents.py
+++ b/tests/integration/test_details_contact_contents.py
@@ -227,8 +227,8 @@ class TestDetailsPageContactDetails:
         if team_email:
             assert self.details_database_page.contact_channels_team_email()
 
-        if not slack_channel and not teams_channel and not team_email and custodian:
-            assert self.details_database_page.contact_channels_data_owner()
+        # if not slack_channel and not teams_channel and not team_email and custodian:
+        #     assert self.details_database_page.contact_channels_data_owner()
         if not slack_channel and not teams_channel and not team_email and not custodian:
             assert self.details_database_page.contact_channels_not_provided()
 


### PR DESCRIPTION
Hide data custodian section