### PR TITLE
fix: handle default value for lastModified time in EntityParser

### DIFF
--- a/datahub_client/parsers.py
+++ b/datahub_client/parsers.py
@@ -252,7 +252,7 @@ class EntityParser:
         Return the time when the data was last updated in the source system
         (not Datahub)
         """
-        modified = (properties.get("lastModified") or {}).get("time")
+        modified = (properties.get("lastModified") or {}).get("time", 0)
         return None if modified == 0 else modified
 
     def _parse_owner_object(self, owner: dict) -> OwnerRef:


### PR DESCRIPTION
https://ministryofjustice.sentry.io/issues/6330921929/?alert_rule_id=15511507&alert_type=issue&environment=prod&notification_uuid=afb12961-d575-41e2-83cc-1f8cab98aec3&project=4507181591101440&referrer=slack