### PR TITLE
fmd-1414-Fix RAG fonts on quality metrics

### DIFF
--- a/home/templatetags/govuk.py
+++ b/home/templatetags/govuk.py
@@ -42,3 +42,14 @@ def pagination(page_obj, urlpattern, **url_kwargs):
     context["page_numbers"] = numbers
 
     return context
+
+
+@register.filter(name="quality_tag")
+def quality_tag(value):
+    """Map quality values to GOV.UK tag colors"""
+    mapping = {
+        "poor": "red",
+        "acceptable": "yellow",
+        "good": "green"
+    }
+    return mapping.get(value, "grey")  # Default to grey if value is unknown

--- a/home/templatetags/govuk.py
+++ b/home/templatetags/govuk.py
@@ -45,11 +45,11 @@ def pagination(page_obj, urlpattern, **url_kwargs):
 
 
 @register.filter(name="quality_tag")
-def quality_tag(value):
+def quality_tag(value: str):
     """Map quality values to GOV.UK tag colors"""
     mapping = {
         "poor": "red",
         "acceptable": "yellow",
         "good": "green"
     }
-    return mapping.get(value, "grey")  # Default to grey if value is unknown
+    return mapping.get(value.lower(), "grey")  # Default to grey if value is unknown

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -96,33 +96,3 @@ code {
   @extend .govuk-list;
   @extend .govuk-list--number;
 }
-
-/* Custom GOV.UK style status tags */
-.govuk-tag-status {
-  display: inline-block;
-  padding: 5px 10px;
-  font-weight: bold;
-  border-radius: 3px;
-  background-color: #e0e0e0; /* Default light gray */
-  color: #333; /* Default dark text */
-}
-
-.govuk-tag-status.good {
-  background-color: #d8ebe6; /* Light green */
-  color: #00703c; /* Dark green */
-}
-
-.govuk-tag-status.acceptable {
-  background-color: #fff1d2; /* Light amber */
-  color: #ffbf47; /* Dark amber */
-}
-
-.govuk-tag-status.poor {
-  background-color: #f3d3d3; /* Light red */
-  color: #d4351c; /* Dark red */
-}
-
-.govuk-tag-status.na {
-  background-color: #f3f2f1; /* Light gray */
-  color: #505a5f; /* Dark gray */
-}

--- a/templates/partial/_specific_table_metrics.html
+++ b/templates/partial/_specific_table_metrics.html
@@ -1,26 +1,28 @@
+{% load govuk %} 
+
 {% if entity.name == "all_assets" %}
       <td class="govuk-table__cell">
-        <span class="govuk-tag-status {{ column.quality_metrics.completeness|default:'na' }}">
+        <span class="govuk-tag govuk-tag--{{ column.quality_metrics.completeness|quality_tag }}">
           {{ column.quality_metrics.completeness|default:"na" }}
         </span>
       </td>
       <td class="govuk-table__cell">
-        <span class="govuk-tag-status {{ column.quality_metrics.accuracy|default:'na' }}">
+        <span class="govuk-tag govuk-tag--{{ column.quality_metrics.accuracy|quality_tag }}">
           {{ column.quality_metrics.accuracy|default:"na" }}
         </span>
       </td>
       <td class="govuk-table__cell">
-        <span class="govuk-tag-status {{ column.quality_metrics.uniqueness|default:'na' }}">
+        <span class="govuk-tag govuk-tag--{{ column.quality_metrics.uniqueness|quality_tag }}">
           {{ column.quality_metrics.uniqueness|default:"na" }}
         </span>
       </td>
       <td class="govuk-table__cell">
-        <span class="govuk-tag-status {{ column.quality_metrics.consistency|default:'na' }}">
+        <span class="govuk-tag govuk-tag--{{ column.quality_metrics.consistency|quality_tag }}">
           {{ column.quality_metrics.consistency|default:"na" }}
         </span>
       </td>
       <td class="govuk-table__cell">
-        <span class="govuk-tag-status {{ column.quality_metrics.validity|default:'na' }}">
+        <span class="govuk-tag govuk-tag--{{ column.quality_metrics.validity|quality_tag }}">
           {{ column.quality_metrics.validity|default:"na" }}
         </span>
       </td>


### PR DESCRIPTION
Created a mapping between (poor, acceptable, good) -> (red, yellow, green) to import gov-uk tags.

Deleted the custom css that was created for that purpose.