### PR TITLE
Glossary improvements

### DIFF
--- a/datahub_client/client.py
+++ b/datahub_client/client.py
@@ -15,6 +15,7 @@ from datahub_client.entities import (
     DatabaseEntityMapping,
     EntitySummary,
     FindMoJdataEntityMapper,
+    GlossaryTermRef,
     PublicationCollection,
     PublicationDataset,
     RelationshipType,
@@ -27,6 +28,7 @@ from datahub_client.parsers import (
     ChartParser,
     DashboardParser,
     DatabaseParser,
+    GlossaryTermParser,
     PublicationCollectionParser,
     PublicationDatasetParser,
     TableParser,
@@ -105,6 +107,7 @@ class DataHubCatalogueClient:
         self.dataset_query = get_graphql_query("getDatasetDetails")
         self.chart_query = get_graphql_query("getChartDetails")
         self.dashboard_query = get_graphql_query("getDashboardDetails")
+        self.glossary_term_query = get_graphql_query("getGlossaryTermDetails")
 
     def check_entity_exists_by_urn(self, urn: str | None):
         if urn is not None:
@@ -221,6 +224,16 @@ class DataHubCatalogueClient:
             return dashboard_object
 
         raise EntityDoesNotExist(f"Dashboard with urn: {urn} does not exist")
+
+    def get_glossary_term_details(self, urn: str) -> GlossaryTermRef:
+        if self.check_entity_exists_by_urn(urn):
+            response = self.graph.execute_graphql(
+                self.glossary_term_query, {"urn": urn}
+            )
+            glossary_term = GlossaryTermParser().parse_to_entity_object(response, urn)
+            return glossary_term
+
+        raise EntityDoesNotExist(f"Glossary term with urn: {urn} does not exist")
 
     def _get_custom_property_key_value_pairs(
         self,

--- a/datahub_client/graphql/getChartDetails.graphql
+++ b/datahub_client/graphql/getChartDetails.graphql
@@ -41,6 +41,9 @@ query getChartDetails($urn: String!) {
     tags {
       ...globalTagsFields
     }
+    glossaryTerms {
+      ...glossaryTermFields
+    }
     ownership {
       ...ownershipFields
     }
@@ -100,6 +103,19 @@ fragment ownershipFields on Ownership {
       type
       info {
         name
+      }
+    }
+  }
+}
+
+fragment glossaryTermFields on GlossaryTerms {
+  terms {
+    term {
+      urn
+      type
+      properties {
+        name
+        description
       }
     }
   }

--- a/datahub_client/graphql/getDashboardDetails.graphql
+++ b/datahub_client/graphql/getDashboardDetails.graphql
@@ -13,6 +13,9 @@ query getDashboard($urn: String!) {
     tags {
       ...globalTagsFields
     }
+    glossaryTerms {
+      ...glossaryTermFields
+    }
     properties {
       name
       description
@@ -96,6 +99,19 @@ fragment ownershipFields on Ownership {
       type
       info {
         name
+      }
+    }
+  }
+}
+
+fragment glossaryTermFields on GlossaryTerms {
+  terms {
+    term {
+      urn
+      type
+      properties {
+        name
+        description
       }
     }
   }

--- a/datahub_client/graphql/getDatasetDetails.graphql
+++ b/datahub_client/graphql/getDatasetDetails.graphql
@@ -105,6 +105,9 @@ query getDatasetDetails($urn: String!) {
     tags {
       ...globalTagsFields
     }
+    glossaryTerms {
+      ...glossaryTermFields
+    }
     lastIngested
     schemaMetadata {
       fields {
@@ -183,6 +186,19 @@ fragment ownershipFields on Ownership {
       type
       info {
         name
+      }
+    }
+  }
+}
+
+fragment glossaryTermFields on GlossaryTerms {
+  terms {
+    term {
+      urn
+      type
+      properties {
+        name
+        description
       }
     }
   }

--- a/datahub_client/graphql/getGlossaryTermDetails.graphql
+++ b/datahub_client/graphql/getGlossaryTermDetails.graphql
@@ -1,0 +1,10 @@
+query getGlossaryTerm($urn: String!) {
+  glossaryTerm(urn: $urn) {
+    urn
+    name
+    properties {
+        name
+        description
+    }
+  }
+}

--- a/datahub_client/parsers.py
+++ b/datahub_client/parsers.py
@@ -890,8 +890,14 @@ class GlossaryTermParser(EntityParser):
         super().__init__()
         self.mapper = GlossaryTermEntityMapping
 
-    def parse_to_entity_object(self):
-        pass
+    def parse_to_entity_object(self, response, urn):
+        entity = response["glossaryTerm"]
+        properties, _ = self.parse_properties(entity)
+        name, display_name, qualified_name = self.parse_names(entity, properties)
+        description = self.parse_description(entity)
+        return GlossaryTermRef(
+            display_name=display_name, urn=urn, description=description
+        )
 
     def parse(self, entity) -> SearchResult:
         properties, _ = self.parse_properties(entity)

--- a/home/service/glossary.py
+++ b/home/service/glossary.py
@@ -121,7 +121,7 @@ class GlossaryTermService(GenericService):
     @property
     def context(self):
         return {
-            "h1_value": "Test",
+            "h1_value": f"{self.glossary_term.display_name} - Glossary term",
             "glossary_term": self.glossary_term,
             "malformed_result_urns": [],
             "results": self.results.page_results,

--- a/home/service/glossary.py
+++ b/home/service/glossary.py
@@ -1,9 +1,22 @@
 from itertools import groupby
 from sys import maxsize
 
+from django.core.paginator import Paginator
+
+from datahub_client.entities import (
+    ChartEntityMapping,
+    DashboardEntityMapping,
+    DatabaseEntityMapping,
+    PublicationCollectionEntityMapping,
+    PublicationDatasetEntityMapping,
+    TableEntityMapping,
+)
+from datahub_client.search.search_types import MultiSelectFilter, SearchResponse
+
 from .base import GenericService
 
 GLOSSARY_ORDERING = [
+    "Electronic monitoring",
     "Key concepts",
     "Technical terms",
     "Data governance terms",
@@ -59,3 +72,60 @@ class GlossaryService(GenericService):
         context = {"results": sorted_total_results, "h1_value": "Glossary"}
 
         return context
+
+
+class GlossaryTermService(GenericService):
+    def __init__(self, page, urn):
+        self.urn = urn
+        self.client = self._get_catalogue_client()
+        self.glossary_term = self.client.get_glossary_term_details(urn)
+        self.page = page
+        self.results = self._get_results(self.page)
+        self.paginator = Paginator(list(range(self.results.total_results)), 20)
+
+    def _get_results(self, page) -> SearchResponse:
+        """
+        Fetch entities linked to the glossary term
+        """
+        return self.client.search(
+            count=20,
+            page=str(int(page) - 1),
+            result_types=[
+                TableEntityMapping,
+                ChartEntityMapping,
+                DatabaseEntityMapping,
+                DashboardEntityMapping,
+                PublicationDatasetEntityMapping,
+                PublicationCollectionEntityMapping,
+            ],
+            filters=[MultiSelectFilter("glossaryTerms", [self.urn])],
+        )
+
+    @property
+    def context(self):
+        return {
+            "h1_value": "Test",
+            "glossary_term": self.glossary_term,
+            "malformed_result_urns": [],
+            "results": self.results.page_results,
+            "highlighted_results": self.results.page_results,
+            "page_obj": self.paginator.get_page(self.page),
+            "page_range": self.paginator.get_elided_page_range(  # type: ignore
+                self.page, on_each_side=2, on_ends=1
+            ),
+            "paginator": self.paginator,
+            "results_per_page": 20,
+            "total_results_str": str(self.results.total_results),
+            "total_results": self.results.total_results,
+            "readable_match_reasons": {
+                "id": "ID",
+                "urn": "URN",
+                "title": "Title",
+                "name": "Name",
+                "description": "Description",
+                "fieldPaths": "Column name",
+                "fieldDescriptions": "Column description",
+                "dc_where_to_access_dataset": "Available on",
+                "qualifiedName": "Qualified name",
+            },
+        }

--- a/home/service/glossary.py
+++ b/home/service/glossary.py
@@ -15,26 +15,33 @@ from datahub_client.search.search_types import MultiSelectFilter, SearchResponse
 
 from .base import GenericService
 
-GLOSSARY_ORDERING = [
-    "Electronic monitoring",
-    "Key concepts",
-    "Technical terms",
-    "Data governance terms",
-    "Data protection terms",
-    "Other technical terms",
-    "Data sources",
-]
+GLOSSARY_ORDERING = sorted(
+    [
+        "Data governance",
+        "Data protection",
+        "Data sources",
+        "Electronic monitoring v0.40",
+        "Other technical terms",
+    ]
+)
+
+GLOSSARIES_WITH_ENTITIES = {"Electronic monitoring v0.40"}
 
 
 class GlossaryService(GenericService):
     def __init__(self):
-        # Can we put the client instantiation in the base class?
         self.client = self._get_catalogue_client()
         self.context = self._get_context()
 
     def _get_context(self):
         """Returns a glossary context which is grouped by parent term"""
         glossary_search_results = self.client.get_glossary_terms()
+
+        def include_term(result):
+            parents = result.metadata.get("parentNodes", [])
+            if not parents:
+                return False
+            return parents[0]["properties"]["name"] in GLOSSARY_ORDERING
 
         def sorter(result):
             first_parent = result.metadata.get("parentNodes", [])
@@ -48,6 +55,11 @@ class GlossaryService(GenericService):
                     pass
             return parent_index, name
 
+        page_results_copy = [
+            i for i in glossary_search_results.page_results if include_term(i)
+        ]
+        page_results_copy.sort(key=sorter)
+
         def grouper(result):
             first_parent = result.metadata.get("parentNodes", [])
             if first_parent:
@@ -55,11 +67,16 @@ class GlossaryService(GenericService):
             if not first_parent:
                 return "Unsorted"
 
-        page_results_copy = sorted(glossary_search_results.page_results, key=sorter)
+        page_results_copy = sorted(page_results_copy, key=sorter)
         sorted_total_results = [
-            {"name": key, "members": list(group)}
+            {
+                "name": key,
+                "members": list(group),
+                "has_entities": key in GLOSSARIES_WITH_ENTITIES,
+            }
             for key, group in groupby(page_results_copy, key=grouper)
         ]
+
         # Adding the description in the list comprehension doesn't seem to work
         for parent_term in sorted_total_results:
             if parent_term["members"][0].metadata.get("parentNodes"):

--- a/home/templatetags/markdown.py
+++ b/home/templatetags/markdown.py
@@ -12,7 +12,7 @@ def markdown(value, heading_offset=0) -> SafeText:
     return mark_safe(
         markdown_func(
             value,
-            extensions=["fenced_code", "mdx_headdown"],
+            extensions=["fenced_code", "mdx_headdown", "sane_lists"],
             extension_configs={
                 "mdx_headdown": {"offset": heading_offset},
             },

--- a/home/templatetags/markdown.py
+++ b/home/templatetags/markdown.py
@@ -10,11 +10,17 @@ register = template.Library()
 @stringfilter
 def markdown(value, heading_offset=0) -> SafeText:
     return mark_safe(
-        markdown_func(
+        """
+        <div class="markdown-container">
+        """
+        + markdown_func(
             value,
             extensions=["fenced_code", "mdx_headdown", "sane_lists"],
             extension_configs={
                 "mdx_headdown": {"offset": heading_offset},
             },
         )
+        + """
+        </div>
+        """
     )

--- a/home/urls.py
+++ b/home/urls.py
@@ -8,6 +8,12 @@ urlpatterns = [
     path("", views.home_view, name="home"),
     path("search", views.search_view, name="search"),
     path("glossary", views.glossary_view, name="glossary"),
+    path("glossary/<str:urn>", views.glossary_term_view, name="glossary_term"),
+    path(
+        "glossary/<str:urn>/pagination/<str:page>",
+        views.glossary_term_view,
+        name="glossary_term_pagination",
+    ),
     path(
         "metadata_specification",
         views.metadata_specification_view,

--- a/home/views.py
+++ b/home/views.py
@@ -31,7 +31,7 @@ from home.service.details_csv import (
     DatabaseDetailsCsvFormatter,
     DatasetDetailsCsvFormatter,
 )
-from home.service.glossary import GlossaryService
+from home.service.glossary import GlossaryService, GlossaryTermService
 from home.service.metadata_specification import MetadataSpecificationService
 from home.service.search import SearchService
 from home.service.subject_area_fetcher import SubjectAreaFetcher
@@ -119,6 +119,11 @@ def search_view(request, page: str = "1"):
 def glossary_view(request):
     glossary_service = GlossaryService()
     return render(request, "glossary.html", glossary_service.context)
+
+
+def glossary_term_view(request, urn, page="1"):
+    service = GlossaryTermService(page, urn)
+    return render(request, "glossary_term.html", service.context)
 
 
 def metadata_specification_view(request):

--- a/scss/_details.scss
+++ b/scss/_details.scss
@@ -5,6 +5,10 @@
     overflow-wrap: break-word;
 }
 
+// Remove extra margin from markdown rendered paragraph
+// at the bottom of the card.
+.app-summary-card > p:last-child {margin-bottom: 0};
+
 .app-summary-card .app-summary-card__footer  {
     margin-bottom: 0;
 }

--- a/scss/_glossary.scss
+++ b/scss/_glossary.scss
@@ -1,7 +1,7 @@
 @include govuk-media-query($from: tablet) {
     #sticky-sidebar {
         position: sticky;
-        top: govuk-spacing(2);
+        top: govuk-spacing(4);
         max-height: 100vh;
         overflow-y: auto;
         margin-bottom: govuk-spacing(6);

--- a/static/assets/js/enhanced-glossary.js
+++ b/static/assets/js/enhanced-glossary.js
@@ -3,14 +3,26 @@ export const init = () => {
   jsRequired.style.display = "block";
 
   const input = document.getElementById("filter-input");
-  input.addEventListener("input", updateResults);
+  input.addEventListener("input", debounce(updateResults, 200));
+
+  document.querySelectorAll("[data-action='clear-filter']").forEach(el => {
+    el.addEventListener("click", clearFilter);
+    return true;
+  })
 };
+
+const clearFilter = () => {
+  const input = document.getElementById("filter-input");
+  input.value = "";
+  updateResults();
+}
 
 const updateResults = () => {
   const input = document.getElementById("filter-input");
   const filter = input.value.toUpperCase();
   const termElements = document.querySelectorAll(".term");
   const termGroups = document.querySelectorAll(".term-group");
+  const noResultsPanel = document.getElementById("no-results-panel")
 
   // Loop through all terms, and hide those who don't match the search query
   termElements.forEach((el) => {
@@ -25,6 +37,8 @@ const updateResults = () => {
     }
   });
 
+  let numberOfVisibleTermGroups = 0;
+
   // Loop through all term groups, and hide those without visible terms
   termGroups.forEach((el) => {
     const terms = Array.from(el.querySelectorAll(".term"));
@@ -36,6 +50,24 @@ const updateResults = () => {
       el.classList.add("govuk-!-display-none");
     } else {
       el.classList.remove("govuk-!-display-none");
+      numberOfVisibleTermGroups += 1;
     }
   });
+
+  if(numberOfVisibleTermGroups > 0) {
+    noResultsPanel.classList.add("govuk-!-display-none");
+  } else {
+    noResultsPanel.classList.remove("govuk-!-display-none");
+  }
 };
+
+const debounce = (callback, wait) => {
+  let timeoutId = null;
+
+  return (...args) => {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => {
+      callback(...args);
+    }, wait);
+  };
+}

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -32,7 +32,7 @@
         {% block breadcrumbs %}
         {% endblock breadcrumbs %}
 
-        <main class="govuk-main-wrapper markdown-container" id="main-content" role="main">
+        <main class="govuk-main-wrapper" id="main-content" role="main">
           {% block content %}
           {% endblock content %}
         </main>

--- a/templates/base/navigation.html
+++ b/templates/base/navigation.html
@@ -64,6 +64,11 @@
             </a>
           </li>
           <li class="moj-primary-navigation__item">
+            <a class="moj-primary-navigation__link" href="{% url 'home:glossary' %}" {% if request.path == glossary_url %}aria-current="page"{% endif %}>
+              Glossary
+            </a>
+          </li>
+          <li class="moj-primary-navigation__item">
             <a class="moj-primary-navigation__link" href="https://user-guide.find-moj-data.service.justice.gov.uk">
               User guide
             </a>

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -4,51 +4,58 @@
 
 {% block content %}
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-quarter">
+        <div class="govuk-grid-column-full">
             <h1 class="govuk-heading-l">{{h1_value}}</h1>
-        </div>
-        <div class="govuk-grid-column-three-quarters">
-            <div role="search" class="app-search govuk-form-group govuk-!-margin-bottom-8 js-required">
-                <label for="filter-input" class="govuk-label govuk-visually-hidden-focusable">Filter this page (the content will be updated as you type)</label>
-                <input class="govuk-input" id="filter-input" type="search" placeholder="Filter this page">
-            </div>
         </div>
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter" id="sticky-sidebar">
-            <a href="#glossary-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to glossary content</a>
+            <h2 class="govuk-heading-s govuk-!-margin-bottom-3">On this page</h2>
             <ul class="govuk-list">
                 {% for parent_term in results %}
-                    <li class="term-group">
-                        <div><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="#{{ parent_term }}">
-                            <strong>{{ parent_term.name }}</strong>
+                    <li class="govuk-!-margin-bottom-3">
+                        <div><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" data-action="clear-filter" href="#{{ parent_term.name }}">
+                            {{ parent_term.name }}
                         </a></div>
-                        {% for member in parent_term.members %}
-                            <div data-term="{{member.name|upper}}" class="term"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="#{{ member.name }}">
-                                {{ member.name }}
-                            </a></div>
-                        {%endfor%}
-                        <br>
                     </li>
                 {%endfor%}
             </ul>
+            <div class="govuk-body govuk-!-margin-top-8 govuk-!-margin-bottom-4"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="#top">Back to top</a></div>
         </div>
-        <div class="govuk-grid-column-three-quarters govuk-!-padding-left-4" id="glossary-content">
-            {% for parent_term in results %}
+        <div class="govuk-grid-column-three-quarters">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Search</h2>
+            <div role="search" class="app-search govuk-form-group govuk-!-margin-bottom-6 js-required">
+                <label for="filter-input" class="govuk-label govuk-visually-hidden-focusable">Search this page (the content will be updated as you type)</label>
+                <input class="govuk-input" id="filter-input" type="search">
+            </div>
+            <div class="govuk-!-display-none" id="no-results-panel">
+                <h2 class="govuk-heading-m">No terms found</h2>
+                <p class="govuk-body">There are no terms in the glossary matching your search query.</p>
+            </div>
+            <div id="glossary-content">
+                {% for parent_term in results %}
                 <div class="term-group">
-                    <h2 class="govuk-heading-l" id="{{ parent_term }}">{{ parent_term.name }}</h2>
-                    <p class="govuk-body-l">{{ parent_term.description }}</p>
+                    <h2 class="govuk-heading-m" id="{{ parent_term.name }}">{{ parent_term.name }}</h2>
+                    <div class="govuk-body">{{ parent_term.description }}</div>
                     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
                     {% for member in parent_term.members %}
-                        <div data-term="{{member.name|upper}}" class="term">
-                            <h3 class="govuk-heading-m" id="{{ member.name }}">{{ member.name }}</h3>
-                            <p class="govuk-body">{{ member.description|markdown:3 }}</p>
+                        <div data-term="{{member.name|upper}}" class="term govuk-!-margin-bottom-5">
+                            <h3 class="govuk-heading-s govuk-!-margin-bottom-3" id="{{ member.name }}">
+                                {% if parent_term.has_entities %}
+                                    <a href="{% url 'home:glossary_term' urn=member.urn %}">{{ member.name }}</a>
+                                {% else %}
+                                    {{ member.name }}
+                                {% endif %}
+                            </h3>
+                            <div class="govuk-body">{{ member.description|markdown:3 }}</div>
                         </div>
                     {%endfor%}
                     <br>
                 </div>
-            {%endfor%}
+                {%endfor%}
+            </div>
+            <div class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="#top">Back to top</a>
         </div>
     </div>
 

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -14,7 +14,7 @@
             <ul class="govuk-list">
                 {% for parent_term in results %}
                     <li class="govuk-!-margin-bottom-3">
-                        <div><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" data-action="clear-filter" href="#{{ parent_term.name }}">
+                        <div><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline glossary-nav-link" data-name="{{parent_term.name}}" data-action="clear-filter" href="#{{ parent_term.name }}">
                             {{ parent_term.name }}
                         </a></div>
                     </li>
@@ -34,7 +34,7 @@
             </div>
             <div id="glossary-content">
                 {% for parent_term in results %}
-                <div class="term-group">
+                <div class="term-group" data-name="{{ parent_term.name }}">
                     <h2 class="govuk-heading-m" id="{{ parent_term.name }}">{{ parent_term.name }}</h2>
                     <div class="govuk-body">{{ parent_term.description }}</div>
                     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -33,7 +33,7 @@
                 {%endfor%}
             </ul>
         </div>
-        <div class="govuk-grid-column-three-quarters" id="glossary-content">
+        <div class="govuk-grid-column-three-quarters govuk-!-padding-left-4" id="glossary-content">
             {% for parent_term in results %}
                 <div class="term-group">
                     <h2 class="govuk-heading-l" id="{{ parent_term }}">{{ parent_term.name }}</h2>

--- a/templates/glossary_term.html
+++ b/templates/glossary_term.html
@@ -1,0 +1,51 @@
+{% extends "base/base.html" %}
+{% load static %}
+{% load markdown %}
+{% load humanize %}
+{% load waffle_tags %}
+{% load govuk %}
+
+{% block breadcrumbs %}
+  <div class="govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{%url 'home:glossary' %}">Glossary</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{request.path}}">{{glossary_term.display_name}}</a>
+      </li>
+    </ol>
+  </div>
+{% endblock breadcrumbs %}
+
+{% block content %}
+<div class="govuk-grid-row app-header-negative-padding">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-l">Glossary term</span>
+    <h1 class="govuk-heading-l">{{glossary_term.display_name}}</h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="app-summary-card">
+      <h2 class="govuk-heading-s">
+        Description
+      </h2>
+      {{glossary_term.description | markdown}}
+    </div>
+  </div>
+</div>
+
+{% if results %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m govuk-!-display-inline-block" id="result-count">Related entit{{total_results|pluralize:"y,ies"}} ({{total_results_str|intcomma}})</h2>
+
+    {% include "partial/search_result.html" %}
+
+    {% pagination page_obj=page_obj urlpattern='home:glossary_term_pagination' urn=glossary_term.urn %}
+  </div>
+</div>
+{% endif %}
+{% endblock content %}

--- a/templates/partial/details_metadata.html
+++ b/templates/partial/details_metadata.html
@@ -92,4 +92,17 @@
   </div>
   {% endif %}
   {% endswitch %}
+
+  {% if entity.glossary_terms %}
+  <div class="app-metadata-list__row">
+    <dt class="app-metadata-list__key">
+      Glossary terms
+    </dt>
+    <dd class="app-metadata-list__value">
+      {% for term in entity.glossary_terms %}
+      <a aria-label="definition for glossary term {{ term }}" href="{% url 'home:glossary_term' urn=term.urn %}">{{ term.display_name }}</a>{% if not forloop.last %}, {% endif %}
+      {% endfor %}
+    </dd>
+  </div>
+  {% endif %}
 </dl>

--- a/templates/partial/search_result_metadata.html
+++ b/templates/partial/search_result_metadata.html
@@ -38,6 +38,7 @@
   {% endif %}
 
   {% switch 'display-result-tags' %}
+  {% if result.tags.to_display %}
   <div class="app-metadata-list__row">
     <dt class="app-metadata-list__key">
       Tags
@@ -48,7 +49,21 @@
       {% endfor %}
     </dd>
   </div>
+  {% endif %}
   {% endswitch %}
+
+  {% if result.glossary_terms %}
+  <div class="app-metadata-list__row">
+    <dt class="app-metadata-list__key">
+      Glossary terms
+    </dt>
+    <dd class="app-metadata-list__value">
+      {% for term in result.glossary_terms %}
+      <a aria-label="definition for glossary term {{ term }}" href="{% url 'home:glossary_term' urn=term.urn %}">{{ term.display_name }}</a>{% if not forloop.last %}, {% endif %}
+      {% endfor %}
+    </dd>
+  </div>
+  {% endif %}
 
   {% with match_reasons=result.matches|lookup:readable_match_reasons|join:", " %}
   {% if match_reasons %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -867,14 +867,14 @@ def mock_get_glossary_terms_response(mock_catalogue):
         page_results=[
             SearchResult(
                 urn="urn:li:glossaryTerm:022b9b68-c211-47ae-aef0-2db13acfeca8",
-                name="IAO",
-                description="Information asset owner.\n",
+                name="NOMIS",
+                description="NOMIS",
                 metadata={
                     "parentNodes": [
                         {
                             "properties": {
-                                "name": "Data protection terms",
-                                "description": "Data protection terms",
+                                "name": "Data sources",
+                                "description": "Data sources",
                             }
                         }
                     ]
@@ -883,14 +883,14 @@ def mock_get_glossary_terms_response(mock_catalogue):
             ),
             SearchResult(
                 urn="urn:li:glossaryTerm:022b9b68-c211-47ae-aef0-2db13acfeca8",
-                name="Other term",
-                description="Term description to test groupings work",
+                name="XHIBIT",
+                description="XHIBIT",
                 metadata={
                     "parentNodes": [
                         {
                             "properties": {
-                                "name": "Data protection terms",
-                                "description": "Data protection terms",
+                                "name": "Data sources",
+                                "description": "Data sources",
                             }
                         }
                     ]
@@ -899,9 +899,18 @@ def mock_get_glossary_terms_response(mock_catalogue):
             ),
             SearchResult(
                 urn="urn:li:glossaryTerm:0eb7af28-62b4-4149-a6fa-72a8f1fea1e6",
-                name="Security classification",
-                description="Only data that is 'official'",
-                metadata={"parentNodes": []},
+                name="Asset",
+                description="Asset",
+                metadata={
+                    "parentNodes": [
+                        {
+                            "properties": {
+                                "name": "Other technical terms",
+                                "description": "Other technical terms",
+                            }
+                        }
+                    ]
+                },
                 result_type=GlossaryTermEntityMapping,
             ),
         ],

--- a/tests/home/service/test_glossary.py
+++ b/tests/home/service/test_glossary.py
@@ -10,20 +10,20 @@ class TestGlossaryService:
             "h1_value": "Glossary",
             "results": [
                 {
-                    "name": "Data protection terms",
+                    "name": "Data sources",
                     "members": [
                         SearchResult(
                             urn="urn:li:glossaryTerm:022b9b68-c211-47ae-aef0-2db13acfeca8",
                             result_type=GlossaryTermEntityMapping,
-                            name="IAO",
-                            description="Information asset owner.\n",
+                            name="NOMIS",
+                            description="NOMIS",
                             matches={},
                             metadata={
                                 "parentNodes": [
                                     {
                                         "properties": {
-                                            "name": "Data protection terms",
-                                            "description": "Data protection terms",
+                                            "name": "Data sources",
+                                            "description": "Data sources",
                                         }
                                     }
                                 ]
@@ -34,15 +34,15 @@ class TestGlossaryService:
                         SearchResult(
                             urn="urn:li:glossaryTerm:022b9b68-c211-47ae-aef0-2db13acfeca8",
                             result_type=GlossaryTermEntityMapping,
-                            name="Other term",
-                            description="Term description to test groupings work",
+                            name="XHIBIT",
+                            description="XHIBIT",
                             matches={},
                             metadata={
                                 "parentNodes": [
                                     {
                                         "properties": {
-                                            "name": "Data protection terms",
-                                            "description": "Data protection terms",
+                                            "name": "Data sources",
+                                            "description": "Data sources",
                                         }
                                     }
                                 ]
@@ -51,25 +51,36 @@ class TestGlossaryService:
                             last_modified=None,
                         ),
                     ],
-                    "description": "Data protection terms",
+                    "description": "Data sources",
+                    "has_entities": False,
                 },
                 {
-                    "name": "Unsorted",
+                    "name": "Other technical terms",
                     "members": [
                         SearchResult(
                             urn="urn:li:glossaryTerm:0eb7af28-62b4-4149-a6fa-72a8f1fea1e6",
                             result_type=GlossaryTermEntityMapping,
-                            name="Security classification",
-                            description="Only data that is 'official'",
+                            name="Asset",
+                            description="Asset",
                             matches={},
-                            metadata={"parentNodes": []},
+                            metadata={
+                                "parentNodes": [
+                                    {
+                                        "properties": {
+                                            "description": "Other technical terms",
+                                            "name": "Other technical terms",
+                                        },
+                                    },
+                                ],
+                            },
                             tags=[],
                             last_modified=None,
                         )
                     ],
-                    "description": "",
+                    "description": "Other technical terms",
+                    "has_entities": False,
                 },
             ],
         }
 
-        assert expected_context == glossary_context.context
+        assert glossary_context.context == expected_context

--- a/tests/javascript/test_enhanced_glossary.js
+++ b/tests/javascript/test_enhanced_glossary.js
@@ -1,5 +1,5 @@
-import { init } from "enhanced-glossary";
-import { expect, test, jest } from "@jest/globals";
+import { init, calculateCurrentTermGroup } from "enhanced-glossary";
+import { expect, test, jest, beforeEach } from "@jest/globals";
 
 jest.useFakeTimers();
 
@@ -34,47 +34,91 @@ let banana;
 let things;
 let noResultsPanel;
 
-beforeEach(() => {
-  document.body.innerHTML = simplifiedPage;
+describe("filtering the glossary", () => {
+  beforeEach(() => {
+    document.body.innerHTML = simplifiedPage;
 
-  filter = document.getElementById("filter-input");
-  apple = document.getElementById("apple");
-  banana = document.getElementById("banana");
-  things = document.getElementById("things");
-  noResultsPanel = document.getElementById("no-results-panel");
+    filter = document.getElementById("filter-input");
+    apple = document.getElementById("apple");
+    banana = document.getElementById("banana");
+    things = document.getElementById("things");
+    noResultsPanel = document.getElementById("no-results-panel");
 
-  init();
+    init();
+  });
+
+  test("everything is shown when the filter is empty", () => {
+    filter.value = "";
+    filter.dispatchEvent(new Event("input"));
+    jest.runAllTimers();
+
+    expect(things).not.toHaveClass("govuk-!-display-none");
+    expect(apple).not.toHaveClass("govuk-!-display-none");
+    expect(banana).not.toHaveClass("govuk-!-display-none");
+    expect(noResultsPanel).toHaveClass("govuk-!-display-none");
+  });
+
+  test("filtering to a term by its prefix", () => {
+    filter.value = "ap";
+    filter.dispatchEvent(new Event("input"));
+    jest.runAllTimers();
+
+    expect(things).not.toHaveClass("govuk-!-display-none");
+    expect(apple).not.toHaveClass("govuk-!-display-none");
+    expect(banana).toHaveClass("govuk-!-display-none");
+    expect(noResultsPanel).toHaveClass("govuk-!-display-none");
+  });
+
+  test("filtering out all terms within a group", () => {
+    filter.value = "carrot";
+    filter.dispatchEvent(new Event("input"));
+    jest.runAllTimers();
+
+    expect(things).toHaveClass("govuk-!-display-none");
+    expect(apple).toHaveClass("govuk-!-display-none");
+    expect(banana).toHaveClass("govuk-!-display-none");
+    expect(noResultsPanel).not.toHaveClass("govuk-!-display-none");
+  });
 });
 
-test("everything is shown when the filter is empty", () => {
-  filter.value = "";
-  filter.dispatchEvent(new Event("input"));
-  jest.runAllTimers();
+describe('navigation highlights', () => {
+  test("when nothing is visible, no section is highlighted", () => {
+    const result = calculateCurrentTermGroup({
+      window: {innerHeight: 300, scrollY: 0},
+      documentHeight: 1000,
+      visibleTermGroups: []
+    });
 
-  expect(things).not.toHaveClass("govuk-!-display-none");
-  expect(apple).not.toHaveClass("govuk-!-display-none");
-  expect(banana).not.toHaveClass("govuk-!-display-none");
-  expect(noResultsPanel).toHaveClass("govuk-!-display-none");
-});
+    expect(result).toEqual(null);
+  });
 
-test("filtering to a term by its prefix", () => {
-  filter.value = "ap";
-  filter.dispatchEvent(new Event("input"));
-  jest.runAllTimers();
+  test("at the top of the page, the first section is highlighted", () => {
+    const result = calculateCurrentTermGroup({
+      window: {innerHeight: 300, scrollY: 0},
+      documentHeight: 1000,
+      visibleTermGroups: [{top: 100, bottom: 200, name: "a"}, {top: 200, bottom: 300, name: "b"}, {top: 300, bottom: 400, name: "c"}]
+    });
 
-  expect(things).not.toHaveClass("govuk-!-display-none");
-  expect(apple).not.toHaveClass("govuk-!-display-none");
-  expect(banana).toHaveClass("govuk-!-display-none");
-  expect(noResultsPanel).toHaveClass("govuk-!-display-none");
-});
+    expect(result).toEqual({top: 100, bottom: 200, name: "a"});
+  });
 
-test("filtering out all terms within a group", () => {
-  filter.value = "carrot";
-  filter.dispatchEvent(new Event("input"));
-  jest.runAllTimers();
+  test("when you scroll to a new section, it is highlighted", () => {
+    const result = calculateCurrentTermGroup({
+      window: {innerHeight: 300, scrollY: 150},
+      documentHeight: 1000,
+      visibleTermGroups: [{top: -150, bottom: -50, name: "a"}, {top: 50, bottom: 150, name: "b"}, {top: 250, bottom: 350, name: "c"}]
+    });
 
-  expect(things).toHaveClass("govuk-!-display-none");
-  expect(apple).toHaveClass("govuk-!-display-none");
-  expect(banana).toHaveClass("govuk-!-display-none");
-  expect(noResultsPanel).not.toHaveClass("govuk-!-display-none");
-});
+    expect(result).toEqual({top: 50, bottom: 150, name: "b"});
+  });
+
+  test("at the bottom of the page, the last section is highlighted", () => {
+    const result = calculateCurrentTermGroup({
+      window: {innerHeight: 300, scrollY: 700},
+      documentHeight: 1000,
+      visibleTermGroups: [{top: -700, bottom: -600, name: "a"}, {top: -600, bottom: -500, name: "b"}, {top: -400, bottom: -300, name: "c"}]
+    });
+
+    expect(result).toEqual({top: -400, bottom: -300, name: "c"});
+  });
+})

--- a/tests/javascript/test_enhanced_glossary.js
+++ b/tests/javascript/test_enhanced_glossary.js
@@ -1,9 +1,15 @@
 import { init } from "enhanced-glossary";
-import { expect, test } from "@jest/globals";
+import { expect, test, jest } from "@jest/globals";
+
+jest.useFakeTimers();
 
 const simplifiedPage = `
 <div class="js-required">
 <input type="search" class="govuk-input" id="filter-input" placeholder="Filter this page">
+<div class="govuk-!-display-none" id="no-results-panel">
+    <h2 class="govuk-heading-m">No terms found</h2>
+    <p class="govuk-body">There are no terms in the glossary matching your search query.</p>
+</div>
 <div id="things" class="term-group">
   <h2>Things</h2>
   <p>Bla bla bla</p>
@@ -26,6 +32,7 @@ let filter;
 let apple;
 let banana;
 let things;
+let noResultsPanel;
 
 beforeEach(() => {
   document.body.innerHTML = simplifiedPage;
@@ -34,6 +41,7 @@ beforeEach(() => {
   apple = document.getElementById("apple");
   banana = document.getElementById("banana");
   things = document.getElementById("things");
+  noResultsPanel = document.getElementById("no-results-panel");
 
   init();
 });
@@ -41,26 +49,32 @@ beforeEach(() => {
 test("everything is shown when the filter is empty", () => {
   filter.value = "";
   filter.dispatchEvent(new Event("input"));
+  jest.runAllTimers();
 
   expect(things).not.toHaveClass("govuk-!-display-none");
   expect(apple).not.toHaveClass("govuk-!-display-none");
   expect(banana).not.toHaveClass("govuk-!-display-none");
+  expect(noResultsPanel).toHaveClass("govuk-!-display-none");
 });
 
 test("filtering to a term by its prefix", () => {
   filter.value = "ap";
   filter.dispatchEvent(new Event("input"));
+  jest.runAllTimers();
 
   expect(things).not.toHaveClass("govuk-!-display-none");
   expect(apple).not.toHaveClass("govuk-!-display-none");
   expect(banana).toHaveClass("govuk-!-display-none");
+  expect(noResultsPanel).toHaveClass("govuk-!-display-none");
 });
 
 test("filtering out all terms within a group", () => {
   filter.value = "carrot";
   filter.dispatchEvent(new Event("input"));
+  jest.runAllTimers();
 
   expect(things).toHaveClass("govuk-!-display-none");
   expect(apple).toHaveClass("govuk-!-display-none");
   expect(banana).toHaveClass("govuk-!-display-none");
+  expect(noResultsPanel).not.toHaveClass("govuk-!-display-none");
 });

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -122,6 +122,10 @@ class TestChartView:
 
 
 class TestGlossaryView:
-    def test_details(self, client):
+    def test_list(self, client):
         response = client.get(reverse("home:glossary"))
+        assert response.status_code == 200
+
+    def test_details(self, client):
+        response = client.get(reverse("home:glossary_term", kwargs={"urn": "fake"}))
         assert response.status_code == 200


### PR DESCRIPTION
Issue: [#1405](https://github.com/ministryofjustice/find-moj-data/issues/1405)
Figma: https://www.figma.com/design/zTOVhHRnWfxRJqH6Gr8cIc/branch/JpBZI7XvBs8H7damHvKkVG/Find-MoJ-data?node-id=1258-1539&p=f&t=fyicHkvijcZ6TsEi-0

This PR reenables the glossary and adds a details page for glossary terms. This is part of merging the user guide with the app.

I've hidden all glossaries except the Electronic monitoring one and those that are currently part of the user guide (which will need to be migrated after this is merged).

<img width="1185" alt="Screenshot 2025-02-26 at 16 17 11" src="https://github.com/user-attachments/assets/224f7b91-6940-4d2f-8521-981a1c81a4f7" />

The electronic monitoring ones are clickable and take you to the glossary term page, which shows related entities.

Search results also show the glossary terms.

<img width="659" alt="Screenshot 2025-02-26 at 16 24 41" src="https://github.com/user-attachments/assets/84360c66-fad1-4e4b-9dff-bd4998c1f4df" />

The sticky sidebar is still there, but we have stopped listing individual terms, and there is a back to top link.

<img width="1165" alt="Screenshot 2025-02-26 at 16 17 25" src="https://github.com/user-attachments/assets/151cbd63-9d54-413f-bf5b-b23b84993bb1" />

Since the glossary is all on one page, I've had to add some javascript to highlight in bold the glossary term group currently in view. This gets updated whenever any of the following happen:
1. Clicking on a link
2. Scrolling
3. Resizing the page
4. Filtering and clearing the filter