### PR TITLE
🌌 Send Prometheus metrics to a null service

### DIFF
--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -32,3 +32,11 @@ spec:
                 name: find-moj-data-service # this should match the metadata.name in service.yml
                 port:
                   number: 80
+          # Route Prometheus metrics endpoint to a null service
+          - path: /metrics
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: null
+                port:
+                  number: 80


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/data-platform-security/issues/68

## Proposed Changes

- Sends `/metrics` to a null service.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>