### PR TITLE
feat: Order publication collection contents by year

### DIFF
--- a/datahub_client/entities.py
+++ b/datahub_client/entities.py
@@ -376,6 +376,13 @@ class EntitySummary(BaseModel):
     entity_type: str = Field(
         description="indicates the type of entity that is summarised"
     )
+    data_last_modified: Annotated[
+        Optional[datetime], AfterValidator(check_timestamp_is_in_the_past)
+    ] = Field(
+        description="When the data entity was last modified in the source system",
+        default=None,
+        examples=[datetime(2011, 10, 2, 3, 0, 0)],
+    )
     tags: list[TagRef] = Field(description="Any tags associated with the entity")
 
 

--- a/datahub_client/graphql/getContainerDetails.graphql
+++ b/datahub_client/graphql/getContainerDetails.graphql
@@ -49,6 +49,9 @@ query getContainer($urn: String!) {
             properties {
               name
               description
+              lastModified {
+                time
+              }
             }
             tags {
               tags {

--- a/datahub_client/parsers.py
+++ b/datahub_client/parsers.py
@@ -1,7 +1,6 @@
 import logging
 from collections import defaultdict
 from datetime import datetime
-import re
 from typing import Any, Tuple
 
 from datahub_client.entities import (
@@ -463,6 +462,7 @@ class EntityParser:
                         description=description,
                         entity_type=entity_type,
                         tags=tags,
+                        data_last_modified=self.parse_data_last_modified(properties),
                     )
                 )
 
@@ -934,29 +934,3 @@ class EntityParserFactory:
                 return PublicationCollectionParser()
             else:
                 return DatabaseParser()
-
-
-def extract_year_timestamp(text):
-    """
-    Find the first 4-digit year in text and return its timestamp.
-    Returns Jan 1, 1900 timestamp if no year found.
-
-    Args:
-        text (str): Input text to search for year
-
-    Returns:
-        int: Unix timestamp for January 1st of found year, or Jan 1, 1900 if none found
-    """
-    DEFAULT_TIMESTAMP = -2208988800  # Jan 1, 1900
-
-    if not text or not isinstance(text, str):
-        return DEFAULT_TIMESTAMP
-
-    # Find first 4-digit number between 1900 and 2100
-    match = re.search(r'(?:19|20)\d{2}', text)
-
-    if match:
-        year = int(match.group(0))
-        return int(datetime(year, 1, 1).timestamp())
-
-    return DEFAULT_TIMESTAMP

--- a/datahub_client/parsers.py
+++ b/datahub_client/parsers.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict
 from datetime import datetime
+import re
 from typing import Any, Tuple
 
 from datahub_client.entities import (
@@ -933,3 +934,29 @@ class EntityParserFactory:
                 return PublicationCollectionParser()
             else:
                 return DatabaseParser()
+
+
+def extract_year_timestamp(text):
+    """
+    Find the first 4-digit year in text and return its timestamp.
+    Returns Jan 1, 1900 timestamp if no year found.
+
+    Args:
+        text (str): Input text to search for year
+
+    Returns:
+        int: Unix timestamp for January 1st of found year, or Jan 1, 1900 if none found
+    """
+    DEFAULT_TIMESTAMP = -2208988800  # Jan 1, 1900
+
+    if not text or not isinstance(text, str):
+        return DEFAULT_TIMESTAMP
+
+    # Find first 4-digit number between 1900 and 2100
+    match = re.search(r'(?:19|20)\d{2}', text)
+
+    if match:
+        year = int(match.group(0))
+        return int(datetime(year, 1, 1).timestamp())
+
+    return DEFAULT_TIMESTAMP

--- a/home/service/details.py
+++ b/home/service/details.py
@@ -12,6 +12,7 @@ from datahub_client.entities import (
     PublicationDatasetEntityMapping,
     RelationshipType,
 )
+from datahub_client.parsers import extract_year_timestamp
 
 from ..urns import PlatformUrns
 from .base import GenericService
@@ -232,7 +233,8 @@ class PublicationCollectionDetailsService(GenericService):
             ),
             "publications": sorted(
                 self.entities_in_container,
-                key=lambda d: d.entity_ref.display_name,
+                key=lambda d: extract_year_timestamp(d.entity_ref.display_name),
+                reverse=True,
             ),
             "h1_value": self.publication_collection_metadata.name,
             "is_access_requirements_a_url": is_access_requirements_a_url(

--- a/home/service/details.py
+++ b/home/service/details.py
@@ -12,7 +12,6 @@ from datahub_client.entities import (
     PublicationDatasetEntityMapping,
     RelationshipType,
 )
-from datahub_client.parsers import extract_year_timestamp
 
 from ..urns import PlatformUrns
 from .base import GenericService
@@ -233,7 +232,7 @@ class PublicationCollectionDetailsService(GenericService):
             ),
             "publications": sorted(
                 self.entities_in_container,
-                key=lambda d: extract_year_timestamp(d.entity_ref.display_name),
+                key=lambda d: d.data_last_modified,
                 reverse=True,
             ),
             "h1_value": self.publication_collection_metadata.name,

--- a/tests/datahub_client/test_parsers.py
+++ b/tests/datahub_client/test_parsers.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import pytest
 
 from datahub_client.entities import (
@@ -36,7 +35,6 @@ from datahub_client.parsers import (
     PublicationCollectionParser,
     PublicationDatasetParser,
     TableParser,
-    extract_year_timestamp,
 )
 from datahub_client.search.search_types import SearchResult
 
@@ -866,51 +864,3 @@ class TestEntityParserFactory:
     ):
         parser = parser_factory.get_parser(entity_slug)
         assert isinstance(parser, expected_parser)
-
-
-def get_timestamp(year, month, day):
-    """Helper function to create timestamps for comparison"""
-    return int(datetime(year, month, day).timestamp())
-
-
-class TestTimestampParser:
-    @pytest.mark.parametrize("text, expected", [
-        # Working cases
-        (
-            "Ad-Hoc IIRMS Publication, March 2024",
-            get_timestamp(2024, 1, 1)
-        ),
-        (
-            "Changes to the Ministry of Justice Official Statistics Publication Schedule May 2013",
-            get_timestamp(2013, 1, 1)
-        ),
-        (
-            "Report from January 15, 2024 shows...",
-            get_timestamp(2024, 1, 1)
-        ),
-        (
-            "Data from 2024-02-14 indicates...",
-            get_timestamp(2024, 1, 1)
-        ),
-        # Failing cases
-        (
-            "No date information here",
-            -2208988800  # Jan 1, 1900 timestamp
-        ),
-        (
-            None,
-            -2208988800  # Jan 1, 1900 timestamp
-        ),
-        (
-            "",
-            -2208988800  # Jan 1, 1900 timestamp
-        ),
-    ])
-    def test_extract_year_timestamp(self, text, expected):
-        result = extract_year_timestamp(text)
-        assert result == expected, f"Failed for input: {text}"
-
-    def test_invalid_input(self):
-        # Test with invalid input type
-        result = extract_year_timestamp(123)
-        assert result == -2208988800, "Should return default timestamp for invalid input type"

--- a/tests/datahub_client/test_parsers.py
+++ b/tests/datahub_client/test_parsers.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import pytest
 
 from datahub_client.entities import (
@@ -35,6 +36,7 @@ from datahub_client.parsers import (
     PublicationCollectionParser,
     PublicationDatasetParser,
     TableParser,
+    extract_year_timestamp,
 )
 from datahub_client.search.search_types import SearchResult
 
@@ -864,3 +866,51 @@ class TestEntityParserFactory:
     ):
         parser = parser_factory.get_parser(entity_slug)
         assert isinstance(parser, expected_parser)
+
+
+def get_timestamp(year, month, day):
+    """Helper function to create timestamps for comparison"""
+    return int(datetime(year, month, day).timestamp())
+
+
+class TestTimestampParser:
+    @pytest.mark.parametrize("text, expected", [
+        # Working cases
+        (
+            "Ad-Hoc IIRMS Publication, March 2024",
+            get_timestamp(2024, 1, 1)
+        ),
+        (
+            "Changes to the Ministry of Justice Official Statistics Publication Schedule May 2013",
+            get_timestamp(2013, 1, 1)
+        ),
+        (
+            "Report from January 15, 2024 shows...",
+            get_timestamp(2024, 1, 1)
+        ),
+        (
+            "Data from 2024-02-14 indicates...",
+            get_timestamp(2024, 1, 1)
+        ),
+        # Failing cases
+        (
+            "No date information here",
+            -2208988800  # Jan 1, 1900 timestamp
+        ),
+        (
+            None,
+            -2208988800  # Jan 1, 1900 timestamp
+        ),
+        (
+            "",
+            -2208988800  # Jan 1, 1900 timestamp
+        ),
+    ])
+    def test_extract_year_timestamp(self, text, expected):
+        result = extract_year_timestamp(text)
+        assert result == expected, f"Failed for input: {text}"
+
+    def test_invalid_input(self):
+        # Test with invalid input type
+        result = extract_year_timestamp(123)
+        assert result == -2208988800, "Should return default timestamp for invalid input type"


### PR DESCRIPTION
The current ordering on publication collections is alphabetical, which leaves especially recent publications [hard to find](https://find-moj-data.service.justice.gov.uk/details/publication_collection/urn:li:container:3d166a9470de1d0243d0e18df13a720d)

We can sort by `data_last_modified` for a far better result