### PR TITLE
Back Button Implementation

### DIFF
--- a/feedback/templates/report_issue.html
+++ b/feedback/templates/report_issue.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block breadcrumbs %}
- <a href="javascript:history.back()" class="govuk-back-link">Back</a>
+  {% include "base/history_back_link.html" with fallback_href=back_fallback_url fallback_label=back_fallback_label %}
 {% endblock breadcrumbs %}
 {% block content %}
 <div class="govuk-grid-row  govuk-!-margin-top-0">

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 from django.contrib import messages
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
+from django.urls import reverse
 
 from core.settings import ALLOWED_HOSTS
 
@@ -19,6 +20,15 @@ from .service import (
 )
 
 log = logging.getLogger(__name__)
+
+
+def _build_report_issue_back_link_context(entity_url: str | None, entity_type: str | None) -> dict[str, str]:
+    fallback_url = entity_url or reverse("home:home")
+    fallback_label = (entity_type or "home").strip().lower()
+    return {
+        "back_fallback_url": fallback_url,
+        "back_fallback_label": fallback_label,
+    }
 
 
 def feedback_view(request) -> HttpResponse:
@@ -170,6 +180,10 @@ def report_issue_view(request) -> HttpResponse:
         else:
             log.info(f"Invalid report issue form submission: {form.errors}")
 
+            entity_url = request.session.get("entity_url")
+            entity_type = request.session.get("entity_type")
+            back_link_context = _build_report_issue_back_link_context(entity_url, entity_type)
+
             return render(
                 request,
                 "report_issue.html",
@@ -186,6 +200,7 @@ def report_issue_view(request) -> HttpResponse:
                     "parent_entity_type": request.session.get("parent_entity_type"),
                     "parent_entity_friendly_name": request.session.get("parent_entity_friendly_name"),
                     "report": True,
+                    **back_link_context,
                 },
             )
     else:
@@ -231,6 +246,8 @@ def report_issue_view(request) -> HttpResponse:
         request.session["data_custodian_email"] = request.GET.get("data_custodian_email", "")
 
         form = IssueForm()
+
+    back_link_context = _build_report_issue_back_link_context(entity_url, entity_type)
     technical_contact = True if request.session.get("data_custodian_email") else False
     return render(
         request,
@@ -249,5 +266,6 @@ def report_issue_view(request) -> HttpResponse:
             "parent_entity_url": parent_entity_url,
             "parent_entity_type": parent_entity_type,
             "parent_entity_friendly_name": parent_entity_friendly_name,
+            **back_link_context,
         },
     )

--- a/static/assets/js/history-back-link.js
+++ b/static/assets/js/history-back-link.js
@@ -1,0 +1,255 @@
+const HISTORY_BACK_LINK_SELECTOR = '[data-history-back-link="true"]';
+const SESSION_LABELS_KEY = "historyBackLabelsV1";
+
+function toDisplayLabel(value) {
+  return value
+    .split(" ")
+    .filter(Boolean)
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function normaliseRouteSegment(segment) {
+  return toDisplayLabel(segment.replace(/[_-]+/g, " "));
+}
+
+function decodeUrlComponent(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function looksLikeOpaqueIdentifier(value) {
+  return /^[a-f0-9]{24,}$/i.test(value);
+}
+
+function getLabelStore() {
+  try {
+    const rawLabels = window.sessionStorage.getItem(SESSION_LABELS_KEY);
+    if (!rawLabels) {
+      return {};
+    }
+
+    const parsed = JSON.parse(rawLabels);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function setLabelStore(store) {
+  try {
+    window.sessionStorage.setItem(SESSION_LABELS_KEY, JSON.stringify(store));
+  } catch {
+    // Ignore storage failures (private mode, disabled storage, quota errors).
+  }
+}
+
+function normaliseAbsoluteUrl(rawUrl, locationOrigin = window.location.origin) {
+  if (!rawUrl) {
+    return null;
+  }
+
+  try {
+    const parsedUrl = new URL(rawUrl, locationOrigin);
+    if (parsedUrl.origin !== locationOrigin) {
+      return null;
+    }
+
+    parsedUrl.hash = "";
+    return parsedUrl.toString();
+  } catch {
+    return null;
+  }
+}
+
+function getCurrentPageLabel() {
+  const pageHeading = document.querySelector("#main-content h1") || document.querySelector("h1");
+  const label = pageHeading?.textContent?.trim();
+
+  return label || null;
+}
+
+function storeCurrentPageLabel() {
+  const pageLabel = getCurrentPageLabel();
+  const currentUrl = normaliseAbsoluteUrl(window.location.href);
+
+  if (!pageLabel || !currentUrl) {
+    return;
+  }
+
+  const labels = getLabelStore();
+  labels[currentUrl] = pageLabel;
+  setLabelStore(labels);
+}
+
+function getStoredReferrerLabel(documentReferrer = document.referrer, locationOrigin = window.location.origin) {
+  const referrerUrl = normaliseAbsoluteUrl(documentReferrer, locationOrigin);
+  if (!referrerUrl) {
+    return null;
+  }
+
+  const labels = getLabelStore();
+  return labels[referrerUrl] || null;
+}
+
+export function extractDisplayNameFromDetailsUrn(rawUrn) {
+  if (!rawUrn) {
+    return null;
+  }
+
+  const decodedUrn = decodeUrlComponent(rawUrn.replace(/\.csv$/, ""));
+  const bracketedEntityMatch = decodedUrn.match(/urn:li:[^:]+:\(([^)]+)\)/);
+
+  let candidate;
+  if (bracketedEntityMatch && bracketedEntityMatch[1]) {
+    const urnParts = bracketedEntityMatch[1].split(",").map((part) => part.trim());
+    candidate = urnParts.length > 1 ? urnParts[1] : urnParts[urnParts.length - 1];
+  } else {
+    const colonParts = decodedUrn.split(":").filter(Boolean);
+    candidate = colonParts[colonParts.length - 1];
+  }
+
+  if (!candidate) {
+    return null;
+  }
+
+  const trimmedCandidate = candidate.trim();
+  if (!trimmedCandidate || looksLikeOpaqueIdentifier(trimmedCandidate)) {
+    return null;
+  }
+
+  // Prefer the entity name when the candidate contains a dotted namespace path.
+  return trimmedCandidate.includes(".") ? trimmedCandidate.split(".").pop() : trimmedCandidate;
+}
+
+export function labelFromPath(pathname) {
+  if (!pathname || pathname === "/") {
+    return "Home";
+  }
+
+  if (pathname.startsWith("/search") || pathname.startsWith("/pagination/")) {
+    return "search results";
+  }
+
+  if (pathname.startsWith("/userguide/")) {
+    return "User guide";
+  }
+
+  if (pathname.startsWith("/metadata_specification")) {
+    return "Metadata specification";
+  }
+
+  if (pathname.startsWith("/cookies")) {
+    return "Cookies";
+  }
+
+  if (pathname.startsWith("/accessibility_statement")) {
+    return "Accessibility statement";
+  }
+
+  if (pathname.startsWith("/details/")) {
+    const pathParts = pathname.split("/").filter(Boolean);
+    if (pathParts.length > 2) {
+      const entityName = extractDisplayNameFromDetailsUrn(pathParts[2]);
+      if (entityName) {
+        return entityName;
+      }
+    }
+
+    if (pathParts.length > 1) {
+      return normaliseRouteSegment(pathParts[1]);
+    }
+
+    return "Details";
+  }
+
+  return null;
+}
+
+export function getReferrerLabel(documentReferrer = document.referrer, locationOrigin = window.location.origin) {
+  if (!documentReferrer) {
+    return null;
+  }
+
+  const storedReferrerLabel = getStoredReferrerLabel(documentReferrer, locationOrigin);
+  if (storedReferrerLabel) {
+    return storedReferrerLabel;
+  }
+
+  try {
+    const referrerUrl = new URL(documentReferrer);
+    if (referrerUrl.origin !== locationOrigin) {
+      return null;
+    }
+
+    return labelFromPath(referrerUrl.pathname);
+  } catch {
+    return null;
+  }
+}
+
+export function shouldUseHistoryBack(
+  documentReferrer = document.referrer,
+  historyLength = window.history.length,
+  locationOrigin = window.location.origin
+) {
+  if (!documentReferrer || historyLength <= 1) {
+    return false;
+  }
+
+  try {
+    const referrerUrl = new URL(documentReferrer);
+    return referrerUrl.origin === locationOrigin;
+  } catch {
+    return false;
+  }
+}
+
+function setBackLinkLabel(linkElement, label) {
+  const backLabel = label.includes("_") ? label : toDisplayLabel(label);
+  const normalisedBackLabel = backLabel.toLowerCase();
+
+  if (normalisedBackLabel === "search for data assets" || normalisedBackLabel === "search results") {
+    linkElement.textContent = "Back to search results";
+  } else {
+    linkElement.textContent = `Back to ${backLabel}`;
+  }
+}
+
+function initialiseLink(linkElement) {
+  if (linkElement.dataset.historyBackInitialised === "true") {
+    return;
+  }
+
+  const fallbackLabel = linkElement.dataset.fallbackLabel || "previous page";
+  const referrerLabel = getReferrerLabel();
+
+  setBackLinkLabel(linkElement, referrerLabel || fallbackLabel);
+
+  linkElement.addEventListener("click", (event) => {
+    if (shouldUseHistoryBack()) {
+      event.preventDefault();
+      window.history.back();
+    }
+  });
+
+  linkElement.dataset.historyBackInitialised = "true";
+}
+
+export function initHistoryBackLinks(root = document) {
+  const backLinks = root.querySelectorAll(HISTORY_BACK_LINK_SELECTOR);
+  backLinks.forEach(initialiseLink);
+}
+
+if (typeof document !== "undefined") {
+  storeCurrentPageLabel();
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => initHistoryBackLinks());
+  } else {
+    initHistoryBackLinks();
+  }
+}

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -84,5 +84,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js"
         integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm"
         crossorigin="anonymous"></script>
+<script type="module" src="/static/assets/js/history-back-link.js"></script>
 </body>
 </html>

--- a/templates/base/history_back_link.html
+++ b/templates/base/history_back_link.html
@@ -1,0 +1,8 @@
+<a
+  href="{{ fallback_href }}"
+  class="govuk-back-link"
+  data-history-back-link="true"
+  data-fallback-label="{{ fallback_label|default:'previous page' }}"
+>
+  Back to {{ fallback_label|default:"previous page" }}
+</a>

--- a/templates/details_base.html
+++ b/templates/details_base.html
@@ -14,13 +14,12 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-  <nav class="govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile" aria-label="Breadcrumb">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-back-link" href="{% url 'home:search' %}?{{ request.session.last_search|default:'' }}">Back to search results</a>
-      </li>
-    </ol>
-  </nav>
+  {% url 'home:search' as search_url %}
+  {% with last_search=request.session.last_search|default:'' %}
+    {% with fallback_href=search_url|add:"?"|add:last_search %}
+      {% include "base/history_back_link.html" with fallback_href=fallback_href fallback_label="search results" %}
+    {% endwith %}
+  {% endwith %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/tests/feedback/test_views.py
+++ b/tests/feedback/test_views.py
@@ -370,6 +370,21 @@ class TestReportIssueView:
         assert response.status_code == 200
         assert response.context["entity_url"] == "http://localhost/details/table/test_urn"
 
+    def test_report_issue_renders_history_back_link_with_fallback(self, client):
+        response = client.get(
+            reverse("feedback:report-issue"),
+            data={
+                "entity_name": "test_entity",
+                "entity_url": "http://localhost/details/table/test_urn",
+                "entity_type": "Table",
+            },
+        )
+
+        assert response.status_code == 200
+        assert 'data-history-back-link="true"' in response.text
+        assert 'href="http://localhost/details/table/test_urn"' in response.text
+        assert "Back to table" in response.text
+
     def test_invalid_form_passes_all_metadata_on_error(self, client):
         """Verify form error preserves ALL entity metadata from session"""
         session = client.session

--- a/tests/javascript/test_history_back_link.js
+++ b/tests/javascript/test_history_back_link.js
@@ -1,0 +1,143 @@
+import {
+  extractDisplayNameFromDetailsUrn,
+  getReferrerLabel,
+  initHistoryBackLinks,
+  labelFromPath,
+  shouldUseHistoryBack,
+} from "history-back-link";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+describe("history back link path labels", () => {
+  test("maps search routes and details URNs to descriptive labels", () => {
+    expect(labelFromPath("/search")).toBe("search results");
+    expect(labelFromPath("/pagination/2")).toBe("search results");
+    expect(labelFromPath("/details/database/urn:li:dataset:db1")).toBe("db1");
+    expect(
+      labelFromPath(
+        "/details/table/urn:li:dataset:(urn:li:dataPlatform:dbt,cadet.awsdatacatalog.cica_datamarts.brg_case_type,PROD)"
+      )
+    ).toBe("brg_case_type");
+    expect(labelFromPath("/")).toBe("Home");
+  });
+
+  test("falls back to entity type label for opaque container ids", () => {
+    expect(labelFromPath("/details/database/urn:li:container:0dcb7860747b546165f4ccc8a9e4141d")).toBe("Database");
+  });
+
+  test("returns null for unknown routes", () => {
+    expect(labelFromPath("/unknown/route")).toBe(null);
+  });
+});
+
+describe("details URN display name extraction", () => {
+  test("extracts the final table name from dotted URN tuple values", () => {
+    const displayName = extractDisplayNameFromDetailsUrn(
+      "urn:li:dataset:(urn:li:dataPlatform:dbt,cadet.awsdatacatalog.cica_datamarts.brg_case_type,PROD)"
+    );
+
+    expect(displayName).toBe("brg_case_type");
+  });
+
+  test("handles encoded URNs", () => {
+    const encodedUrn =
+      "urn%3Ali%3Adataset%3A(urn%3Ali%3AdataPlatform%3Adbt%2Ccadet.awsdatacatalog.cica_datamarts.brg_case_type%2CPROD)";
+    expect(extractDisplayNameFromDetailsUrn(encodedUrn)).toBe("brg_case_type");
+  });
+
+  test("falls back to the final urn token for simple URNs", () => {
+    expect(extractDisplayNameFromDetailsUrn("urn:li:dataset:db1")).toBe("db1");
+  });
+});
+
+describe("history back link referrer and click behavior", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    window.sessionStorage.clear();
+  });
+
+  test("uses same-origin referrer to derive a label", () => {
+    const label = getReferrerLabel("http://localhost/search?query=nomis", "http://localhost");
+    expect(label).toBe("search results");
+  });
+
+  test("prefers sessionStorage label for previous page url", () => {
+    window.sessionStorage.setItem(
+      "historyBackLabelsV1",
+      JSON.stringify({
+        "http://localhost/details/database/urn:li:container:0dcb7860747b546165f4ccc8a9e4141d":
+          "Crown Court dimensional model",
+      })
+    );
+
+    const label = getReferrerLabel(
+      "http://localhost/details/database/urn:li:container:0dcb7860747b546165f4ccc8a9e4141d",
+      "http://localhost"
+    );
+    expect(label).toBe("Crown Court dimensional model");
+  });
+
+  test("ignores cross-origin referrer labels", () => {
+    const label = getReferrerLabel("https://example.com/search", "http://localhost");
+    expect(label).toBe(null);
+  });
+
+  test("initialises fallback label when no referrer label is available", () => {
+    document.body.innerHTML = `
+      <a
+        href="/search"
+        class="govuk-back-link"
+        data-history-back-link="true"
+        data-fallback-label="search results"
+      >
+        Back
+      </a>
+    `;
+
+    initHistoryBackLinks(document);
+
+    const backLink = document.querySelector("[data-history-back-link='true']");
+    expect(backLink.textContent.trim()).toBe("Back to search results");
+  });
+
+  test("uses browser history for one-step back when available", () => {
+    const historyBackSpy = jest.spyOn(window.history, "back").mockImplementation(() => {});
+
+    document.body.innerHTML = `
+      <a
+        href="/search"
+        class="govuk-back-link"
+        data-history-back-link="true"
+        data-fallback-label="search results"
+      >
+        Back
+      </a>
+    `;
+
+    Object.defineProperty(document, "referrer", {
+      configurable: true,
+      value: "http://localhost/details/database/foo",
+    });
+
+    window.history.pushState({}, "", "/details/table/bar");
+    initHistoryBackLinks(document);
+
+    const backLink = document.querySelector("[data-history-back-link='true']");
+    const clickEvent = new MouseEvent("click", { bubbles: true, cancelable: true });
+    backLink.dispatchEvent(clickEvent);
+
+    expect(shouldUseHistoryBack(document.referrer, window.history.length, window.location.origin)).toBe(true);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(historyBackSpy).toHaveBeenCalled();
+
+    historyBackSpy.mockRestore();
+  });
+
+  test("uses browser history even when no label can be resolved", () => {
+    Object.defineProperty(document, "referrer", {
+      configurable: true,
+      value: "http://localhost/unknown/route",
+    });
+
+    expect(shouldUseHistoryBack(document.referrer, 2, "http://localhost")).toBe(true);
+  });
+});

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -139,3 +139,12 @@ class TestChartView:
         response = client.get(reverse("home:details", kwargs={"urn": "fake", "result_type": "chart"}))
         assert response.status_code == 200
         assert response.headers["Cache-Control"] == "max-age=300, private"
+
+    @pytest.mark.django_db
+    def test_details_page_renders_history_back_link_with_search_fallback(self, client):
+        response = client.get(reverse("home:details", kwargs={"urn": "fake", "result_type": "chart"}))
+
+        assert response.status_code == 200
+        assert 'data-history-back-link="true"' in response.text
+        assert 'href="/search?"' in response.text
+        assert "Back to search results" in response.text


### PR DESCRIPTION
Back button now goes back to previous page, rather than always to the search results.

Back button will now provide the name of the previous page for awareness to user.

Wasn't able to use Django's 'reverse' due to how FMD uses container Ids for Database and Schema data assets (Table was fine) so had to use a workaround.

Going back to Search Results will simply say, _back to search results_