### PR TITLE
fix: restore color of sign out link

### DIFF
--- a/scss/base.scss
+++ b/scss/base.scss
@@ -87,12 +87,12 @@ code {
 }
 
 // Workaround for compiled markdown not following design system markup.
-ul {
+.markdown-container ul {
   @extend .govuk-list;
   @extend .govuk-list--bullet;
 }
 
-ol {
+.markdown-container ol {
   @extend .govuk-list;
   @extend .govuk-list--number;
 }

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -32,7 +32,7 @@
         {% block breadcrumbs %}
         {% endblock breadcrumbs %}
 
-        <main class="govuk-main-wrapper" id="main-content" role="main">
+        <main class="govuk-main-wrapper markdown-container" id="main-content" role="main">
           {% block content %}
           {% endblock content %}
         </main>


### PR DESCRIPTION
The color of the navigation links is set to inherit, which should mean white. However, if we blanket apply govuk list styles to all lists, this interferes with that and makes it black, visually hiding it.

We should make this opt-in via a class on a parent container. As a quick fix I've applied this to the main element, to catch all rendered markdown on the details and glossary pages.