### PR TITLE
Enhance modsecurity rules to include exception for 'nomis_internet'

### DIFF
--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -11,6 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecRule REQUEST_URI "@contains .profile" "id:1005,phase:1,t:lowercase,ctl:ruleRemoveById=930130"
+      SecRule REQUEST_URI "@contains nomis_internet" "id:1006,phase:2,t:none,nolog,pass,ctl:ruleRemoveById=933150"
       SecDefaultAction "phase:2,pass,log,tag:github_team=data-catalogue"
       SecDefaultAction "phase:4,pass,log,tag:github_team=data-catalogue"
 spec:


### PR DESCRIPTION
Attempts to urls containing "nomis_internet" trigger the Modsec `is_int` check, resulting in blocking.