### PR TITLE
Fix failing integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,7 +274,6 @@ class SearchPage(Page):
         return selected_filters
 
     def sort_label(self, name) -> WebElement:
-        # self.wait_for_element_to_be_visible(By.XPATH, f"//label[ text() = '{name}' ]")
         return self.selenium.find_element(By.XPATH, f"//label[ text() = '{name}' ]")
 
     def selected_filter_tags(self) -> list[WebElement]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-import os
+import time
 from random import choice
 from typing import Any, Generator
 from unittest.mock import MagicMock, patch
@@ -13,7 +13,9 @@ from selenium.webdriver.chrome.webdriver import WebDriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
+from selenium.webdriver.support.ui import WebDriverWait
 
 from datahub_client.client import DataHubCatalogueClient
 from datahub_client.entities import (
@@ -93,6 +95,16 @@ class Page:
 
     def primary_heading(self):
         return self.selenium.find_element(By.TAG_NAME, "h1")
+
+    def wait_for_element_to_be_visible(
+        self, locator_type: str, element: str, wait: float = 0.1
+    ):
+        WebDriverWait(self.selenium, wait).until(
+            EC.visibility_of_element_located((locator_type, element))
+        )
+
+    def sleep(self, seconds: float):
+        time.sleep(seconds)
 
 
 class DetailsPage(Page):
@@ -262,6 +274,7 @@ class SearchPage(Page):
         return selected_filters
 
     def sort_label(self, name) -> WebElement:
+        # self.wait_for_element_to_be_visible(By.XPATH, f"//label[ text() = '{name}' ]")
         return self.selenium.find_element(By.XPATH, f"//label[ text() = '{name}' ]")
 
     def selected_filter_tags(self) -> list[WebElement]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,7 @@ from selenium.webdriver.chrome.webdriver import WebDriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 from selenium.webdriver.remote.webelement import WebElement
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
-from selenium.webdriver.support.ui import WebDriverWait
 
 from datahub_client.client import DataHubCatalogueClient
 from datahub_client.entities import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,14 +96,7 @@ class Page:
     def primary_heading(self):
         return self.selenium.find_element(By.TAG_NAME, "h1")
 
-    def wait_for_element_to_be_visible(
-        self, locator_type: str, element: str, wait: float = 0.1
-    ):
-        WebDriverWait(self.selenium, wait).until(
-            EC.visibility_of_element_located((locator_type, element))
-        )
-
-    def sleep(self, seconds: float):
+    def sleep(self, seconds: float = 0.1):
         time.sleep(seconds)
 
 

--- a/tests/integration/test_interact_with_search_results.py
+++ b/tests/integration/test_interact_with_search_results.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from datahub_client.entities import TableEntityMapping
@@ -170,6 +172,7 @@ class TestInteractWithSearchResults:
         search_bar = self.search_page.search_bar()
         search_bar.send_keys(query)
         self.click_on_the_search_button()
+        time.sleep(0.01)
 
     def verify_sort_selected(self, expected):
         value = self.search_page.checked_sort_option().get_attribute("value") or ""

--- a/tests/integration/test_interact_with_search_results.py
+++ b/tests/integration/test_interact_with_search_results.py
@@ -1,6 +1,5 @@
-import time
-
 import pytest
+from selenium.webdriver.common.by import By
 
 from datahub_client.entities import TableEntityMapping
 from tests.conftest import (
@@ -172,7 +171,7 @@ class TestInteractWithSearchResults:
         search_bar = self.search_page.search_bar()
         search_bar.send_keys(query)
         self.click_on_the_search_button()
-        time.sleep(0.01)
+        self.search_page.wait_for_element_to_be_visible(By.ID, "result-count")
 
     def verify_sort_selected(self, expected):
         value = self.search_page.checked_sort_option().get_attribute("value") or ""

--- a/tests/integration/test_interact_with_search_results.py
+++ b/tests/integration/test_interact_with_search_results.py
@@ -1,5 +1,4 @@
 import pytest
-from selenium.webdriver.common.by import By
 
 from datahub_client.entities import TableEntityMapping
 from tests.conftest import (
@@ -171,7 +170,7 @@ class TestInteractWithSearchResults:
         search_bar = self.search_page.search_bar()
         search_bar.send_keys(query)
         self.click_on_the_search_button()
-        self.search_page.wait_for_element_to_be_visible(By.ID, "result-count")
+        self.search_page.sleep()
 
     def verify_sort_selected(self, expected):
         value = self.search_page.checked_sort_option().get_attribute("value") or ""

--- a/tests/integration/test_search_controls.py
+++ b/tests/integration/test_search_controls.py
@@ -1,7 +1,6 @@
 import re
 
 import pytest
-from selenium.webdriver.common.by import By
 
 from .helpers import check_for_accessibility_issues
 
@@ -143,7 +142,7 @@ class TestSearchInteractions:
         self.select_subject_area(subject_area)
         for filter in filters:
             self.click_option(filter)
-            self.search_page.sleep(0.01)
+            self.search_page.sleep()
         self.verify_subject_area_selected(subject_area)
         self.verify_checkbox_filters_selected(filters)
         self.click_clear_filters()
@@ -196,7 +195,7 @@ class TestSearchInteractions:
         search_bar = self.search_page.search_bar()
         search_bar.send_keys(query)
         self.click_on_the_search_button()
-        self.search_page.wait_for_element_to_be_visible(By.ID, "result-count")
+        self.search_page.sleep()
 
     def select_subject_area(self, subject_area):
         self.search_page.select_subject_area(subject_area)

--- a/tests/integration/test_search_controls.py
+++ b/tests/integration/test_search_controls.py
@@ -1,7 +1,7 @@
 import re
-import time
 
 import pytest
+from selenium.webdriver.common.by import By
 
 from .helpers import check_for_accessibility_issues
 
@@ -37,7 +37,6 @@ class TestSearchInteractions:
         """
         self.start_on_the_search_page()
         self.enter_a_query_and_submit("nomis")
-        time.sleep(0.01)
         self.verify_i_am_on_the_search_page()
         self.verify_the_search_bar_has_value("nomis")
         self.verify_i_have_results()
@@ -107,7 +106,6 @@ class TestSearchInteractions:
         self.click_next_page()
         self.verify_page("2")
         self.enter_a_query_and_submit("nomis")
-        time.sleep(0.01)
         self.verify_page("1")
 
     def test_adding_a_filter_resets_pagination(self):
@@ -145,7 +143,7 @@ class TestSearchInteractions:
         self.select_subject_area(subject_area)
         for filter in filters:
             self.click_option(filter)
-            time.sleep(0.01)
+            self.search_page.sleep(0.01)
         self.verify_subject_area_selected(subject_area)
         self.verify_checkbox_filters_selected(filters)
         self.click_clear_filters()
@@ -198,6 +196,7 @@ class TestSearchInteractions:
         search_bar = self.search_page.search_bar()
         search_bar.send_keys(query)
         self.click_on_the_search_button()
+        self.search_page.wait_for_element_to_be_visible(By.ID, "result-count")
 
     def select_subject_area(self, subject_area):
         self.search_page.select_subject_area(subject_area)

--- a/tests/integration/test_search_controls.py
+++ b/tests/integration/test_search_controls.py
@@ -1,4 +1,5 @@
 import re
+import time
 
 import pytest
 
@@ -36,6 +37,7 @@ class TestSearchInteractions:
         """
         self.start_on_the_search_page()
         self.enter_a_query_and_submit("nomis")
+        time.sleep(0.01)
         self.verify_i_am_on_the_search_page()
         self.verify_the_search_bar_has_value("nomis")
         self.verify_i_have_results()
@@ -105,6 +107,7 @@ class TestSearchInteractions:
         self.click_next_page()
         self.verify_page("2")
         self.enter_a_query_and_submit("nomis")
+        time.sleep(0.01)
         self.verify_page("1")
 
     def test_adding_a_filter_resets_pagination(self):
@@ -142,6 +145,7 @@ class TestSearchInteractions:
         self.select_subject_area(subject_area)
         for filter in filters:
             self.click_option(filter)
+            time.sleep(0.01)
         self.verify_subject_area_selected(subject_area)
         self.verify_checkbox_filters_selected(filters)
         self.click_clear_filters()


### PR DESCRIPTION
Adds a sleep method to the Page object to bypass issues with Staleobject exceptions. I have attempted various combinations of expected conditions without consistent success so far.