### PR TITLE
Accessibility Changes: Search Tips Box Edits

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -41,7 +41,7 @@
           <div class="govuk-!-padding-2">
             {# Search query tips (when expanded) #}
             <ul class="govuk-list govuk-list--bullet">
-              <li><p>Use a pipe <b>|</b> to broaden your search: prisons | probation searches "prisons" OR "probation".
+              <li><p>Use a pipe <b>|</b> to broaden your search: "prisons | probation" searches "prisons" OR "probation".
               </p></li>
               <li><p>Use <b>""</b> to search for an exact match for a phrase.</p></li>
               <li><p>Use a <b>-</b> to exclude words.</p></li>

--- a/templates/search.html
+++ b/templates/search.html
@@ -43,7 +43,7 @@
             <ul class="govuk-list govuk-list--bullet">
               <li><p>Use a pipe <b>|</b> to broaden your search: "prisons | probation" searches "prisons" OR "probation".
               </p></li>
-              <li><p>Use <b>""</b> to search for an exact match for a phrase.</p></li>
+              <li><p>Use quotes <b>""</b> to search for an exact match for a phrase.</p></li>
               <li><p>Use a <b>-</b> to exclude words.</p></li>
               <li><p>Use an asterisk <b>*</b> to search for unknown, variable, or missing text.</p></li>
             </ul>

--- a/templates/search.html
+++ b/templates/search.html
@@ -44,7 +44,7 @@
               <li><p>Use a pipe <b>|</b> to broaden your search: "prisons | probation" searches "prisons" OR "probation".
               </p></li>
               <li><p>Use quotes <b>""</b> to search for an exact match for a phrase.</p></li>
-              <li><p>Use a <b>-</b> to exclude words.</p></li>
+              <li><p>Use a hyphen <b>-</b> to exclude words.</p></li>
               <li><p>Use an asterisk <b>*</b> to search for unknown, variable, or missing text.</p></li>
             </ul>
           </div>


### PR DESCRIPTION
Addressed three issues for Task [258](https://github.com/orgs/ministryofjustice/projects/167/views/7?filterQuery=Sprint%3A%40current+label%3A%22Squad-two%22+assignee%3A%40me&pane=issue&itemId=187068669&issue=ministryofjustice%7Cdata-platform%7C258):

- Addition of double-quotes
- Addition of word 'quotes'
- Addition of word 'hyphen'

Reason for change:

- Remediation arising from accessibility review of Find MoJ Data platform.

Image of FMD running locally post-changes:
<img width="995" height="604" alt="image" src="https://github.com/user-attachments/assets/f5b84139-bf68-4308-9a19-29e62746d120" />
