### PR TITLE
Do not include the phase banner in landmarks

### DIFF
--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -32,9 +32,21 @@
         {% block breadcrumbs %}
         {% endblock breadcrumbs %}
 
-        <main class="govuk-main-wrapper" id="main-content" role="main">
-          {% block content %}
-          {% endblock content %}
+        <main id="main-content" role="main">
+          <div class="govuk-phase-banner">
+            <p class="govuk-phase-banner__content">
+              <strong class="govuk-tag govuk-phase-banner__content__tag">
+                Private beta
+              </strong>
+              <span class="govuk-phase-banner__text">
+                This is a new service. Help us improve it and <a class="govuk-link" href="{% url 'feedback:feedback' %}" rel="noreferrer noopener" target="_blank">give your feedback (opens in new tab)</a>.
+              </span>
+            </p>
+          </div>
+          <div class="govuk-main-wrapper">
+            {% block content %}
+            {% endblock content %}
+          </div>
         </main>
       </div>
     {% endblock main %}

--- a/templates/base/navigation.html
+++ b/templates/base/navigation.html
@@ -117,18 +117,3 @@
   </div>
 
 </div>
-
-{% if request.path != home_url %}
-<div class="govuk-width-container">
-  <div class="govuk-phase-banner" role="region" aria-label="New service information">
-    <p class="govuk-phase-banner__content">
-      <strong class="govuk-tag govuk-phase-banner__content__tag">
-        Private beta
-      </strong>
-      <span class="govuk-phase-banner__text">
-        This is a new service. Help us improve it and <a class="govuk-link" href="{% url 'feedback:feedback' %}" rel="noreferrer noopener" target="_blank">give your feedback (opens in new tab)</a>.
-      </span>
-    </p>
-  </div>
-</div>
-{% endif %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -6,7 +6,7 @@
   <main class="main-wrapper-with-masthead" id="main-content" role="main">
     <div class="x-govuk-masthead x-govuk-masthead--large">
       <div class="govuk-width-container">
-        <div class="govuk-phase-banner x-govuk-phase-banner--inverse" role="region" aria-label="New service information">
+        <div class="govuk-phase-banner x-govuk-phase-banner--inverse">
           <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag x-govuk-tag--inverse">
               Beta


### PR DESCRIPTION
I originally added an aria-role of region to the phase banner because axe complains if you have any elements on the page that don't belong to a landmark.

> Ensure all content is contained within a landmark region, designated with HTML5 landmark elements and/or ARIA landmark regions.
>
> Screen reader users can navigate to a section based on its HTML element or ARIA Landmark. For example, you might use ARIA Landmarks to provide a simple replacement for a skip navigation link, though the replacement is only useful for users of screen readers. Sighted users or people using screen enlargers won't benefit from the addition, so it's not a good practice to substitute ARIA landmarks for skip navigation links altogether.

https://dequeuniversity.com/rules/axe/3.3/region?application=AxeChrome

However, from speaking to the GOV.UK design system team, it seems like it's not recommended to create a distinct landmark just for the phase banner, because it's not important enough. Early on GOV.UK made a decision to reduce the number of landmarks to improve usability for screenreader users (see
https://github.com/alphagov/govuk-frontend/issues/1604 for more context).

The general advice is:
**If a banner can be reasonably added to any other landmark because it can be interpreted to be part of it, or is at least somewhat related, it's better to add it to that element rather than create a new landmark.**

Normally that would be the `<header>`, but in our case we display the phase banner further down, below the nav, so I've included it in the main element instead.

This is consistent with the phase banner variant of the x-gov masthead component, which we are using on the homepage.
However, this has the drawback that the skiplink will not skip past the phase banner, which may violate "2.4.1 Bypass Blocks" in the WCAG, unless we judge it to be important enough that it can be read out any time the user skips to main content. 