### PR TITLE
🌌 Send Prometheus metrics to a blackhole service

### DIFF
--- a/deployments/templates/ingress.yml
+++ b/deployments/templates/ingress.yml
@@ -37,6 +37,6 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: null
+                name: blackhole
                 port:
                   number: 80


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/data-platform-security/issues/68

## Proposed Changes

- Sends `/metrics` to a blackhole service.

## Notes

`null` was literal, oops!

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>