### PR TITLE
Form Options Select Using Tab (Task: 513)

### DIFF
--- a/static/assets/js/feedback-announcement.js
+++ b/static/assets/js/feedback-announcement.js
@@ -146,6 +146,27 @@ document.body.addEventListener("htmx:afterSwap", function (event) {
   toggleWhatWentWell();
   toggleWhatWentWrong();
   toggleSomeOtherIssue();
+
+  window.setTimeout(function () {
+    // GOV.UK pattern: focus error summary first
+    const errorSummary = document.querySelector(".govuk-error-summary");
+
+    if (errorSummary && typeof errorSummary.focus === "function") {
+      if (!errorSummary.hasAttribute("tabindex")) {
+        errorSummary.setAttribute("tabindex", "-1");
+      }
+      errorSummary.focus({ preventScroll: true });
+      return;
+    }
+
+    // Otherwise focus the questions
+    const feedbackOptions = getFeedbackWidget().querySelector("#feedback-options");
+
+    if (feedbackOptions && typeof feedbackOptions.focus === "function") {
+      feedbackOptions.focus({ preventScroll: true });
+    }
+  }, 0);
+
 });
 
 // Initial page-load sync so server-rendered states match checkbox values.


### PR DESCRIPTION
When the Feedback Form is opened in Find MoJ Data when using tab (i.e. keyboard only usage) the next thing tab goes to should be the first option/checkbox in the newly opened form (not simply skipping to a post-form option/item).

The fix for this has been implemented in this Pull Request.

Task: Feedback form - Tab skipping revealed form #513