### PR TITLE
feat: Rearrange call to action for tables

### DIFF
--- a/datahub_client/parsers.py
+++ b/datahub_client/parsers.py
@@ -185,7 +185,8 @@ class EntityParser:
 
         properties.pop("customProperties", None)
         # Some urls come in with a trailing newline
-        properties["dc_access_requirements"] = properties.get("dc_access_requirements", "").rstrip()
+        if properties.get("dc_access_requirements"):
+            properties["dc_access_requirements"] = properties.get("dc_access_requirements", "").rstrip()
         access_information = AccessInformation.model_validate(custom_properties_dict)
         usage_restrictions = UsageRestrictions.model_validate(custom_properties_dict)
         data_summary = DataSummary.model_validate(custom_properties_dict)

--- a/datahub_client/parsers.py
+++ b/datahub_client/parsers.py
@@ -184,6 +184,8 @@ class EntityParser:
             )
 
         properties.pop("customProperties", None)
+        # Some urls come in with a trailing newline
+        properties["dc_access_requirements"] = properties.get("dc_access_requirements", "").rstrip()
         access_information = AccessInformation.model_validate(custom_properties_dict)
         usage_restrictions = UsageRestrictions.model_validate(custom_properties_dict)
         data_summary = DataSummary.model_validate(custom_properties_dict)

--- a/datahub_client/parsers.py
+++ b/datahub_client/parsers.py
@@ -185,8 +185,8 @@ class EntityParser:
 
         properties.pop("customProperties", None)
         # Some urls come in with a trailing newline
-        if properties.get("dc_access_requirements"):
-            properties["dc_access_requirements"] = properties.get("dc_access_requirements", "").rstrip()
+        if custom_properties_dict.get("dc_access_requirements"):
+            custom_properties_dict["dc_access_requirements"] = custom_properties_dict.get("dc_access_requirements", "").rstrip()
         access_information = AccessInformation.model_validate(custom_properties_dict)
         usage_restrictions = UsageRestrictions.model_validate(custom_properties_dict)
         data_summary = DataSummary.model_validate(custom_properties_dict)

--- a/datahub_client/parsers.py
+++ b/datahub_client/parsers.py
@@ -462,7 +462,7 @@ class EntityParser:
                         description=description,
                         entity_type=entity_type,
                         tags=tags,
-                        data_last_modified=self.parse_data_last_modified(properties),
+                        data_last_modified=self.parse_data_last_modified(properties) if properties else None,
                     )
                 )
 

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -79,7 +79,7 @@
       </div>
     </div>
     <div class="govuk-grid-column-one-third">
-      {% include "partial/contact_info.html" with entity_name=entity.name governance=entity.governance further_information=entity.custom_properties.further_information access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_url=is_access_requirements_a_url platform=entity.platform security_classification=entity.custom_properties.security_classification %}
+      {% include "partial/contact_info.html" with entity_name=entity.name governance=entity.governance further_information=entity.custom_properties.further_information platform=entity.platform %}
     </div>
   </div>
 

--- a/templates/details_database.html
+++ b/templates/details_database.html
@@ -4,6 +4,7 @@
 {% block extra_details %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      {% comment %} All databases should be accessible via the AP {% endcomment %}
       {% if entity.custom_properties.security_classification == "Official-Sensitive" %}
         {% include "partial/access_ap_data.html" with access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_requirements_a_url=is_access_requirements_a_url entity_name=entity.name %}
       {% endif %}

--- a/templates/details_database.html
+++ b/templates/details_database.html
@@ -4,6 +4,9 @@
 {% block extra_details %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      {% if entity.custom_properties.security_classification == "Official-Sensitive" %}
+        {% include "partial/access_ap_data.html" with access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_requirements_a_url=is_access_requirements_a_url entity_name=entity.name %}
+      {% endif %}
       {% if tables %}
       <div class="govuk-heading-m">Database content</div>
         {% include "partial/download_button.html" with entity_type='database' title="table descriptions" %}

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -5,25 +5,8 @@
 {% block extra_details %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {% if entity.custom_properties.security_classification == "Official-Sensitive"%}
-      <div class="govuk-body govuk-!-padding-top-7 govuk-!-padding-bottom-7">
-        <h2 class="govuk-heading-m">Access this data</h2>
-        <p id="request_access" class="govuk-body"></p>
-          {% if entity.custom_properties.access_information.dc_access_requirements %}
-        {% if is_access_requirements_a_url %}
-          <a onclick="gtag('event', 'click_access_link', {'entity_name': '{{ entity.name }}'})" href="{{ entity.custom_properties.access_information.dc_access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Learn how to access this data in the Analytical Platform (opens in new tab)</a>
-        {% else %}
-          {{ entity.custom_properties.access_information.dc_access_requirements }}
-        {% endif %}
-        {% comment %}
-        {% elif entity.governance.data_custodians or entity.governance.data_owner.email %}
-        Contact the data custodian to request access.
-        {% endcomment %}
-          {% else %}
-        Not provided.
-          {% endif %}
-        </p>
-      </div>
+      {% if entity.custom_properties.security_classification == "Official-Sensitive" %}
+        {% include "partial/access_ap_data.html" with access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_requirements_a_url=is_access_requirements_a_url entity_name=entity.name %}
       {% endif %}
       {% if entity.column_details %}
         <div class="govuk-heading-m">Table schema</div>

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -5,6 +5,7 @@
 {% block extra_details %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      {% comment %} All tables should be accessible via the AP {% endcomment %}
       {% if entity.custom_properties.security_classification == "Official-Sensitive" %}
         {% include "partial/access_ap_data.html" with access_requirements=entity.custom_properties.access_information.dc_access_requirements is_access_requirements_a_url=is_access_requirements_a_url entity_name=entity.name %}
       {% endif %}

--- a/templates/details_table.html
+++ b/templates/details_table.html
@@ -5,6 +5,26 @@
 {% block extra_details %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      {% if entity.custom_properties.security_classification == "Official-Sensitive"%}
+      <div class="govuk-body govuk-!-padding-top-7 govuk-!-padding-bottom-7">
+        <h2 class="govuk-heading-m">Access this data</h2>
+        <p id="request_access" class="govuk-body"></p>
+          {% if entity.custom_properties.access_information.dc_access_requirements %}
+        {% if is_access_requirements_a_url %}
+          <a onclick="gtag('event', 'click_access_link', {'entity_name': '{{ entity.name }}'})" href="{{ entity.custom_properties.access_information.dc_access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Learn how to access this data in the Analytical Platform (opens in new tab)</a>
+        {% else %}
+          {{ entity.custom_properties.access_information.dc_access_requirements }}
+        {% endif %}
+        {% comment %}
+        {% elif entity.governance.data_custodians or entity.governance.data_owner.email %}
+        Contact the data custodian to request access.
+        {% endcomment %}
+          {% else %}
+        Not provided.
+          {% endif %}
+        </p>
+      </div>
+      {% endif %}
       {% if entity.column_details %}
         <div class="govuk-heading-m">Table schema</div>
         {% include "partial/download_button.html" with entity_type='database' title="table descriptions" %}
@@ -50,7 +70,7 @@
         <h2 class="govuk-heading-m">Lineage</h2>
         <div class="govuk-body-m" >
           See where this data came from and how it is used in other tables.
-        </div class="govuk-body-m">
+        </div>
         <div class="govuk-body">
           <a href="{{lineage_url}}" class="govuk-link" rel="noreferrer noopener" target="_blank">
             View lineage in DataHub (opens in new tab)

--- a/templates/partial/access_ap_data.html
+++ b/templates/partial/access_ap_data.html
@@ -1,0 +1,14 @@
+<div class="govuk-!-padding-top-7 govuk-!-padding-bottom-7">
+    <h2 class="govuk-heading-m">Access this data</h2>
+    <p id="request_access" class="govuk-body"></p>
+      {% if access_requirements and is_access_requirements_a_url %}
+        <a onclick="gtag('event', 'click_access_link', {'entity_name': '{{ entity_name }}'})" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Learn how to access this data in the Analytical Platform (opens in new tab)</a>
+        {% comment %}
+        {% elif entity.governance.data_custodians or entity.governance.data_owner.email %}
+        Contact the data custodian to request access.
+        {% endcomment %}
+      {% else %}
+        <a onclick="gtag('event', 'click_access_link', {'entity_name': '{{ entity_name }}'})" href="https://user-guidance.analytical-platform.service.justice.gov.uk/tools/create-a-derived-table/database-access/#database-access" class="govuk-link" rel="noreferrer noopener" target="_blank">Learn how to access this data in the Analytical Platform (opens in new tab)</a>
+      {% endif %}
+    </p>
+  </div>

--- a/templates/partial/access_ap_data.html
+++ b/templates/partial/access_ap_data.html
@@ -1,8 +1,12 @@
 <div class="govuk-!-padding-top-7 govuk-!-padding-bottom-7">
     <h2 class="govuk-heading-m">Access this data</h2>
     <p id="request_access" class="govuk-body">
-      {% if access_requirements and is_access_requirements_a_url %}
+      {% if access_requirements %}
+        {% if is_access_requirements_a_url %}
         <a onclick="gtag('event', 'click_access_link', {'entity_name': '{{ entity_name }}'})" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Learn how to access this data in the Analytical Platform (opens in new tab)</a>
+        {% else %}
+            {{ access_requirements }}
+        {% endif %}
         {% comment %}
         {% elif entity.governance.data_custodians or entity.governance.data_owner.email %}
         Contact the data custodian to request access.

--- a/templates/partial/access_ap_data.html
+++ b/templates/partial/access_ap_data.html
@@ -1,6 +1,6 @@
 <div class="govuk-!-padding-top-7 govuk-!-padding-bottom-7">
     <h2 class="govuk-heading-m">Access this data</h2>
-    <p id="request_access" class="govuk-body"></p>
+    <p id="request_access" class="govuk-body">
       {% if access_requirements and is_access_requirements_a_url %}
         <a onclick="gtag('event', 'click_access_link', {'entity_name': '{{ entity_name }}'})" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Learn how to access this data in the Analytical Platform (opens in new tab)</a>
         {% comment %}

--- a/templates/partial/contact_info.html
+++ b/templates/partial/contact_info.html
@@ -1,26 +1,4 @@
 <div class="govuk-body">
-  {% if security_classification == "Official-Sensitive"%}
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Request access</h2>
-    <p id="request_access" class="govuk-body">
-
-      {% if access_requirements %}
-        {% if is_access_url %}
-          <a onclick="gtag('event', 'click_access_link', {'entity_name': '{{ entity_name }}'})" href="{{ access_requirements }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Select this link for access information (opens in new tab)</a>
-        {% else %}
-          {{ access_requirements }}
-        {% endif %}
-        {% comment %}
-         {% elif governance.data_custodians or governance.data_owner.email %}
-         Contact the data custodian to request access.
-        {% endcomment %}
-      {% else %}
-        Not provided.
-      {% endif %}
-    </p>
-  {% endif %}
-</div>
-
-<div class="govuk-body">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Ask a question</h2>
   <ul id="contact_channels" class="govuk-list">
     {% if further_information.dc_slack_channel_url and further_information.dc_slack_channel_name %}

--- a/tests/integration/test_details_contact_contents.py
+++ b/tests/integration/test_details_contact_contents.py
@@ -75,6 +75,7 @@ class TestDetailsPageContactDetails:
         database.custom_properties.access_information = AccessInformation(
             dc_access_requirements=access_reqs
         )
+        database.custom_properties.security_classification = "Official-Sensitive"
         mock_get_database_details_response(mock_catalogue, database)
 
         self.start_on_the_details_page()
@@ -120,6 +121,7 @@ class TestDetailsPageContactDetails:
         custodian,
         expected_text,
     ):
+        database.custom_properties.security_classification = "Official-Sensitive"
         if access_reqs:
             database.custom_properties.access_information = AccessInformation(
                 dc_access_requirements=access_reqs

--- a/tests/integration/test_details_contact_contents.py
+++ b/tests/integration/test_details_contact_contents.py
@@ -108,7 +108,7 @@ class TestDetailsPageContactDetails:
                 "",
                 "",
                 "",
-                "Not provided.",
+                "Learn how to access this data in the Analytical Platform (opens in new tab)",
             ),
         ],
     )

--- a/tests/integration/test_details_contact_contents.py
+++ b/tests/integration/test_details_contact_contents.py
@@ -53,12 +53,12 @@ class TestDetailsPageContactDetails:
         [
             (
                 "https://place-to-get-your-access.com",
-                "Select this link for access information (opens in new tab)",
+                "Learn how to access this data in the Analytical Platform (opens in new tab)",
             ),
-            (
-                "To access these data you need to seek permission from the data custodian by email",
-                "To access these data you need to seek permission from the data custodian by email",
-            ),
+            # ( commented out as we're hiding references to data custodians for now
+            #     "To access these data you need to seek permission from the data custodian by email",
+            #     "To access these data you need to seek permission from the data custodian by email",
+            # ),
         ],
     )
     def test_access_requirements_content(
@@ -70,7 +70,7 @@ class TestDetailsPageContactDetails:
         1 - a sole link given is rendered as a hyperlink with standard link text
         2 - some other specific free text held in the access_requirements custom property is
         shown as given
-        3 - where no access_requirements custom property exists default to the standrd line
+        3 - where no access_requirements custom property exists default to the standard line
         """
         database.custom_properties.access_information = AccessInformation(
             dc_access_requirements=access_reqs


### PR DESCRIPTION
* Tables and databases now have an "Access this data on the AP" section
* I've hardcoded in the database access page of the AP docs
* Fixed a bug where some relations of entities have no properties, which was causing an error