### PR TITLE
fix: workaround for markdown with lists in

### DIFF
--- a/scss/base.scss
+++ b/scss/base.scss
@@ -86,3 +86,14 @@ code {
 .skip-underlined-current.moj-primary-navigation__link[aria-current]:before {
   display: none;
 }
+
+// Workaround for compiled markdown not following design system markup.
+ul {
+  @extend .govuk-list;
+  @extend .govuk-list--bullet;
+}
+
+ol {
+  @extend .govuk-list;
+  @extend .govuk-list--number;
+}


### PR DESCRIPTION
Markdown may contain ordered and unordered lists. These should be styled according to the design system.